### PR TITLE
fix: naive datetime in UserOAuthAccount (500 in production)

### DIFF
--- a/src/modules/user/domain/entities/user_oauth_account.py
+++ b/src/modules/user/domain/entities/user_oauth_account.py
@@ -4,7 +4,7 @@ User OAuth Account Entity - Domain Layer
 Representa una cuenta OAuth vinculada a un usuario del sistema.
 """
 
-from datetime import UTC, datetime
+from datetime import datetime
 
 from src.shared.domain.events.domain_event import DomainEvent
 
@@ -45,7 +45,7 @@ class UserOAuthAccount:
         self._provider = provider
         self._provider_user_id = provider_user_id
         self._provider_email = provider_email
-        self._created_at = created_at or datetime.now(UTC)
+        self._created_at = created_at or datetime.now()
         self._domain_events = domain_events or []
 
     # === Read-only Properties ===
@@ -100,7 +100,7 @@ class UserOAuthAccount:
             provider=provider,
             provider_user_id=provider_user_id,
             provider_email=provider_email,
-            created_at=datetime.now(UTC),
+            created_at=datetime.now(),
         )
 
         account._add_domain_event(

--- a/tests/unit/modules/user/domain/entities/test_user_oauth_account.py
+++ b/tests/unit/modules/user/domain/entities/test_user_oauth_account.py
@@ -8,7 +8,7 @@ Este archivo contiene tests que verifican:
 - Validaciones
 """
 
-from datetime import UTC, datetime
+from datetime import datetime
 
 from src.modules.user.domain.entities.user_oauth_account import UserOAuthAccount
 from src.modules.user.domain.events.google_account_linked_event import (
@@ -131,11 +131,11 @@ class TestUserOAuthAccountCreation:
         Test: El constructor inicializa created_at por defecto
         Given: Constructor sin created_at explícito
         When: Se crea UserOAuthAccount
-        Then: created_at se establece a datetime.now(UTC)
+        Then: created_at se establece a datetime.now()
         """
         # Arrange
         user_id = UserId.generate()
-        before = datetime.now(UTC)
+        before = datetime.now()
 
         # Act
         account = UserOAuthAccount(
@@ -147,7 +147,7 @@ class TestUserOAuthAccountCreation:
         )
 
         # Assert
-        after = datetime.now(UTC)
+        after = datetime.now()
         assert before <= account.created_at <= after
 
 


### PR DESCRIPTION
## Summary
- `UserOAuthAccount` used `datetime.now(UTC)` (timezone-aware) but the DB column is `TIMESTAMP WITHOUT TIME ZONE`
- asyncpg rejects the mismatch causing a **500 error on Google OAuth login in production**
- All other entities in the project use `datetime.now()` (naive) — this aligns the pattern

## Files Changed (2)
- `src/modules/user/domain/entities/user_oauth_account.py` — `datetime.now(UTC)` → `datetime.now()`
- `tests/unit/modules/user/domain/entities/test_user_oauth_account.py` — same fix in test

## Test plan
- [x] 50 OAuth-related tests passing (0 failures)
- [ ] Deploy to Render and verify Google OAuth login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)