### PR TITLE
feat: add auth_providers and has_password to UserResponseDTO

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@
 **Swagger UI**: `/docs` (auto-generated with interactive examples)
 **ReDoc**: `/redoc` (alternative documentation)
 **Total Endpoints**: 69 active
-**Version**: Sprint 3 Block 1
+**Version**: Sprint 3 Block 1.1 (auth_providers + has_password in UserResponseDTO)
 **Last Updated**: 16 February 2026
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -146,9 +146,26 @@ Support (1 endpoint) ⭐ v2.0.8
 - `access_token` (string, JWT) - LEGACY, use cookie
 - `refresh_token` (string, JWT) - LEGACY, use cookie
 - `csrf_token` (string, 256-bit) - CSRF protection token (v1.13.0)
-- `user` (object) - User data
+- `user` (object) - User data (see User Object below)
 - httpOnly Cookies: `access_token` (15 min), `refresh_token` (7 days)
 - Cookie NO httpOnly: `csrf_token` (15 min, readable by JS)
+
+**User Object (UserResponseDTO):**
+Returned in all endpoints that include user data (login, current-user, register, refresh-token, etc.)
+- `id` (string, UUID) - User ID
+- `email` (string) - User email
+- `first_name` (string) - First name
+- `last_name` (string) - Last name
+- `country_code` (string, nullable) - ISO 3166-1 alpha-2
+- `handicap` (float, nullable) - Golf handicap
+- `handicap_updated_at` (datetime, nullable) - Last handicap update
+- `email_verified` (bool) - Whether email is verified
+- `is_admin` (bool) - Global admin flag
+- `gender` (string, nullable) - "MALE" or "FEMALE"
+- `auth_providers` (string[], default `[]`) - Linked OAuth providers (e.g. `["google"]`) ⭐ v2.0.10
+- `has_password` (bool, default `true`) - Whether user has a password set ⭐ v2.0.10
+- `created_at` (datetime) - Account creation timestamp
+- `updated_at` (datetime) - Last update timestamp
 
 **Forgot Password Request:**
 - `email` (string, required)
@@ -211,7 +228,7 @@ Support (1 endpoint) ⭐ v2.0.8
 **Response (200 OK):**
 - `access_token`, `refresh_token`, `csrf_token` - JWT tokens
 - `token_type` - "bearer"
-- `user` - User data (id, email, first_name, last_name, email_verified, etc.)
+- `user` - User data (see User Object in Authentication section, includes `auth_providers` and `has_password`)
 - `is_new_user` (bool) - True if user was auto-registered (frontend should redirect to "Complete Profile")
 - `device_id`, `should_set_device_cookie` - Device registration info
 
@@ -868,4 +885,4 @@ PENDING_APPROVAL → APPROVED
 ---
 
 **Last Updated:** 16 February 2026
-**Version:** Sprint 3 Block 1 (Google OAuth)
+**Version:** Sprint 3 Block 1.1 (auth_providers + has_password in UserResponseDTO)

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -163,6 +163,15 @@ class UserResponseDTO(BaseModel):
         None,
         description="Género del usuario (MALE/FEMALE). Usado para resolución automática de tees.",
     )
+    # OAuth & Auth Method fields (v2.0.10)
+    auth_providers: list[str] = Field(
+        default_factory=list,
+        description="Proveedores OAuth vinculados al usuario (ej: ['google']). Vacío si solo usa email/password.",
+    )
+    has_password: bool = Field(
+        default=True,
+        description="True si el usuario tiene contraseña configurada. False si se registró solo con OAuth.",
+    )
 
     # Configuración de Pydantic actualizada para V2
     model_config = ConfigDict(from_attributes=True)

--- a/src/modules/user/application/use_cases/unlink_google_account_use_case.py
+++ b/src/modules/user/application/use_cases/unlink_google_account_use_case.py
@@ -54,7 +54,7 @@ class UnlinkGoogleAccountUseCase:
             if not user:
                 raise ValueError("User not found")
 
-            if not user.has_password():
+            if not user.has_password:
                 raise ValueError(
                     "Cannot unlink Google account: it is your only authentication method. "
                     "Set a password first."

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -125,6 +125,7 @@ class User:
             and self.last_name.strip() != ""
         )
 
+    @property
     def has_password(self) -> bool:
         """Verifica si el usuario tiene password (False para OAuth-only users)."""
         return self.password is not None

--- a/tests/unit/modules/user/application/use_cases/test_get_current_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_current_user_use_case.py
@@ -1,0 +1,215 @@
+"""
+Tests para GetCurrentUserUseCase
+
+Tests unitarios para el caso de uso de obtener usuario actual,
+incluyendo campos auth_providers y has_password.
+"""
+
+import pytest
+
+from src.modules.user.application.use_cases.get_current_user_use_case import (
+    GetCurrentUserUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.entities.user_oauth_account import UserOAuthAccount
+from src.modules.user.domain.value_objects.oauth_provider import OAuthProvider
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+
+@pytest.fixture
+def uow():
+    return InMemoryUnitOfWork()
+
+
+@pytest.fixture
+def use_case(uow):
+    return GetCurrentUserUseCase(uow=uow)
+
+
+@pytest.fixture
+async def normal_user(uow):
+    """Usuario registrado con email/password (sin OAuth)."""
+    user = User.create(
+        first_name="Normal",
+        last_name="User",
+        email_str="normal@example.com",
+        plain_password="SecureP@ss123!",
+    )
+    async with uow:
+        await uow.users.save(user)
+    return user
+
+
+@pytest.fixture
+async def oauth_user(uow):
+    """Usuario registrado via OAuth (sin password)."""
+    user = User.create_from_oauth(
+        first_name="OAuth",
+        last_name="User",
+        email_str="oauth@gmail.com",
+    )
+    async with uow:
+        await uow.users.save(user)
+
+    oauth = UserOAuthAccount.create(
+        user_id=user.id,
+        provider=OAuthProvider.GOOGLE,
+        provider_user_id="google-123",
+        provider_email="oauth@gmail.com",
+    )
+    async with uow:
+        await uow.oauth_accounts.save(oauth)
+
+    return user
+
+
+@pytest.fixture
+async def user_with_google_linked(uow):
+    """Usuario con password Y Google vinculado."""
+    user = User.create(
+        first_name="Both",
+        last_name="Methods",
+        email_str="both@example.com",
+        plain_password="SecureP@ss123!",
+    )
+    async with uow:
+        await uow.users.save(user)
+
+    oauth = UserOAuthAccount.create(
+        user_id=user.id,
+        provider=OAuthProvider.GOOGLE,
+        provider_user_id="google-456",
+        provider_email="both@gmail.com",
+    )
+    async with uow:
+        await uow.oauth_accounts.save(oauth)
+
+    return user
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUserUseCase:
+    """Tests para obtener usuario actual."""
+
+    async def test_returns_user_dto(self, use_case, normal_user):
+        """
+        Test: Retorna UserResponseDTO para usuario existente.
+        Given: Usuario registrado con email/password
+        When: Se ejecuta con su ID
+        Then: Retorna DTO con datos correctos
+        """
+        result = await use_case.execute(str(normal_user.id.value))
+
+        assert result is not None
+        assert result.email == "normal@example.com"
+        assert result.first_name == "Normal"
+
+    async def test_returns_none_for_nonexistent_user(self, use_case):
+        """
+        Test: Retorna None si el usuario no existe.
+        Given: ID de usuario inexistente
+        When: Se ejecuta con ese ID
+        Then: Retorna None
+        """
+        result = await use_case.execute("00000000-0000-0000-0000-000000000000")
+
+        assert result is None
+
+    async def test_returns_none_for_invalid_id(self, use_case):
+        """
+        Test: Retorna None si el ID es inválido.
+        Given: ID mal formado
+        When: Se ejecuta con ese ID
+        Then: Retorna None
+        """
+        result = await use_case.execute("not-a-valid-uuid")
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUserAuthProviders:
+    """Tests para el campo auth_providers en la respuesta."""
+
+    async def test_empty_auth_providers_for_normal_user(self, use_case, normal_user):
+        """
+        Test: auth_providers es [] para usuario sin OAuth.
+        Given: Usuario registrado con email/password, sin Google vinculado
+        When: Se obtiene el usuario actual
+        Then: auth_providers es lista vacía
+        """
+        result = await use_case.execute(str(normal_user.id.value))
+
+        assert result is not None
+        assert result.auth_providers == []
+
+    async def test_google_in_auth_providers_for_oauth_user(self, use_case, oauth_user):
+        """
+        Test: auth_providers incluye 'google' para usuario OAuth.
+        Given: Usuario registrado via Google OAuth
+        When: Se obtiene el usuario actual
+        Then: auth_providers contiene 'google'
+        """
+        result = await use_case.execute(str(oauth_user.id.value))
+
+        assert result is not None
+        assert result.auth_providers == ["google"]
+
+    async def test_google_in_auth_providers_for_linked_user(
+        self, use_case, user_with_google_linked
+    ):
+        """
+        Test: auth_providers incluye 'google' para usuario que vinculó Google.
+        Given: Usuario con password que vinculó cuenta Google
+        When: Se obtiene el usuario actual
+        Then: auth_providers contiene 'google'
+        """
+        result = await use_case.execute(str(user_with_google_linked.id.value))
+
+        assert result is not None
+        assert result.auth_providers == ["google"]
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUserHasPassword:
+    """Tests para el campo has_password en la respuesta."""
+
+    async def test_has_password_true_for_normal_user(self, use_case, normal_user):
+        """
+        Test: has_password es True para usuario con contraseña.
+        Given: Usuario registrado con email/password
+        When: Se obtiene el usuario actual
+        Then: has_password es True
+        """
+        result = await use_case.execute(str(normal_user.id.value))
+
+        assert result is not None
+        assert result.has_password is True
+
+    async def test_has_password_false_for_oauth_only_user(self, use_case, oauth_user):
+        """
+        Test: has_password es False para usuario OAuth sin contraseña.
+        Given: Usuario registrado solo via Google OAuth
+        When: Se obtiene el usuario actual
+        Then: has_password es False
+        """
+        result = await use_case.execute(str(oauth_user.id.value))
+
+        assert result is not None
+        assert result.has_password is False
+
+    async def test_has_password_true_for_linked_user(
+        self, use_case, user_with_google_linked
+    ):
+        """
+        Test: has_password es True para usuario con password y Google vinculado.
+        Given: Usuario con password que también tiene Google vinculado
+        When: Se obtiene el usuario actual
+        Then: has_password es True (tiene ambos métodos)
+        """
+        result = await use_case.execute(str(user_with_google_linked.id.value))
+
+        assert result is not None
+        assert result.has_password is True

--- a/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
@@ -123,7 +123,7 @@ class TestGoogleLoginUseCaseAutoRegister:
 
         user = await uow.users.find_by_email(Email("oauth@example.com"))
         assert user is not None
-        assert user.has_password() is False
+        assert user.has_password is False
 
     async def test_auto_register_user_email_verified(
         self, use_case, uow, google_oauth_service, google_user_info, login_request

--- a/tests/unit/modules/user/domain/entities/test_user_oauth_methods.py
+++ b/tests/unit/modules/user/domain/entities/test_user_oauth_methods.py
@@ -121,13 +121,13 @@ class TestUserCreateFromOAuth:
 
 
 class TestUserHasPassword:
-    """Tests para el método has_password()"""
+    """Tests para la propiedad has_password"""
 
     def test_has_password_true_for_normal_user(self):
         """
-        Test: has_password() retorna True para usuarios normales
+        Test: has_password retorna True para usuarios normales
         Given: Usuario creado con password
-        When: Se verifica has_password()
+        When: Se verifica has_password
         Then: Retorna True
         """
         # Arrange
@@ -139,13 +139,13 @@ class TestUserHasPassword:
         )
 
         # Act & Assert
-        assert user.has_password() is True
+        assert user.has_password is True
 
     def test_has_password_false_for_oauth_user(self):
         """
-        Test: has_password() retorna False para usuarios OAuth
+        Test: has_password retorna False para usuarios OAuth
         Given: Usuario creado desde OAuth (sin password)
-        When: Se verifica has_password()
+        When: Se verifica has_password
         Then: Retorna False
         """
         # Arrange
@@ -156,7 +156,7 @@ class TestUserHasPassword:
         )
 
         # Act & Assert
-        assert user.has_password() is False
+        assert user.has_password is False
 
 
 class TestUserIsValidOAuth:


### PR DESCRIPTION
## Summary
- Add `auth_providers: list[str]` and `has_password: bool` fields to `UserResponseDTO` so the frontend can render the profile security section correctly (link/unlink Google, password status)
- Convert `User.has_password()` method to `@property` for correct Pydantic `model_validate` behavior
- Enrich `GetCurrentUserUseCase` to query OAuth accounts and populate `auth_providers`
- Fix `InvalidUserIdError` not caught in `GetCurrentUserUseCase`
- Update `docs/API.md` with User Object field documentation
- Update `docs/FRONTEND_INTEGRATION.md` with Bloque 1.1 (scenarios, UI logic, TypeScript types)

## Context
Sprint 3 Block 1 (Google OAuth) shipped the endpoints but didn't include OAuth state in user profile responses. The frontend had no way to know if a user has Google linked or has a password set.

## Test plan
- [x] 9 new unit tests (3 base + 3 auth_providers + 3 has_password)
- [x] All 1,441 unit tests passing (0 failures)
- [x] Ruff linting clean
- [x] Existing OAuth tests updated (`has_password()` → `has_password`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles now display information about linked OAuth providers and password configuration status.

* **Documentation**
  * API reference documentation updated with expanded user object details, including authentication provider data and password status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->