### PR TITLE
feat: Implement resend verification email functionality

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -13,6 +13,7 @@ from src.modules.user.application.use_cases.update_user_handicap_manually_use_ca
 from src.modules.user.application.use_cases.update_profile_use_case import UpdateProfileUseCase
 from src.modules.user.application.use_cases.update_security_use_case import UpdateSecurityUseCase
 from src.modules.user.application.use_cases.verify_email_use_case import VerifyEmailUseCase
+from src.modules.user.application.use_cases.resend_verification_email_use_case import ResendVerificationEmailUseCase
 from src.modules.user.application.dto.user_dto import UserResponseDTO
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
@@ -268,3 +269,16 @@ def get_verify_email_use_case(
     3. Devuelve la instancia lista para ser usada por el endpoint de la API.
     """
     return VerifyEmailUseCase(uow)
+
+def get_resend_verification_email_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow)
+) -> ResendVerificationEmailUseCase:
+    """
+    Proveedor del caso de uso ResendVerificationEmailUseCase.
+
+    Esta función:
+    1. Depende de `get_uow` para obtener una Unit of Work.
+    2. Crea una instancia de `ResendVerificationEmailUseCase` con esa dependencia.
+    3. Devuelve la instancia lista para ser usada por el endpoint de la API.
+    """
+    return ResendVerificationEmailUseCase(uow)

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -214,3 +214,20 @@ class VerifyEmailResponseDTO(BaseModel):
     """DTO de salida para verificación de email."""
     message: str = Field(default="Email verificado exitosamente", description="Mensaje de confirmación.")
     email_verified: bool = Field(default=True, description="Confirmación de que el email fue verificado.")
+
+
+# ======================================================================================
+# DTO para el Caso de Uso: Resend Verification Email
+# ======================================================================================
+
+class ResendVerificationEmailRequestDTO(BaseModel):
+    """
+    DTO de entrada para reenvío de email de verificación.
+    """
+    email: EmailStr = Field(..., description=EMAIL_DESCRIPTION)
+
+
+class ResendVerificationEmailResponseDTO(BaseModel):
+    """DTO de salida para reenvío de email de verificación."""
+    message: str = Field(default="Email de verificación enviado exitosamente", description="Mensaje de confirmación.")
+    email: EmailStr = Field(..., description="Email al que se envió el mensaje de verificación.")

--- a/src/modules/user/application/use_cases/resend_verification_email_use_case.py
+++ b/src/modules/user/application/use_cases/resend_verification_email_use_case.py
@@ -1,0 +1,100 @@
+"""
+Resend Verification Email Use Case - Application Layer
+
+Caso de uso para reenviar el email de verificación a un usuario.
+"""
+
+import logging
+from typing import Optional
+
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.services.user_finder import UserFinder
+from src.modules.user.domain.value_objects.email import Email
+from src.shared.infrastructure.email.email_service import email_service
+
+logger = logging.getLogger(__name__)
+
+
+class ResendVerificationEmailUseCase:
+    """
+    Caso de uso para reenviar el email de verificación a un usuario.
+
+    Este caso de uso orquesta el proceso de regenerar el token de verificación
+    y reenviar el email al usuario que lo solicite.
+    """
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_finder = UserFinder(self._uow.users)
+
+    async def execute(self, email: str) -> bool:
+        """
+        Ejecuta el caso de uso de reenvío de email de verificación.
+
+        Args:
+            email: Email del usuario al que reenviar la verificación
+
+        Returns:
+            bool: True si el email se envió exitosamente
+
+        Raises:
+            ValueError: Si el email no existe o ya está verificado
+        """
+        if not email or email.strip() == "":
+            raise ValueError("El email es requerido")
+
+        # Primera transacción: buscar usuario y validar
+        async with self._uow:
+            # Buscar el usuario por email (convertir a Value Object)
+            email_vo = Email(email)
+            user = await self._user_finder.by_email(email_vo)
+
+            if not user:
+                raise ValueError("Si el email existe y no está verificado, se enviará un email de verificación")
+
+            # Verificar si el email ya está verificado
+            if user.is_email_verified():
+                raise ValueError("Si el email existe y no está verificado, se enviará un email de verificación")
+
+            # Generar nuevo token de verificación (solo en memoria, NO guardamos aún)
+            new_token = user.generate_verification_token()
+
+            # Extraer datos necesarios ANTES de salir del contexto
+            # para evitar detached entity errors
+            user_id = user.id.value
+            user_name = user.get_full_name()
+
+        # PRIMERO: Enviar email (fuera de transacción porque es síncrono)
+        # Si esto falla, no se ha guardado nada en BD (no hay inconsistencia)
+        email_sent = email_service.send_verification_email(
+            to_email=email,
+            user_name=user_name,
+            verification_token=new_token
+        )
+
+        if not email_sent:
+            logger.error("No se pudo enviar el email de verificación al usuario %s", user_id)
+            raise ValueError("Error al enviar el email de verificación")
+
+        # SEGUNDO: Solo si el email se envió correctamente, guardar el token en BD
+        async with self._uow:
+            # Re-buscar el usuario para tener una entidad attached
+            user = await self._user_finder.by_email(email_vo)
+            if not user:
+                raise ValueError("Usuario no encontrado")
+
+            # Regenerar el mismo token (es determinista si no ha pasado tiempo)
+            # O mejor: guardamos el token que ya generamos
+            user.verification_token = new_token
+
+            await self._uow.users.save(user)
+            # El context manager (__aexit__) hace commit automático
+
+        logger.info(
+            "Email de verificación reenviado correctamente al usuario %s",
+            user_id
+        )
+
+        return True

--- a/src/modules/user/infrastructure/api/v1/auth_routes.py
+++ b/src/modules/user/infrastructure/api/v1/auth_routes.py
@@ -1,3 +1,4 @@
+import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from src.config.dependencies import (
@@ -6,6 +7,7 @@ from src.config.dependencies import (
     get_current_user,
     get_logout_user_use_case,
     get_verify_email_use_case,
+    get_resend_verification_email_use_case,
 )
 from src.modules.user.application.dto.user_dto import (
     RegisterUserRequestDTO,
@@ -16,13 +18,17 @@ from src.modules.user.application.dto.user_dto import (
     LogoutResponseDTO,
     VerifyEmailRequestDTO,
     VerifyEmailResponseDTO,
+    ResendVerificationEmailRequestDTO,
+    ResendVerificationEmailResponseDTO,
 )
 from src.modules.user.application.use_cases.register_user_use_case import RegisterUserUseCase
 from src.modules.user.application.use_cases.login_user_use_case import LoginUserUseCase
 from src.modules.user.application.use_cases.logout_user_use_case import LogoutUserUseCase
 from src.modules.user.application.use_cases.verify_email_use_case import VerifyEmailUseCase
+from src.modules.user.application.use_cases.resend_verification_email_use_case import ResendVerificationEmailUseCase
 from src.modules.user.domain.errors.user_errors import UserAlreadyExistsError
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 @router.post(
@@ -169,6 +175,10 @@ async def verify_email(
     El usuario recibe un email con un link que contiene un token.
     Este endpoint valida el token y marca el email como verificado.
 
+    Security Note:
+    - Usa mensajes de error genéricos para prevenir user enumeration
+    - No revela información sobre el estado de la cuenta
+
     Args:
         request: DTO con el token de verificación
         use_case: Caso de uso de verificación de email
@@ -177,16 +187,104 @@ async def verify_email(
         VerifyEmailResponseDTO con confirmación de la verificación
 
     Raises:
-        HTTPException 400: Si el token es inválido o ha expirado
+        HTTPException 400: Si el token es inválido (mensaje genérico)
     """
+    # Log intento de verificación (sin exponer el token completo)
+    token_preview = f"{request.token[:8]}..." if len(request.token) > 8 else "***"
+    logger.info(f"Email verification attempt with token: {token_preview}")
+
     try:
         await use_case.execute(request.token)
+        logger.info(f"Email verification successful for token: {token_preview}")
         return VerifyEmailResponseDTO(
             message="Email verificado exitosamente",
             email_verified=True
         )
     except ValueError as e:
+        # Log para monitoreo de seguridad sin exponer en respuesta
+        logger.warning(
+            f"Email verification failed (expected): {type(e).__name__} - token: {token_preview}"
+        )
+        # Mensaje genérico para prevenir user enumeration
+        # No revelamos si el token es inválido, expirado, o si el usuario no existe
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
+            detail="Unable to verify email. Please check your verification link or request a new one.",
         )
+    except Exception as e:
+        # Log errores inesperados para monitoreo del sistema
+        logger.error(
+            f"Unexpected error in email verification: {type(e).__name__}",
+            exc_info=True
+        )
+        # Aún así retornamos mensaje genérico para no exponer detalles del sistema
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to verify email. Please check your verification link or request a new one.",
+        )
+
+
+@router.post(
+    "/resend-verification",
+    response_model=ResendVerificationEmailResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Reenviar email de verificación",
+    description="Genera un nuevo token de verificación y reenvía el email al usuario.",
+    tags=["Authentication"],
+)
+async def resend_verification_email(
+    request: ResendVerificationEmailRequestDTO,
+    use_case: ResendVerificationEmailUseCase = Depends(get_resend_verification_email_use_case),
+):
+    """
+    Endpoint para reenviar el email de verificación.
+
+    Este endpoint permite al usuario solicitar un nuevo email de verificación
+    si no recibió el original o si expiró.
+
+    Security Note:
+    - Siempre retorna 200 OK con mensaje genérico (independiente del resultado)
+    - No revela si el email existe en el sistema (previene user enumeration)
+    - No revela si el email ya está verificado
+
+    Args:
+        request: DTO con el email del usuario
+        use_case: Caso de uso de reenvío de email de verificación
+
+    Returns:
+        ResendVerificationEmailResponseDTO con mensaje genérico
+
+    Note:
+        Por razones de seguridad, este endpoint siempre retorna éxito,
+        independientemente de si el email existe o está verificado.
+    """
+    # Log intento de reenvío (parcialmente ofuscado para proteger privacidad)
+    email_preview = f"{request.email[:3]}***@{request.email.split('@')[1] if '@' in request.email else '***'}"
+    logger.info(f"Verification email resend requested for: {email_preview}")
+
+    try:
+        await use_case.execute(request.email)
+        logger.info(f"Verification email resend successful for: {email_preview}")
+    except ValueError as e:
+        # Log para monitoreo de seguridad sin exponer en respuesta
+        logger.info(
+            f"Verification email resend failed (expected): {type(e).__name__} - email: {email_preview}"
+        )
+        # Silenciosamente ignoramos errores para prevenir user enumeration
+        # Casos posibles:
+        # - Email no existe
+        # - Email ya verificado
+        # - Error al enviar email
+    except Exception as e:
+        # Log errores inesperados para monitoreo del sistema
+        logger.error(
+            f"Unexpected error in resend verification: {type(e).__name__}",
+            exc_info=True
+        )
+        # Aún así procedemos con respuesta genérica
+
+    # Siempre retornamos el mismo mensaje genérico
+    return ResendVerificationEmailResponseDTO(
+        message="If the email address exists in our system, a verification email has been sent.",
+        email=request.email
+    )

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -28,7 +28,8 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def find_by_email(self, email: Email) -> Optional[User]:
         """Busca un usuario por su email."""
-        statement = select(User).filter_by(email=email)
+        # Para composites, necesitamos usar where() y comparar con el atributo privado
+        statement = select(User).where(User._email == email.value)
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
@@ -76,7 +77,8 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def exists_by_email(self, email: Email) -> bool:
         """Verifica si un usuario existe por su email."""
-        statement = select(func.count()).select_from(User).filter_by(email=email)
+        # Para composites, necesitamos usar where() y comparar con el atributo privado
+        statement = select(func.count()).select_from(User).where(User._email == email.value)
         result = await self._session.execute(statement)
         return result.scalar_one() > 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,3 +349,31 @@ async def get_user_by_email(client: AsyncClient, email: str):
 
     assert user is not None, f"Usuario con email {email} no encontrado"
     return user
+
+
+# ======================================================================================
+# MOCK AUTOMÁTICO DEL SERVICIO DE EMAIL
+# ======================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_email_service():
+    """
+    Mock automático del servicio de email para todos los tests.
+    Esto evita enviar emails reales a Mailgun y gastar la cuota diaria.
+
+    El mock siempre retorna True (éxito) para simular que el email se envió correctamente.
+    """
+    from unittest.mock import patch, MagicMock
+
+    # Crear un mock que siempre retorna True
+    mock_send = MagicMock(return_value=True)
+
+    # Parchear el método send_verification_email
+    with patch.object(
+        type(  # Obtenemos la clase EmailService
+            __import__('src.shared.infrastructure.email.email_service', fromlist=['email_service']).email_service
+        ),
+        'send_verification_email',
+        mock_send
+    ):
+        yield mock_send

--- a/tests/integration/api/v1/test_auth_security.py
+++ b/tests/integration/api/v1/test_auth_security.py
@@ -1,0 +1,412 @@
+"""
+Tests de seguridad para endpoints de autenticación.
+
+Este archivo contiene tests que verifican que los endpoints NO revelen
+información sensible que pueda ser usada para user enumeration.
+"""
+
+import logging
+import time
+import pytest
+from httpx import AsyncClient
+from fastapi import status
+from tests.conftest import get_user_by_email
+
+
+@pytest.mark.asyncio
+class TestAuthSecurityUserEnumeration:
+    """
+    Suite de tests para verificar protección contra user enumeration.
+
+    User enumeration es un vector de ataque donde un atacante puede
+    determinar qué emails están registrados en el sistema basándose
+    en diferentes respuestas del servidor.
+    """
+
+    async def test_verify_email_returns_generic_message_for_all_errors(self, client: AsyncClient):
+        """
+        Test: verify-email no revela información sobre tokens/usuarios
+
+        Security Concern: Si el endpoint retorna diferentes mensajes para:
+        - Token inválido
+        - Token expirado
+        - Usuario no encontrado
+        - Email ya verificado
+
+        Un atacante podría usar esto para enumerar usuarios.
+
+        Expected Behavior: Siempre retornar el mismo mensaje genérico.
+        """
+        test_cases = [
+            {"token": "invalid_token_123", "description": "Token inválido"},
+            {"token": "a" * 100, "description": "Token muy largo"},
+            {"token": "expired_token", "description": "Token que no existe"},
+        ]
+
+        expected_message = "unable to verify email"
+
+        for test_case in test_cases:
+            # Act
+            response = await client.post(
+                "/api/v1/auth/verify-email",
+                json={"token": test_case["token"]}
+            )
+
+            # Assert
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, \
+                f"Failed for: {test_case['description']}"
+
+            detail = response.json()["detail"].lower()
+            assert expected_message in detail, \
+                f"Message differs for {test_case['description']}: {detail}"
+
+            # Verificar que no contiene información específica
+            assert "not found" not in detail.lower()
+            assert "expired" not in detail.lower()
+            assert "invalid token" not in detail.lower()
+            assert "already verified" not in detail.lower()
+
+    async def test_resend_verification_always_returns_success(self, client: AsyncClient):
+        """
+        Test: resend-verification siempre retorna 200 OK
+
+        Security Concern: Si el endpoint retorna:
+        - 400 para email no existente
+        - 200 para email existente
+
+        Un atacante puede enumerar emails registrados.
+
+        Expected Behavior: Siempre retornar 200 OK con mensaje genérico,
+        independientemente de si el email existe o no.
+        """
+        # Registrar un usuario para tener un caso válido
+        valid_user_data = {
+            "email": "security.test@example.com",
+            "password": "ValidPass123",
+            "first_name": "Security",
+            "last_name": "Test",
+        }
+        await client.post("/api/v1/auth/register", json=valid_user_data)
+
+        test_cases = [
+            {"email": "security.test@example.com", "description": "Email existente"},
+            {"email": "noexiste@example.com", "description": "Email no existente"},
+            {"email": "otro.noexiste@example.com", "description": "Otro email no existente"},
+        ]
+
+        expected_message = "if the email address exists in our system"
+        responses = []
+
+        for test_case in test_cases:
+            # Act
+            response = await client.post(
+                "/api/v1/auth/resend-verification",
+                json={"email": test_case["email"]}
+            )
+
+            # Assert
+            assert response.status_code == status.HTTP_200_OK, \
+                f"Status code differs for: {test_case['description']}"
+
+            detail = response.json()["message"].lower()
+            assert expected_message in detail, \
+                f"Message differs for {test_case['description']}: {detail}"
+
+            responses.append(response.json())
+
+        # Verificar que TODAS las respuestas son idénticas
+        first_message = responses[0]["message"]
+        for i, resp in enumerate(responses[1:], 1):
+            assert resp["message"] == first_message, \
+                f"Response {i} differs from first response - potential user enumeration!"
+
+    async def test_resend_verification_same_response_for_verified_user(self, client: AsyncClient):
+        """
+        Test: resend-verification retorna el mismo mensaje para usuarios verificados
+
+        Security Concern: Si el endpoint retorna diferente respuesta para
+        usuarios verificados vs no verificados, revela información de estado.
+
+        Expected Behavior: Mismo mensaje genérico para todos los casos.
+        """
+        # Registrar y verificar usuario
+        user_data = {
+            "email": "verified.security@example.com",
+            "password": "ValidPass123",
+            "first_name": "Verified",
+            "last_name": "Security",
+        }
+        register_response = await client.post("/api/v1/auth/register", json=user_data)
+        assert register_response.status_code == status.HTTP_201_CREATED
+
+        # Obtener token y verificar
+        user = await get_user_by_email(client, user_data["email"])
+        verify_response = await client.post(
+            "/api/v1/auth/verify-email",
+            json={"token": user.verification_token}
+        )
+        assert verify_response.status_code == status.HTTP_200_OK
+
+        # Act - Intentar reenviar verificación a usuario ya verificado
+        response = await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": user_data["email"]}
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        detail = response.json()["message"].lower()
+
+        # Debe usar el mismo mensaje genérico
+        assert "if the email address exists" in detail
+
+        # No debe revelar que el email ya está verificado
+        assert "already verified" not in detail.lower()
+        assert "verified" not in detail.lower()
+
+    async def test_timing_attack_mitigation(self, client: AsyncClient):
+        """
+        Test: Verificar que no hay timing attacks obvios
+
+        Security Concern: Si el servidor tarda más en responder cuando
+        un email existe vs cuando no existe, un atacante puede usar
+        timing attacks para enumerar usuarios.
+
+        Note: Este es un test básico. Para timing attacks reales,
+        se necesitarían mediciones estadísticas más sofisticadas.
+        """
+        import time
+
+        # Registrar un usuario
+        valid_user = {
+            "email": "timing.test@example.com",
+            "password": "ValidPass123",
+            "first_name": "Timing",
+            "last_name": "Test",
+        }
+        await client.post("/api/v1/auth/register", json=valid_user)
+
+        # Medir tiempo para email existente
+        start = time.time()
+        response_exists = await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": "timing.test@example.com"}
+        )
+        time_exists = time.time() - start
+
+        # Medir tiempo para email no existente
+        start = time.time()
+        response_not_exists = await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": "noexiste.timing@example.com"}
+        )
+        time_not_exists = time.time() - start
+
+        # Assert - Ambos deben retornar 200 OK
+        assert response_exists.status_code == status.HTTP_200_OK
+        assert response_not_exists.status_code == status.HTTP_200_OK
+
+        # Note: No verificamos timing exacto porque puede variar,
+        # pero documentamos que ambos deberían tener timing similar
+        # En producción, considerar agregar delays constantes si es necesario
+        print(f"\n[Security] Timing - Email exists: {time_exists:.4f}s")
+        print(f"[Security] Timing - Email not exists: {time_not_exists:.4f}s")
+
+
+@pytest.mark.asyncio
+class TestAuthSecurityLogging:
+    """
+    Suite de tests para verificar que el logging de seguridad funciona correctamente.
+
+    El logging es crítico para:
+    - Detectar intentos de brute force
+    - Monitorear fallos del servicio de email
+    - Debug en desarrollo
+    - Auditoría de seguridad
+    """
+
+    async def test_verify_email_logs_attempts(self, client: AsyncClient, caplog):
+        """
+        Test: verify-email registra intentos de verificación en logs
+
+        Verifica que:
+        - Se loggean intentos de verificación
+        - No se expone el token completo (solo preview)
+        - Se loggean fallos sin exponer información sensible
+        """
+        import logging
+        caplog.set_level(logging.INFO)
+
+        # Act - Intentar verificar con token inválido
+        response = await client.post(
+            "/api/v1/auth/verify-email",
+            json={"token": "invalid_token_12345"}
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # Verificar que se loggeó el intento
+        log_messages = [record.message for record in caplog.records]
+        assert any("Email verification attempt" in msg for msg in log_messages)
+        assert any("Email verification failed" in msg for msg in log_messages)
+
+        # Verificar que NO se expone el token completo
+        full_token_exposed = any("invalid_token_12345" in msg for msg in log_messages)
+        assert not full_token_exposed, "Full token should not be exposed in logs"
+
+    async def test_resend_verification_logs_requests(self, client: AsyncClient, caplog):
+        """
+        Test: resend-verification registra solicitudes en logs
+
+        Verifica que:
+        - Se loggean solicitudes de reenvío
+        - El email está parcialmente ofuscado (protección de privacidad)
+        - Se distingue entre éxito y fallo en los logs
+        """
+        import logging
+        caplog.set_level(logging.INFO)
+
+        # Registrar un usuario válido
+        valid_user = {
+            "email": "logging.test@example.com",
+            "password": "ValidPass123",
+            "first_name": "Logging",
+            "last_name": "Test",
+        }
+        await client.post("/api/v1/auth/register", json=valid_user)
+
+        # Clear previous logs
+        caplog.clear()
+
+        # Act - Solicitar reenvío para email existente
+        response_exists = await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": "logging.test@example.com"}
+        )
+
+        # Assert
+        assert response_exists.status_code == status.HTTP_200_OK
+
+        log_messages = [record.message for record in caplog.records]
+
+        # Verificar que se loggeó la solicitud
+        assert any("Verification email resend requested" in msg for msg in log_messages)
+        assert any("Verification email resend successful" in msg for msg in log_messages)
+
+        # Verificar que el email está ofuscado (no completo)
+        full_email_exposed = any("logging.test@example.com" in msg for msg in log_messages)
+        assert not full_email_exposed, "Full email should not be exposed in logs"
+
+        # Verificar que se muestra preview del email
+        assert any("log***@example.com" in msg for msg in log_messages)
+
+    async def test_error_handling_structure_is_present(self, client: AsyncClient, caplog):
+        """
+        Test: Verificar que la estructura de manejo de errores está implementada
+
+        Este test verifica indirectamente que el código tiene la estructura
+        necesaria para manejar errores inesperados de forma segura, sin
+        necesidad de forzar excepciones reales.
+
+        Verifica:
+        1. Logger está configurado en el módulo
+        2. Endpoints responden de forma consistente incluso con inputs extremos
+        3. Mensajes genéricos se mantienen en todos los casos
+        """
+        import logging
+
+        caplog.set_level(logging.INFO)
+
+        # 1. Verificar que el logger existe en el módulo
+        from src.modules.user.infrastructure.api.v1 import auth_routes
+        assert hasattr(auth_routes, 'logger'), "Logger should be configured in auth_routes module"
+        assert auth_routes.logger.name == "src.modules.user.infrastructure.api.v1.auth_routes"
+
+        # 2. Probar con inputs edge case para verify-email
+        edge_cases_verify = [
+            "x" * 1000,  # Token extremadamente largo
+            "!@#$%^&*()",  # Caracteres especiales
+            "unicode🔥test",  # Unicode
+            "",  # Vacío (maneja Pydantic)
+        ]
+
+        for token in edge_cases_verify:
+            if token:  # Skip vacío (Pydantic lo rechaza antes)
+                response = await client.post(
+                    "/api/v1/auth/verify-email",
+                    json={"token": token}
+                )
+                # Siempre debe retornar mensaje genérico
+                if response.status_code == 400:
+                    detail = response.json().get("detail", "")
+                    assert "unable to verify email" in detail.lower() or "validation" in detail.lower(), \
+                        f"Should return generic message for token: {token[:20]}..."
+
+        # 3. Probar con inputs edge case para resend-verification
+        edge_cases_resend = [
+            "test@" + "x" * 200 + ".com",  # Email muy largo
+            "test@domain.com" + ";" + "DROP TABLE users",  # SQL injection attempt
+        ]
+
+        for email in edge_cases_resend:
+            response = await client.post(
+                "/api/v1/auth/resend-verification",
+                json={"email": email}
+            )
+            # Siempre debe retornar 200 OK o 422 (validación Pydantic)
+            assert response.status_code in [200, 422], \
+                f"Should handle edge case gracefully for: {email[:30]}..."
+
+            if response.status_code == 200:
+                # Si pasa validación, debe retornar mensaje genérico
+                message = response.json().get("message", "")
+                assert "if the email address exists" in message.lower()
+
+        # 4. Verificar que se generaron logs (estructura de logging funciona)
+        assert len(caplog.records) > 0, "Logging should be working"
+
+        # 5. Verificar que ningún log expone datos sensibles completos
+        all_log_messages = " ".join([r.message for r in caplog.records])
+        # Los tokens deben estar ofuscados (no completos)
+        assert "x" * 1000 not in all_log_messages, "Long token should be truncated in logs"
+
+        print("\n✅ Error handling structure verified:")
+        print(f"  - Logger configured: {auth_routes.logger.name}")
+        print(f"  - Edge cases handled gracefully")
+        print(f"  - Generic messages maintained")
+        print(f"  - Logging active: {len(caplog.records)} log entries")
+
+    async def test_security_monitoring_capabilities(self, client: AsyncClient, caplog):
+        """
+        Test: Los logs permiten monitoreo de seguridad
+
+        Verifica que se pueden detectar patrones de ataque mediante logs:
+        - Múltiples intentos fallidos (potencial brute force)
+        - Enumeración de usuarios
+        - Timing patterns
+        """
+        import logging
+        caplog.set_level(logging.INFO)
+
+        # Simular múltiples intentos fallidos (posible ataque)
+        for i in range(3):
+            await client.post(
+                "/api/v1/auth/verify-email",
+                json={"token": f"attack_token_{i}"}
+            )
+
+        # Verificar que se puede detectar el patrón en logs
+        failed_attempts = [
+            record for record in caplog.records
+            if "verification failed" in record.message.lower()
+        ]
+
+        assert len(failed_attempts) >= 3, \
+            "Should be able to detect multiple failed attempts for security monitoring"
+
+        # En producción, un sistema de monitoreo podría:
+        # - Alertar si hay >10 intentos fallidos en <1 minuto
+        # - Bloquear IPs con comportamiento sospechoso
+        # - Generar reportes de seguridad
+        print(f"\n[Security] Detected {len(failed_attempts)} failed attempts - potential attack pattern")

--- a/tests/unit/modules/user/application/use_cases/test_resend_verification_email_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_resend_verification_email_use_case.py
@@ -1,0 +1,256 @@
+"""
+Tests unitarios para ResendVerificationEmailUseCase.
+
+Este archivo contiene tests que verifican:
+- Reenvío exitoso con email válido
+- Manejo de email no encontrado
+- Validación de email vacío
+- Prevención de reenvío a emails ya verificados
+- Generación de nuevo token
+- Persistencia de cambios
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.modules.user.application.use_cases.resend_verification_email_use_case import (
+    ResendVerificationEmailUseCase
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+# Marcar todos los tests de este fichero para que se ejecuten con asyncio
+pytestmark = pytest.mark.asyncio
+
+
+class TestResendVerificationEmailUseCase:
+    """
+    Suite de tests para el caso de uso ResendVerificationEmailUseCase.
+    """
+
+    @pytest.fixture
+    def uow(self) -> InMemoryUnitOfWork:
+        """Fixture que proporciona una Unit of Work en memoria para cada test."""
+        return InMemoryUnitOfWork()
+
+    @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
+    async def test_execute_with_valid_email_sends_verification_email(
+        self,
+        mock_email_service: MagicMock,
+        uow: InMemoryUnitOfWork
+    ):
+        """
+        Test: Reenviar email con dirección válida
+        Given: Un usuario registrado pero no verificado
+        When: Se ejecuta resend_verification_email con su email
+        Then: Se genera nuevo token y se envía el email
+        """
+        # Arrange - Mock del servicio de email
+        mock_email_service.send_verification_email.return_value = True
+
+        # Crear usuario sin verificar
+        async with uow:
+            user = User.create("Juan", "Pérez", "juan@test.com", "Password123!")
+            old_token = user.generate_verification_token()
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act
+        use_case = ResendVerificationEmailUseCase(uow)
+        result = await use_case.execute("juan@test.com")
+
+        # Assert
+        assert result is True
+        mock_email_service.send_verification_email.assert_called_once()
+
+        # Verificar que se generó un nuevo token
+        async with uow:
+            from src.modules.user.domain.value_objects.email import Email
+            email = Email("juan@test.com")
+            updated_user = await uow.users.find_by_email(email)
+
+            assert updated_user is not None
+            assert updated_user.verification_token is not None
+            assert updated_user.verification_token != old_token  # Debe ser diferente
+
+    async def test_execute_with_nonexistent_email_raises_error(self, uow: InMemoryUnitOfWork):
+        """
+        Test: Email no encontrado lanza error genérico
+        Given: Un email que no existe en la BD
+        When: Se ejecuta resend_verification_email
+        Then: Se lanza ValueError con mensaje genérico (seguridad: prevención de user enumeration)
+        """
+        # Arrange
+        use_case = ResendVerificationEmailUseCase(uow)
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
+            await use_case.execute("noexiste@test.com")
+
+    async def test_execute_with_empty_email_raises_error(self, uow: InMemoryUnitOfWork):
+        """
+        Test: Email vacío lanza error
+        Given: Un email vacío o solo espacios
+        When: Se ejecuta resend_verification_email
+        Then: Se lanza ValueError
+        """
+        # Arrange
+        use_case = ResendVerificationEmailUseCase(uow)
+
+        # Act & Assert - Email vacío
+        with pytest.raises(ValueError, match="El email es requerido"):
+            await use_case.execute("")
+
+        # Act & Assert - Email solo con espacios
+        with pytest.raises(ValueError, match="El email es requerido"):
+            await use_case.execute("   ")
+
+    async def test_execute_with_verified_email_raises_error(self, uow: InMemoryUnitOfWork):
+        """
+        Test: Email ya verificado lanza error genérico
+        Given: Un usuario con email ya verificado
+        When: Se intenta reenviar verificación
+        Then: Se lanza ValueError con mensaje genérico (seguridad: prevención de user enumeration)
+        """
+        # Arrange - Crear usuario y verificarlo
+        async with uow:
+            user = User.create("María", "García", "maria@test.com", "Password123!")
+            token = user.generate_verification_token()
+            user.verify_email(token)  # Verificar el email
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act & Assert
+        use_case = ResendVerificationEmailUseCase(uow)
+        with pytest.raises(ValueError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
+            await use_case.execute("maria@test.com")
+
+    @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
+    async def test_execute_generates_new_token(
+        self,
+        mock_email_service: MagicMock,
+        uow: InMemoryUnitOfWork
+    ):
+        """
+        Test: Se genera un nuevo token de verificación
+        Given: Un usuario con token existente
+        When: Se reenvía la verificación
+        Then: Se genera un nuevo token diferente al anterior
+        """
+        # Arrange
+        mock_email_service.send_verification_email.return_value = True
+
+        async with uow:
+            user = User.create("Pedro", "López", "pedro@test.com", "Password123!")
+            old_token = user.generate_verification_token()
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act
+        use_case = ResendVerificationEmailUseCase(uow)
+        await use_case.execute("pedro@test.com")
+
+        # Assert - Verificar que el token cambió
+        async with uow:
+            from src.modules.user.domain.value_objects.email import Email
+            email = Email("pedro@test.com")
+            updated_user = await uow.users.find_by_email(email)
+
+            assert updated_user.verification_token is not None
+            assert updated_user.verification_token != old_token
+
+    @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
+    async def test_execute_commits_transaction(
+        self,
+        mock_email_service: MagicMock,
+        uow: InMemoryUnitOfWork
+    ):
+        """
+        Test: Reenvío persiste los cambios
+        Given: Un usuario sin verificar
+        When: Se reenvía la verificación
+        Then: Los cambios se persisten correctamente
+        """
+        # Arrange
+        mock_email_service.send_verification_email.return_value = True
+
+        async with uow:
+            user = User.create("Ana", "Martínez", "ana@test.com", "Password123!")
+            user.generate_verification_token()
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act
+        use_case = ResendVerificationEmailUseCase(uow)
+        await use_case.execute("ana@test.com")
+
+        # Assert - Verificar que los cambios persisten en nueva transacción
+        async with uow:
+            from src.modules.user.domain.value_objects.email import Email
+            email = Email("ana@test.com")
+            persisted_user = await uow.users.find_by_email(email)
+
+            assert persisted_user is not None
+            assert persisted_user.verification_token is not None
+            assert persisted_user.email_verified is False
+
+    @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
+    async def test_execute_when_email_service_fails_raises_error(
+        self,
+        mock_email_service: MagicMock,
+        uow: InMemoryUnitOfWork
+    ):
+        """
+        Test: Error al enviar email lanza excepción
+        Given: Un usuario válido pero el servicio de email falla
+        When: Se intenta reenviar la verificación
+        Then: Se lanza ValueError
+        """
+        # Arrange - Mock del servicio de email para que falle
+        mock_email_service.send_verification_email.return_value = False
+
+        async with uow:
+            user = User.create("Carlos", "Ruiz", "carlos@test.com", "Password123!")
+            user.generate_verification_token()
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act & Assert
+        use_case = ResendVerificationEmailUseCase(uow)
+        with pytest.raises(ValueError, match="Error al enviar el email de verificación"):
+            await use_case.execute("carlos@test.com")
+
+    @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
+    async def test_execute_calls_email_service_with_correct_params(
+        self,
+        mock_email_service: MagicMock,
+        uow: InMemoryUnitOfWork
+    ):
+        """
+        Test: Servicio de email se llama con parámetros correctos
+        Given: Un usuario válido
+        When: Se reenvía la verificación
+        Then: El servicio de email se llama con los parámetros correctos
+        """
+        # Arrange
+        mock_email_service.send_verification_email.return_value = True
+
+        async with uow:
+            user = User.create("Luis", "Fernández", "luis@test.com", "Password123!")
+            user.generate_verification_token()
+            await uow.users.save(user)
+            await uow.commit()
+
+        # Act
+        use_case = ResendVerificationEmailUseCase(uow)
+        await use_case.execute("luis@test.com")
+
+        # Assert
+        call_args = mock_email_service.send_verification_email.call_args
+        assert call_args is not None
+        assert call_args.kwargs['to_email'] == "luis@test.com"
+        assert call_args.kwargs['user_name'] == "Luis Fernández"
+        assert isinstance(call_args.kwargs['verification_token'], str)
+        assert len(call_args.kwargs['verification_token']) > 0

--- a/tests/unit/modules/user/application/use_cases/test_resend_verification_email_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_resend_verification_email_use_case.py
@@ -14,7 +14,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from src.modules.user.application.use_cases.resend_verification_email_use_case import (
-    ResendVerificationEmailUseCase
+    ResendVerificationEmailUseCase,
+    ResendVerificationError
 )
 from src.modules.user.domain.entities.user import User
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
@@ -86,7 +87,7 @@ class TestResendVerificationEmailUseCase:
         use_case = ResendVerificationEmailUseCase(uow)
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
+        with pytest.raises(ResendVerificationError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
             await use_case.execute("noexiste@test.com")
 
     async def test_execute_with_empty_email_raises_error(self, uow: InMemoryUnitOfWork):
@@ -100,11 +101,11 @@ class TestResendVerificationEmailUseCase:
         use_case = ResendVerificationEmailUseCase(uow)
 
         # Act & Assert - Email vacío
-        with pytest.raises(ValueError, match="El email es requerido"):
+        with pytest.raises(ResendVerificationError, match="El email es requerido"):
             await use_case.execute("")
 
         # Act & Assert - Email solo con espacios
-        with pytest.raises(ValueError, match="El email es requerido"):
+        with pytest.raises(ResendVerificationError, match="El email es requerido"):
             await use_case.execute("   ")
 
     async def test_execute_with_verified_email_raises_error(self, uow: InMemoryUnitOfWork):
@@ -124,7 +125,7 @@ class TestResendVerificationEmailUseCase:
 
         # Act & Assert
         use_case = ResendVerificationEmailUseCase(uow)
-        with pytest.raises(ValueError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
+        with pytest.raises(ResendVerificationError, match="Si el email existe y no está verificado, se enviará un email de verificación"):
             await use_case.execute("maria@test.com")
 
     @patch('src.modules.user.application.use_cases.resend_verification_email_use_case.email_service')
@@ -219,7 +220,7 @@ class TestResendVerificationEmailUseCase:
 
         # Act & Assert
         use_case = ResendVerificationEmailUseCase(uow)
-        with pytest.raises(ValueError, match="Error al enviar el email de verificación"):
+        with pytest.raises(ResendVerificationError, match="Error al enviar el email de verificación"):
             await use_case.execute("carlos@test.com")
 
         # Verificar que NO se guardó ningún token nuevo en la BD


### PR DESCRIPTION
- Added ResendVerificationEmailUseCase to handle the logic for resending verification emails.
- Created DTOs for request and response of the resend verification email endpoint.
- Updated dependencies to include the new use case.
- Implemented API endpoint for resending verification emails with appropriate logging and security measures.
- Enhanced user repository methods to support email lookups.
- Added unit tests for the resend verification email use case covering various scenarios.
- Implemented integration tests to ensure security against user enumeration and proper logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resend-verification endpoint so users can request a new verification email; new request/response payloads included.

* **Security Improvements**
  * Endpoints return generic, non-revealing messages; logging sanitizes sensitive data and response timing mitigations added.

* **Behavior**
  * Resend generates a new verification token while preserving unverified status until confirmation.

* **Tests**
  * Added comprehensive integration and unit tests; test suite now globally mocks email delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->