### PR TITLE
fix(auth): add COOKIE_DOMAIN for cross-subdomain authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,4 +47,23 @@ MAILGUN_API_KEY=your-mailgun-api-key
 MAILGUN_DOMAIN=rydercupfriends.com
 MAILGUN_FROM_EMAIL="Ryder Cup Friends <noreply@rydercupfriends.com>"
 MAILGUN_API_URL=https://api.eu.mailgun.net/v3
+
+# ================================
+# FRONTEND CONFIGURATION
+# ================================
+# URL del frontend para enlaces en emails (verificación, password reset, etc.)
+# Development: http://localhost:5173
+# Production: https://www.rydercupfriends.com
 FRONTEND_URL=http://localhost:5173
+
+# Orígenes permitidos para CORS (separados por coma)
+# Development: http://localhost:5173,http://localhost:5174,http://localhost:8080
+# Production: https://www.rydercupfriends.com
+FRONTEND_ORIGINS=http://localhost:5173,http://localhost:5174,http://localhost:8080
+
+# Dominio para cookies (cross-subdomain authentication)
+# CRÍTICO: El punto inicial permite compartir cookies entre subdominios
+# Development: Dejar vacío (default a localhost)
+# Production: .rydercupfriends.com (permite www + api subdominios)
+# Ejemplo: .rydercupfriends.com permite www.rydercupfriends.com y api.rydercupfriends.com
+COOKIE_DOMAIN=

--- a/src/shared/infrastructure/security/cookie_handler.py
+++ b/src/shared/infrastructure/security/cookie_handler.py
@@ -38,6 +38,36 @@ def is_production() -> bool:
     return os.getenv("ENVIRONMENT", "development").lower() == "production"
 
 
+def get_cookie_domain() -> str | None:
+    """
+    Retorna el dominio para las cookies.
+
+    En producción con subdominios (api.rydercupfriends.com):
+    - COOKIE_DOMAIN=.rydercupfriends.com (permite www + api)
+
+    En desarrollo local:
+    - COOKIE_DOMAIN vacío o None (default a localhost)
+
+    Returns:
+        Domain string con punto inicial o None
+
+    Example:
+        >>> os.environ['COOKIE_DOMAIN'] = '.rydercupfriends.com'
+        >>> get_cookie_domain()
+        '.rydercupfriends.com'
+
+        >>> os.environ['COOKIE_DOMAIN'] = ''
+        >>> get_cookie_domain()
+        None
+
+    Note:
+        El punto inicial es CRÍTICO para permitir subdominios.
+        Sin el punto, las cookies solo funcionarían en el dominio exacto.
+    """
+    domain = os.getenv("COOKIE_DOMAIN")
+    return domain if domain and domain.strip() else None
+
+
 def set_auth_cookie(response: Response, token: str) -> None:
     """
     Establece una cookie httpOnly con el JWT de autenticación.
@@ -83,6 +113,7 @@ def set_auth_cookie(response: Response, token: str) -> None:
         samesite="lax",  # ✅ Protección CSRF moderada
         max_age=COOKIE_MAX_AGE,  # ✅ Expira en 1 hora
         path="/",  # ✅ Disponible en toda la app
+        domain=get_cookie_domain(),  # ✅ Cross-subdomain support (www ↔ api)
     )
 
 
@@ -113,6 +144,7 @@ def delete_auth_cookie(response: Response) -> None:
         httponly=True,  # Mismo httponly que al crear
         secure=is_production(),  # Mismo secure que al crear
         samesite="lax",  # Mismo samesite que al crear
+        domain=get_cookie_domain(),  # Mismo domain que al crear
     )
 
 
@@ -179,6 +211,7 @@ def set_refresh_token_cookie(response: Response, refresh_token: str) -> None:
         samesite="lax",  # ✅ Protección CSRF
         max_age=REFRESH_COOKIE_MAX_AGE,  # ✅ Expira en 7 días
         path="/",  # ✅ Disponible en toda la app
+        domain=get_cookie_domain(),  # ✅ Cross-subdomain support (www ↔ api)
     )
 
 
@@ -208,6 +241,7 @@ def delete_refresh_token_cookie(response: Response) -> None:
         httponly=True,  # Mismo httponly que al crear
         secure=is_production(),  # Mismo secure que al crear
         samesite="lax",  # Mismo samesite que al crear
+        domain=get_cookie_domain(),  # Mismo domain que al crear
     )
 
 
@@ -274,6 +308,7 @@ def set_csrf_cookie(response: Response, csrf_token: str) -> None:
         samesite="lax",  # ✅ Protección CSRF adicional
         max_age=CSRF_COOKIE_MAX_AGE,  # ✅ Expira en 15 minutos
         path="/",  # ✅ Disponible en toda la app
+        domain=get_cookie_domain(),  # ✅ Cross-subdomain support (www ↔ api)
     )
 
 
@@ -303,6 +338,7 @@ def delete_csrf_cookie(response: Response) -> None:
         httponly=False,  # Mismo httponly que al crear
         secure=is_production(),  # Mismo secure que al crear
         samesite="lax",  # Mismo samesite que al crear
+        domain=get_cookie_domain(),  # Mismo domain que al crear
     )
 
 


### PR DESCRIPTION
## 🔴 HOTFIX v2.0.3 - Cookie Domain Support

### 🐛 Bug Crítico en Producción
**Síntoma:** Usuarios expulsados inmediatamente después de login con mensaje "sesión ha caducado"

**Causa Raíz:** Cookies httpOnly configuradas sin dominio explícito, impidiendo autenticación cross-subdomain entre `www.rydercupfriends.com` y `api.rydercupfriends.com`

### ✅ Solución Implementada

#### 1. Cookie Handler Refactoring
**Archivo:** `src/shared/infrastructure/security/cookie_handler.py`

**Añadido:**
- Helper function `get_cookie_domain()` que lee variable `COOKIE_DOMAIN` del entorno
- Lógica de detección: retorna `None` en desarrollo (localhost) o dominio con punto inicial en producción

**Modificado (6 funciones):**
- `set_auth_cookie()` - Access token (15 min)
- `delete_auth_cookie()` - Logout access token
- `set_refresh_token_cookie()` - Refresh token (7 días)
- `delete_refresh_token_cookie()` - Logout refresh token
- `set_csrf_cookie()` - CSRF token (15 min)
- `delete_csrf_cookie()` - Logout CSRF token

**Cambio aplicado:**
```python
response.set_cookie(
    key=COOKIE_NAME,
    value=token,
    httponly=True,
    secure=is_production(),
    samesite="lax",
    max_age=COOKIE_MAX_AGE,
    path="/",
    domain=get_cookie_domain(),  # ✅ AÑADIDO
)
```

#### 2. Environment Configuration
**Archivo:** `.env.example`

**Añadida sección FRONTEND CONFIGURATION:**
```bash
# Dominio para cookies (cross-subdomain authentication)
# CRÍTICO: El punto inicial permite compartir cookies entre subdominios
# Development: Dejar vacío (default a localhost)
# Production: .rydercupfriends.com (permite www + api subdominios)
COOKIE_DOMAIN=
```

### 🚀 Deployment Instructions

#### Backend (Render - rydercupam-euzt.onrender.com)
**Variable de entorno requerida:**
```
COOKIE_DOMAIN=.rydercupfriends.com
```

**Notas importantes:**
- El punto inicial (`.rydercupfriends.com`) es **CRÍTICO** para habilitar subdominios
- Sin el punto, las cookies solo funcionarían en el dominio exacto
- Esta configuración permite que www y api compartan la sesión de autenticación

#### Verificación Post-Deploy
1. Login desde `https://www.rydercupfriends.com`
2. Inspeccionar cookies en DevTools → Application → Cookies
3. Verificar que `access_token`, `refresh_token`, `csrf_token` tengan:
   - Domain: `.rydercupfriends.com`
   - HttpOnly: ✅
   - Secure: ✅
   - SameSite: Lax

### 🔐 Security Compliance

**OWASP Mitigations:**
- **A01: Broken Access Control** → Cross-subdomain session management
- **A02: Cryptographic Failures** → secure=True enforced en producción
- **A07: Authentication Failures** → Sesión compartida segura entre subdominios

**Protecciones mantenidas:**
- httpOnly=True (protección XSS)
- secure=True en producción (solo HTTPS)
- samesite="lax" (protección CSRF básica)
- Tiempos de expiración: 15 min (access) / 7 días (refresh)

### 📊 Testing

**Tests afectados:** Ninguno (cambio backward-compatible)
- Development: `COOKIE_DOMAIN` vacío → comportamiento actual (localhost)
- Production: `COOKIE_DOMAIN` configurado → nueva funcionalidad

### 🎯 Arquitectura Target

Este hotfix habilita la migración a arquitectura de subdominios:

**Antes (Proxy):**
```
www.rydercupfriends.com (proxy)
  ↓ /api/* → rydercupam-euzt.onrender.com
  ↓ /*     → rydercupweb-3sqn.onrender.com
```

**Después (Subdominios):**
```
www.rydercupfriends.com → Frontend directo
api.rydercupfriends.com → Backend directo
(cookies compartidas vía .rydercupfriends.com)
```

### ✅ Checklist de Merge

- [x] Commit firmado con GPG
- [x] Convencional Commits (fix:)
- [x] Pipeline CI/CD passing
- [x] Documentación actualizada (.env.example)
- [ ] Variable COOKIE_DOMAIN configurada en Render Backend
- [ ] Verificación post-deploy en producción

---

**GitFlow:** Hotfix desde main → merge a main → cherry-pick a develop
**Versión:** v2.0.3 (hotfix de v2.0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)