### PR TITLE
feat(ci): Add Snyk Code (SAST) scan to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci_cd_pipeline.yml
+++ b/.github/workflows/ci_cd_pipeline.yml
@@ -528,7 +528,9 @@ jobs:
   # ================================
   # JOB 8: SNYK SECURITY SCAN
   # ================================
-  # Escanea vulnerabilidades con Snyk (alternativa a Safety/pip-audit)
+  # Escanea vulnerabilidades con Snyk (SCA + SAST)
+  # - Snyk Test: Vulnerabilidades en dependencias (requirements.txt)
+  # - Snyk Code: Vulnerabilidades en código fuente (src/)
   # Requiere SNYK_TOKEN en GitHub Secrets
 
   snyk_scan:
@@ -556,21 +558,60 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run Snyk Security Scan
+      - name: Run Snyk Test (Dependency Scan)
         uses: snyk/actions/python@master
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --json-file-output=snyk-report.json
+          args: --severity-threshold=high --json-file-output=snyk-dependencies-report.json
 
-      - name: Upload Snyk Report (if exists)
+      - name: Run Snyk Code (SAST - Source Code Analysis)
+        uses: snyk/actions/python@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: code test
+          args: --severity-threshold=high --json-file-output=snyk-code-report.json
+
+      - name: Generate Snyk Summary
+        if: always()
+        run: |
+          echo "=========================================="
+          echo "🐍 SNYK SECURITY SCAN SUMMARY"
+          echo "=========================================="
+          echo ""
+
+          # Dependencies scan results
+          if [ -f snyk-dependencies-report.json ]; then
+            DEPS_ISSUES=$(jq '.vulnerabilities | length' snyk-dependencies-report.json 2>/dev/null || echo "0")
+            echo "📦 Dependencies Scan:"
+            echo "  Issues found: $DEPS_ISSUES"
+          else
+            echo "📦 Dependencies Scan: No report generated"
+          fi
+
+          # Code scan results
+          if [ -f snyk-code-report.json ]; then
+            CODE_ISSUES=$(jq '.runs[0].results | length' snyk-code-report.json 2>/dev/null || echo "0")
+            echo "🔍 Code Analysis (SAST):"
+            echo "  Issues found: $CODE_ISSUES"
+          else
+            echo "🔍 Code Analysis (SAST): No report generated"
+          fi
+
+          echo "=========================================="
+
+      - name: Upload Snyk Reports
         uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:
-          name: snyk-security-report
-          path: snyk-report.json
+          name: snyk-security-reports
+          path: |
+            snyk-dependencies-report.json
+            snyk-code-report.json
           retention-days: 30
 
       - name: Snyk Monitor (Track in Dashboard)


### PR DESCRIPTION
## 📝 Summary

Add **Snyk Code (SAST)** scanning to the CI/CD pipeline to detect vulnerabilities in source code alongside the existing dependency scanning.

## 🔍 Changes

### Job 8: Snyk Security Scan (Enhanced)

Now runs **2 types of analysis**:

1. **Snyk Test (SCA)** - Dependencies scan
   - Scans `requirements.txt` for CVEs
   - Output: `snyk-dependencies-report.json`

2. **Snyk Code (SAST)** - Source code analysis ⭐ **NEW**
   - Scans `src/` for code vulnerabilities
   - Detects: SQL Injection, XSS, hardcoded secrets, weak crypto, command injection
   - Output: `snyk-code-report.json`

3. **Summary step** ⭐ **NEW**
   - Shows issue count by type (Dependencies vs Code)

## 🎯 What Snyk Code Detects

| Vulnerability | Severity |
|--------------|----------|
| SQL Injection | HIGH |
| XSS (Cross-Site Scripting) | HIGH |
| Hardcoded secrets | CRITICAL |
| Path Traversal | MEDIUM |
| Weak Cryptography | MEDIUM |
| Command Injection | HIGH |

## 🛡️ OWASP Coverage

- **A03: Injection** - Continuous validation
- **A02: Cryptographic Failures** - Weak crypto detection
- **A01: Access Control** - Authorization bypass detection

## ⚙️ Configuration

- Severity threshold: `high` (only HIGH and CRITICAL)
- Both scans: `continue-on-error: true` (non-blocking)
- Artifacts retention: 30 days
- Results sent to Snyk dashboard

## ✅ Prerequisites

- [x] `SNYK_TOKEN` configured in GitHub Secrets
- [x] Snyk Code enabled in Snyk account (https://app.snyk.io/settings/snyk-code)

## 📊 Expected Output

```
==========================================
🐍 SNYK SECURITY SCAN SUMMARY
==========================================

📦 Dependencies Scan:
  Issues found: 0

🔍 Code Analysis (SAST):
  Issues found: 0

==========================================
```

## 🧪 Testing

The pipeline will run automatically and show:
- Both scan results in GitHub Actions logs
- JSON reports as downloadable artifacts
- Results in Snyk dashboard

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)