### PR TITLE
feat: Add Invitations module (Sprint 3 Block 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ requirements.lock.metadata
 # ==================================
 docs/frontend-examples/
 docs/FRONTEND_INTEGRATION_v1.13.0.md
+docs/FRONTEND_INTEGRATION.md
 docker/.env
 
 # K8s database backups

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,32 +1,27 @@
 # Roadmap - RyderCupFriends Backend
 
-> **Version:** 2.0.8 | **Tests:** 1,567 (1 skipped) | **Endpoints:** 66 | **OWASP:** 9.4/10
+> **Version:** 2.0.11 | **Tests:** 1,646 unit + 236 integration (1 skipped) | **Endpoints:** 74 | **OWASP:** 9.4/10
 >
-> **Last Updated:** Feb 15, 2026
+> **Last Updated:** Feb 18, 2026
 
 ---
 
-## En Progreso
+## Completado: Sprint 3 — Google OAuth + Invitations
 
-### Clean Architecture Refactoring (PR #63)
+### Bloque 1: Google OAuth (Social Login) ✅ v2.0.9 → v2.0.11
 
-- **Rama:** `refactor/clean-architecture-violations`
-- **Objetivo:** Resolver violaciones DDD/Clean Architecture detectadas post-Sprint 2
-- **Resultado:** 12/15 violaciones resueltas (97% compliance)
-  - Zero framework imports en domain layer
-  - Entidades encapsuladas (Competition, Enrollment)
-  - DTO mappers movidos a application layer
-  - Competition routes dividido en 3 ficheros (CRUD, State, GolfCourse)
-  - Domain services inyectados via DI
-  - Excepciones centralizadas
+```http
+POST /api/v1/auth/google                              # Login/registro con Google
+POST /api/v1/auth/google/link                          # Vincular cuenta Google a usuario existente
+DELETE /api/v1/auth/google/unlink                      # Desvincular cuenta Google
+```
 
----
+- OAuth 2.0 Authorization Code Flow con PKCE
+- Tabla `user_oauth_accounts` (user_id, provider, provider_user_id, email)
+- `auth_providers` + `has_password` en UserResponseDTO (v2.0.10)
+- Hotfix: naive datetime en UserOAuthAccount (v2.0.11)
 
-## Próximo: Sprint 3 — Invitations (1 semana)
-
-**Objetivo:** Sistema de invitaciones para competiciones
-
-### Endpoints (5)
+### Bloque 2: Invitations ✅
 
 ```http
 POST /api/v1/competitions/{id}/invitations            # Invitar por user ID
@@ -36,12 +31,11 @@ POST /api/v1/invitations/{id}/respond                  # Aceptar/Rechazar
 GET  /api/v1/competitions/{id}/invitations             # Vista creador
 ```
 
-### Reglas clave
-
-- Token 256-bit (`secrets.token_urlsafe(32)`), SHA256 hash en BD, expira 7 días
+- Token 256-bit, SHA256 hash en BD, expira 7 días
 - Aceptar invitación → Enrollment status APPROVED (bypasses approval flow)
-- Emails bilingües ES/EN via Mailgun
-- Limpieza automática de tokens expirados (Celery, cada 6h)
+- Rate limiting: max_players invitaciones por hora por competición
+- **Emails bilingües ES/EN via Mailgun** (ISP: `IInvitationEmailService` port en Competition module)
+- Email no bloquea creación de invitación (fire-and-forget con try/except)
 
 ---
 
@@ -96,7 +90,7 @@ GET  /api/v1/competitions/{id}/invitations             # Vista creador
 
 ### v3.0.0 — Major Release (4-6 meses)
 
-- OAuth 2.0 / Social Login (Google, Apple)
+- Apple Sign In (requiere Apple Developer Program)
 - WebAuthn (Hardware Security Keys)
 - Push notifications (Firebase)
 - Payment system (Stripe)
@@ -112,7 +106,7 @@ GET  /api/v1/competitions/{id}/invitations             # Vista creador
 2025 Q4  │ v1.0.0 → v1.8.0   Auth, Security, Email, Handicap
 2026 Q1  │ v1.11.0 → v1.13.1  Password Reset, CI/CD, Security Hardening
          │ v2.0.0 → v2.0.8    RBAC, Golf Courses, Scheduling, Support
-         │ ⭐ Sprint 3         Invitations ← NEXT
+         │ v2.0.9 → v2.0.11   Sprint 3: Google OAuth + Invitations ✅
 2026 Q2  │ Sprint 4-5          Scoring + Leaderboards
          │ v2.1.0              Compliance (GDPR, Audit, Avatars)
          │ v2.2.0              AI & RAG Module
@@ -126,6 +120,9 @@ GET  /api/v1/competitions/{id}/invitations             # Vista creador
 
 | Version | Fecha | Highlights |
 |---------|-------|------------|
+| **v2.0.11** | Feb 17, 2026 | Hotfix: naive datetime in UserOAuthAccount |
+| **v2.0.10** | Feb 17, 2026 | auth_providers + has_password in UserResponseDTO |
+| **v2.0.9** | Feb 16, 2026 | Google OAuth (login, link, unlink) + Invitations (5 endpoints) |
 | **v2.0.8** | Feb 9, 2026 | Support Module (contact form → GitHub Issues) |
 | **v2.0.7** | Feb 8, 2026 | Gender-based tee categories, hotfixes |
 | **v2.0.1-v2.0.6** | Feb 1-6, 2026 | Sprint 2: Rounds, Matches, Teams (11 endpoints, 422 tests) |

--- a/alembic/versions/f6b8c4d2e3a5_add_invitations_table.py
+++ b/alembic/versions/f6b8c4d2e3a5_add_invitations_table.py
@@ -1,0 +1,91 @@
+"""Add invitations table
+
+Revision ID: f6b8c4d2e3a5
+Revises: e5a7b9c3d1f4
+Create Date: 2026-02-18 16:30:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f6b8c4d2e3a5"
+down_revision = "e5a7b9c3d1f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invitations",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("competition_id", sa.CHAR(36), nullable=False),
+        sa.Column("inviter_id", sa.CHAR(36), nullable=False),
+        sa.Column("invitee_email", sa.String(254), nullable=False),
+        sa.Column("invitee_user_id", sa.CHAR(36), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="PENDING"),
+        sa.Column("personal_message", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("responded_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["competitions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["inviter_id"],
+            ["users.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["invitee_user_id"],
+            ["users.id"],
+        ),
+    )
+
+    # Indexes for common queries
+    op.create_index(
+        "ix_invitations_competition_id",
+        "invitations",
+        ["competition_id"],
+    )
+    op.create_index(
+        "ix_invitations_invitee_email",
+        "invitations",
+        ["invitee_email"],
+    )
+    op.create_index(
+        "ix_invitations_invitee_user_id",
+        "invitations",
+        ["invitee_user_id"],
+    )
+    op.create_index(
+        "ix_invitations_status",
+        "invitations",
+        ["status"],
+    )
+    op.create_index(
+        "ix_invitations_expires_at",
+        "invitations",
+        ["expires_at"],
+    )
+
+    # Partial unique index: only one PENDING invitation per email+competition
+    op.execute(
+        "CREATE UNIQUE INDEX uq_invitation_pending_email_competition "
+        "ON invitations (competition_id, invitee_email) "
+        "WHERE status = 'PENDING'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_invitation_pending_email_competition")
+    op.drop_index("ix_invitations_expires_at", table_name="invitations")
+    op.drop_index("ix_invitations_status", table_name="invitations")
+    op.drop_index("ix_invitations_invitee_user_id", table_name="invitations")
+    op.drop_index("ix_invitations_invitee_email", table_name="invitations")
+    op.drop_index("ix_invitations_competition_id", table_name="invitations")
+    op.drop_table("invitations")

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from src.modules.competition.infrastructure.api.v1 import (  # noqa: E402
     competition_golf_course_routes,
     competition_state_routes,
     enrollment_routes,
+    invitation_routes,
     round_match_routes,
 )
 from src.modules.competition.infrastructure.persistence.sqlalchemy.mappers import (  # noqa: E402
@@ -313,6 +314,12 @@ app.include_router(
     enrollment_routes.router,
     prefix="/api/v1",
     tags=["Enrollments"],
+)
+
+app.include_router(
+    invitation_routes.router,
+    prefix="/api/v1",
+    tags=["Invitations"],
 )
 
 app.include_router(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -65,11 +65,17 @@ from src.modules.competition.application.use_cases.get_schedule_use_case import 
 from src.modules.competition.application.use_cases.handle_enrollment_use_case import (
     HandleEnrollmentUseCase,
 )
+from src.modules.competition.application.use_cases.list_competition_invitations_use_case import (
+    ListCompetitionInvitationsUseCase,
+)
 from src.modules.competition.application.use_cases.list_competitions_use_case import (
     ListCompetitionsUseCase,
 )
 from src.modules.competition.application.use_cases.list_enrollments_use_case import (
     ListEnrollmentsUseCase,
+)
+from src.modules.competition.application.use_cases.list_my_invitations_use_case import (
+    ListMyInvitationsUseCase,
 )
 from src.modules.competition.application.use_cases.reassign_match_players_use_case import (
     ReassignMatchPlayersUseCase,
@@ -82,6 +88,15 @@ from src.modules.competition.application.use_cases.reorder_golf_courses_use_case
 )
 from src.modules.competition.application.use_cases.request_enrollment_use_case import (
     RequestEnrollmentUseCase,
+)
+from src.modules.competition.application.use_cases.respond_to_invitation_use_case import (
+    RespondToInvitationUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_email_use_case import (
+    SendInvitationByEmailUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_user_id_use_case import (
+    SendInvitationByUserIdUseCase,
 )
 from src.modules.competition.application.use_cases.set_custom_handicap_use_case import (
     SetCustomHandicapUseCase,
@@ -1157,6 +1172,51 @@ def get_reassign_match_players_use_case(
         user_repository=user_uow.users,
         handicap_calculator=PlayingHandicapCalculator(),
     )
+
+
+# ======================================================================================
+# INVITATION USE CASE PROVIDERS (Sprint 3 - Block 2)
+# ======================================================================================
+
+
+def get_send_invitation_by_user_id_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> SendInvitationByUserIdUseCase:
+    """Proveedor del caso de uso SendInvitationByUserIdUseCase."""
+    return SendInvitationByUserIdUseCase(uow, user_uow)
+
+
+def get_send_invitation_by_email_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> SendInvitationByEmailUseCase:
+    """Proveedor del caso de uso SendInvitationByEmailUseCase."""
+    return SendInvitationByEmailUseCase(uow, user_uow)
+
+
+def get_list_my_invitations_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> ListMyInvitationsUseCase:
+    """Proveedor del caso de uso ListMyInvitationsUseCase."""
+    return ListMyInvitationsUseCase(uow, user_uow)
+
+
+def get_respond_to_invitation_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> RespondToInvitationUseCase:
+    """Proveedor del caso de uso RespondToInvitationUseCase."""
+    return RespondToInvitationUseCase(uow, user_uow)
+
+
+def get_list_competition_invitations_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> ListCompetitionInvitationsUseCase:
+    """Proveedor del caso de uso ListCompetitionInvitationsUseCase."""
+    return ListCompetitionInvitationsUseCase(uow, user_uow)
 
 
 # ============================================================================

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -8,6 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.database import async_session_maker
 from src.config.settings import settings
+from src.modules.competition.application.ports.invitation_email_service_interface import (
+    IInvitationEmailService,
+)
 from src.modules.competition.application.use_cases.activate_competition_use_case import (
     ActivateCompetitionUseCase,
 )
@@ -1179,20 +1182,27 @@ def get_reassign_match_players_use_case(
 # ======================================================================================
 
 
+def get_invitation_email_service() -> IInvitationEmailService:
+    """Proveedor del servicio de email para invitaciones."""
+    return EmailService()
+
+
 def get_send_invitation_by_user_id_use_case(
     uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    email_service: IInvitationEmailService = Depends(get_invitation_email_service),
 ) -> SendInvitationByUserIdUseCase:
     """Proveedor del caso de uso SendInvitationByUserIdUseCase."""
-    return SendInvitationByUserIdUseCase(uow, user_uow)
+    return SendInvitationByUserIdUseCase(uow, user_uow, email_service)
 
 
 def get_send_invitation_by_email_use_case(
     uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    email_service: IInvitationEmailService = Depends(get_invitation_email_service),
 ) -> SendInvitationByEmailUseCase:
     """Proveedor del caso de uso SendInvitationByEmailUseCase."""
-    return SendInvitationByEmailUseCase(uow, user_uow)
+    return SendInvitationByEmailUseCase(uow, user_uow, email_service)
 
 
 def get_list_my_invitations_use_case(

--- a/src/modules/competition/application/dto/invitation_dto.py
+++ b/src/modules/competition/application/dto/invitation_dto.py
@@ -1,0 +1,80 @@
+"""DTOs para el modulo de invitaciones."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SendInvitationByUserIdRequestDTO(BaseModel):
+    """DTO para enviar invitacion por user_id."""
+
+    competition_id: UUID
+    inviter_id: UUID
+    invitee_user_id: UUID
+    personal_message: str | None = Field(None, max_length=500)
+
+
+class SendInvitationByEmailRequestDTO(BaseModel):
+    """DTO para enviar invitacion por email."""
+
+    competition_id: UUID
+    inviter_id: UUID
+    invitee_email: str
+    personal_message: str | None = Field(None, max_length=500)
+
+
+class RespondInvitationRequestDTO(BaseModel):
+    """DTO para responder a una invitacion."""
+
+    invitation_id: UUID
+    user_id: UUID
+    action: str  # "ACCEPT" or "DECLINE"
+
+
+class InvitationResponseDTO(BaseModel):
+    """DTO de respuesta con shape completa del contrato frontend."""
+
+    id: UUID
+    competition_id: UUID
+    competition_name: str
+    inviter_id: UUID
+    inviter_name: str
+    invitee_email: str
+    invitee_user_id: UUID | None = None
+    invitee_name: str | None = None
+    status: str
+    personal_message: str | None = None
+    expires_at: datetime
+    responded_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class RespondInvitationResponseDTO(BaseModel):
+    """DTO de respuesta al responder a una invitacion."""
+
+    id: UUID
+    competition_id: UUID
+    competition_name: str
+    inviter_id: UUID
+    inviter_name: str
+    invitee_email: str
+    invitee_user_id: UUID | None = None
+    invitee_name: str | None = None
+    status: str
+    personal_message: str | None = None
+    expires_at: datetime
+    responded_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+    enrollment_id: UUID | None = None
+
+
+class PaginatedInvitationResponseDTO(BaseModel):
+    """DTO paginado de invitaciones."""
+
+    invitations: list[InvitationResponseDTO]
+    total_count: int
+    page: int
+    limit: int

--- a/src/modules/competition/application/exceptions.py
+++ b/src/modules/competition/application/exceptions.py
@@ -53,3 +53,21 @@ class InvalidTeeCategoryError(ValueError):
     """El valor de tee_category no es válido."""
 
     pass
+
+
+class InvitationNotFoundError(Exception):
+    """La invitacion no existe."""
+
+    pass
+
+
+class InviteeNotFoundError(Exception):
+    """El invitee (user_id) no existe."""
+
+    pass
+
+
+class NotInviteeError(Exception):
+    """El usuario no es el invitee de la invitacion."""
+
+    pass

--- a/src/modules/competition/application/ports/invitation_email_service_interface.py
+++ b/src/modules/competition/application/ports/invitation_email_service_interface.py
@@ -1,0 +1,44 @@
+"""
+Invitation Email Service Interface - Application Layer Port
+
+Define el contrato para envio de emails de invitacion.
+Vive en el Competition module (Interface Segregation Principle).
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+
+class IInvitationEmailService(ABC):
+    """
+    Puerto para envio de emails de invitacion a competiciones.
+
+    Separado de IEmailService (User module) para respetar ISP.
+    La implementacion concreta (EmailService) puede implementar ambas interfaces.
+    """
+
+    @abstractmethod
+    async def send_invitation_email(
+        self,
+        to_email: str,
+        invitee_name: str | None,
+        inviter_name: str,
+        competition_name: str,
+        personal_message: str | None,
+        expires_at: datetime,
+    ) -> bool:
+        """
+        Envia un email de invitacion a una competicion.
+
+        Args:
+            to_email: Email del invitado
+            invitee_name: Nombre del invitado (None si no registrado)
+            inviter_name: Nombre del que invita
+            competition_name: Nombre de la competicion
+            personal_message: Mensaje personal opcional
+            expires_at: Fecha de expiracion de la invitacion
+
+        Returns:
+            True si se envio correctamente, False en caso contrario
+        """
+        pass

--- a/src/modules/competition/application/use_cases/list_competition_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_competition_invitations_use_case.py
@@ -78,50 +78,50 @@ class ListCompetitionInvitationsUseCase:
                 competition_id_vo, status=status_vo
             )
 
-            # 6. Enriquecer con nombres
+            # 6. Guardar datos intermedios
             competition_name = str(competition.name)
-            invitation_dtos = []
 
+        # 7. Enriquecer con nombres en una sola sesion de usuario
+        invitation_dtos = []
+        async with self._user_uow:
             for inv in invitations:
-                # Resolver inviter_name
-                async with self._user_uow:
-                    inviter_user = await self._user_uow.users.find_by_id(inv.inviter_id)
-                    inviter_name = (
-                        f"{inviter_user.first_name} {inviter_user.last_name}"
-                        if inviter_user
-                        else "Unknown"
-                    )
-
-                    # Resolver invitee_name
-                    invitee_name = None
-                    if inv.invitee_user_id:
-                        invitee_user = await self._user_uow.users.find_by_id(
-                            inv.invitee_user_id
-                        )
-                        if invitee_user:
-                            invitee_name = (
-                                f"{invitee_user.first_name} {invitee_user.last_name}"
-                            )
-
-                dto = InvitationResponseDTO(
-                    id=inv.id.value,
-                    competition_id=inv.competition_id.value,
-                    competition_name=competition_name,
-                    inviter_id=inv.inviter_id.value,
-                    inviter_name=inviter_name,
-                    invitee_email=inv.invitee_email,
-                    invitee_user_id=(
-                        inv.invitee_user_id.value if inv.invitee_user_id else None
-                    ),
-                    invitee_name=invitee_name,
-                    status=inv.status.value,
-                    personal_message=inv.personal_message,
-                    expires_at=inv.expires_at,
-                    responded_at=inv.responded_at,
-                    created_at=inv.created_at,
-                    updated_at=inv.updated_at,
+                inviter_user = await self._user_uow.users.find_by_id(inv.inviter_id)
+                inviter_name = (
+                    f"{inviter_user.first_name} {inviter_user.last_name}"
+                    if inviter_user
+                    else "Unknown"
                 )
-                invitation_dtos.append(dto)
+
+                invitee_name = None
+                if inv.invitee_user_id:
+                    invitee_user = await self._user_uow.users.find_by_id(
+                        inv.invitee_user_id
+                    )
+                    if invitee_user:
+                        invitee_name = (
+                            f"{invitee_user.first_name} {invitee_user.last_name}"
+                        )
+
+                invitation_dtos.append(
+                    InvitationResponseDTO(
+                        id=inv.id.value,
+                        competition_id=inv.competition_id.value,
+                        competition_name=competition_name,
+                        inviter_id=inv.inviter_id.value,
+                        inviter_name=inviter_name,
+                        invitee_email=inv.invitee_email,
+                        invitee_user_id=(
+                            inv.invitee_user_id.value if inv.invitee_user_id else None
+                        ),
+                        invitee_name=invitee_name,
+                        status=inv.status.value,
+                        personal_message=inv.personal_message,
+                        expires_at=inv.expires_at,
+                        responded_at=inv.responded_at,
+                        created_at=inv.created_at,
+                        updated_at=inv.updated_at,
+                    )
+                )
 
         return PaginatedInvitationResponseDTO(
             invitations=invitation_dtos,

--- a/src/modules/competition/application/use_cases/list_competition_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_competition_invitations_use_case.py
@@ -1,0 +1,131 @@
+"""Caso de Uso: Listar Invitaciones de una Competicion (para el creator)."""
+
+from src.modules.competition.application.dto.invitation_dto import (
+    InvitationResponseDTO,
+    PaginatedInvitationResponseDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_status import InvitationStatus
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class ListCompetitionInvitationsUseCase:
+    """Lista las invitaciones de una competicion (vista del creator)."""
+
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self,
+        competition_id: str,
+        current_user_id: str,
+        is_admin: bool = False,
+        status_filter: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedInvitationResponseDTO:
+        competition_id_vo = CompetitionId(competition_id)
+        creator_id = UserId(current_user_id)
+        offset = (page - 1) * limit
+
+        # Parsear status filter
+        status_vo = InvitationStatus(status_filter) if status_filter else None
+
+        async with self._uow:
+            # 1. Buscar competition
+            competition = await self._uow.competitions.find_by_id(competition_id_vo)
+            if not competition:
+                raise CompetitionNotFoundError(
+                    f"Competition not found: {competition_id}"
+                )
+
+            # 2. Verificar creator/admin
+            if not is_admin and not competition.is_creator(creator_id):
+                raise NotCompetitionCreatorError(
+                    "Only the competition creator or an administrator can view invitations."
+                )
+
+            # 3. Obtener invitaciones con filtro
+            invitations = await self._uow.invitations.find_by_competition(
+                competition_id_vo, status=status_vo, limit=limit, offset=offset
+            )
+
+            # 4. Check expiration on-read para PENDING
+            for inv in invitations:
+                inv.check_expiration()
+
+            # Filtrar de nuevo si el status cambio por expiracion
+            if status_vo:
+                invitations = [inv for inv in invitations if inv.status == status_vo]
+
+            # 5. Total count
+            total_count = await self._uow.invitations.count_by_competition(
+                competition_id_vo, status=status_vo
+            )
+
+            # 6. Enriquecer con nombres
+            competition_name = str(competition.name)
+            invitation_dtos = []
+
+            for inv in invitations:
+                # Resolver inviter_name
+                async with self._user_uow:
+                    inviter_user = await self._user_uow.users.find_by_id(inv.inviter_id)
+                    inviter_name = (
+                        f"{inviter_user.first_name} {inviter_user.last_name}"
+                        if inviter_user
+                        else "Unknown"
+                    )
+
+                    # Resolver invitee_name
+                    invitee_name = None
+                    if inv.invitee_user_id:
+                        invitee_user = await self._user_uow.users.find_by_id(
+                            inv.invitee_user_id
+                        )
+                        if invitee_user:
+                            invitee_name = (
+                                f"{invitee_user.first_name} {invitee_user.last_name}"
+                            )
+
+                dto = InvitationResponseDTO(
+                    id=inv.id.value,
+                    competition_id=inv.competition_id.value,
+                    competition_name=competition_name,
+                    inviter_id=inv.inviter_id.value,
+                    inviter_name=inviter_name,
+                    invitee_email=inv.invitee_email,
+                    invitee_user_id=(
+                        inv.invitee_user_id.value if inv.invitee_user_id else None
+                    ),
+                    invitee_name=invitee_name,
+                    status=inv.status.value,
+                    personal_message=inv.personal_message,
+                    expires_at=inv.expires_at,
+                    responded_at=inv.responded_at,
+                    created_at=inv.created_at,
+                    updated_at=inv.updated_at,
+                )
+                invitation_dtos.append(dto)
+
+        return PaginatedInvitationResponseDTO(
+            invitations=invitation_dtos,
+            total_count=total_count,
+            page=page,
+            limit=limit,
+        )

--- a/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
@@ -13,6 +13,8 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
+_DEDUP_OVERFETCH_BUFFER = 50
+
 
 class ListMyInvitationsUseCase:
     """Lista las invitaciones recibidas por el usuario actual."""
@@ -53,12 +55,12 @@ class ListMyInvitationsUseCase:
             invitations_by_email = []
             if user_email:
                 invitations_by_email = await self._uow.invitations.find_by_invitee_email(
-                    user_email, status=status_vo, limit=limit + offset + 50, offset=0
+                    user_email, status=status_vo, limit=limit + offset + _DEDUP_OVERFETCH_BUFFER, offset=0
                 )
 
             # Buscar por user_id (cubre invitaciones donde el user_id fue resuelto)
             invitations_by_user_id = await self._uow.invitations.find_by_invitee_user_id(
-                user_id_vo, status=status_vo, limit=limit + offset + 50, offset=0
+                user_id_vo, status=status_vo, limit=limit + offset + _DEDUP_OVERFETCH_BUFFER, offset=0
             )
 
             # Merge y deduplicar por ID

--- a/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
@@ -1,0 +1,132 @@
+"""Caso de Uso: Listar Mis Invitaciones (como invitado)."""
+
+from src.modules.competition.application.dto.invitation_dto import (
+    InvitationResponseDTO,
+    PaginatedInvitationResponseDTO,
+)
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.value_objects.invitation_status import InvitationStatus
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class ListMyInvitationsUseCase:
+    """Lista las invitaciones recibidas por el usuario actual."""
+
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self,
+        user_id: str,
+        status_filter: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedInvitationResponseDTO:
+        user_id_vo = UserId(user_id)
+        offset = (page - 1) * limit
+
+        # Parsear status filter
+        status_vo = InvitationStatus(status_filter) if status_filter else None
+
+        # Obtener email del usuario
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id_vo)
+            user_email = str(user.email) if user else None
+
+        async with self._uow:
+            # Buscar por email (cubre invitaciones pre-registro)
+            invitations_by_email = []
+            if user_email:
+                invitations_by_email = await self._uow.invitations.find_by_invitee_email(
+                    user_email, status=status_vo, limit=limit + offset + 50, offset=0
+                )
+
+            # Buscar por user_id (cubre invitaciones donde el user_id fue resuelto)
+            invitations_by_user_id = await self._uow.invitations.find_by_invitee_user_id(
+                user_id_vo, status=status_vo, limit=limit + offset + 50, offset=0
+            )
+
+            # Merge y deduplicar por ID
+            seen_ids = set()
+            all_invitations = []
+            for inv in invitations_by_email + invitations_by_user_id:
+                if inv.id not in seen_ids:
+                    seen_ids.add(inv.id)
+                    # Check expiration on-read
+                    inv.check_expiration()
+                    # Si filtramos por status, verificar despues de expiracion
+                    if status_vo and inv.status != status_vo:
+                        continue
+                    all_invitations.append(inv)
+
+            # Total count (despues de filtro)
+            total_count = len(all_invitations)
+
+            # Paginar
+            paginated = all_invitations[offset : offset + limit]
+
+            # Enriquecer con nombres
+            invitation_dtos = []
+            for inv in paginated:
+                dto = await self._enrich_invitation(inv)
+                invitation_dtos.append(dto)
+
+        return PaginatedInvitationResponseDTO(
+            invitations=invitation_dtos,
+            total_count=total_count,
+            page=page,
+            limit=limit,
+        )
+
+    async def _enrich_invitation(self, invitation) -> InvitationResponseDTO:
+        """Enriquece una invitation con nombres resueltos."""
+        # Resolver competition_name
+        competition = await self._uow.competitions.find_by_id(invitation.competition_id)
+        competition_name = str(competition.name) if competition else "Unknown"
+
+        # Resolver inviter_name
+        async with self._user_uow:
+            inviter_user = await self._user_uow.users.find_by_id(invitation.inviter_id)
+            inviter_name = (
+                f"{inviter_user.first_name} {inviter_user.last_name}"
+                if inviter_user
+                else "Unknown"
+            )
+
+            # Resolver invitee_name
+            invitee_name = None
+            if invitation.invitee_user_id:
+                invitee_user = await self._user_uow.users.find_by_id(
+                    invitation.invitee_user_id
+                )
+                if invitee_user:
+                    invitee_name = f"{invitee_user.first_name} {invitee_user.last_name}"
+
+        return InvitationResponseDTO(
+            id=invitation.id.value,
+            competition_id=invitation.competition_id.value,
+            competition_name=competition_name,
+            inviter_id=invitation.inviter_id.value,
+            inviter_name=inviter_name,
+            invitee_email=invitation.invitee_email,
+            invitee_user_id=(
+                invitation.invitee_user_id.value if invitation.invitee_user_id else None
+            ),
+            invitee_name=invitee_name,
+            status=invitation.status.value,
+            personal_message=invitation.personal_message,
+            expires_at=invitation.expires_at,
+            responded_at=invitation.responded_at,
+            created_at=invitation.created_at,
+            updated_at=invitation.updated_at,
+        )

--- a/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
@@ -43,6 +43,11 @@ class ListMyInvitationsUseCase:
             user = await self._user_uow.users.find_by_id(user_id_vo)
             user_email = str(user.email) if user else None
 
+        # Datos intermedios para enrichment
+        paginated = []
+        competition_names: dict[str, str] = {}
+        total_count = 0
+
         async with self._uow:
             # Buscar por email (cubre invitaciones pre-registro)
             invitations_by_email = []
@@ -75,58 +80,66 @@ class ListMyInvitationsUseCase:
             # Paginar
             paginated = all_invitations[offset : offset + limit]
 
-            # Enriquecer con nombres
-            invitation_dtos = []
+            # Resolver competition_names dentro del comp UoW
             for inv in paginated:
-                dto = await self._enrich_invitation(inv)
-                invitation_dtos.append(dto)
+                comp_id_str = str(inv.competition_id.value)
+                if comp_id_str not in competition_names:
+                    competition = await self._uow.competitions.find_by_id(
+                        inv.competition_id
+                    )
+                    competition_names[comp_id_str] = (
+                        str(competition.name) if competition else "Unknown"
+                    )
+
+        # Resolver nombres de usuarios en una sola sesion
+        invitation_dtos = []
+        async with self._user_uow:
+            for inv in paginated:
+                inviter_user = await self._user_uow.users.find_by_id(inv.inviter_id)
+                inviter_name = (
+                    f"{inviter_user.first_name} {inviter_user.last_name}"
+                    if inviter_user
+                    else "Unknown"
+                )
+
+                invitee_name = None
+                if inv.invitee_user_id:
+                    invitee_user = await self._user_uow.users.find_by_id(
+                        inv.invitee_user_id
+                    )
+                    if invitee_user:
+                        invitee_name = (
+                            f"{invitee_user.first_name} {invitee_user.last_name}"
+                        )
+
+                invitation_dtos.append(
+                    InvitationResponseDTO(
+                        id=inv.id.value,
+                        competition_id=inv.competition_id.value,
+                        competition_name=competition_names.get(
+                            str(inv.competition_id.value), "Unknown"
+                        ),
+                        inviter_id=inv.inviter_id.value,
+                        inviter_name=inviter_name,
+                        invitee_email=inv.invitee_email,
+                        invitee_user_id=(
+                            inv.invitee_user_id.value
+                            if inv.invitee_user_id
+                            else None
+                        ),
+                        invitee_name=invitee_name,
+                        status=inv.status.value,
+                        personal_message=inv.personal_message,
+                        expires_at=inv.expires_at,
+                        responded_at=inv.responded_at,
+                        created_at=inv.created_at,
+                        updated_at=inv.updated_at,
+                    )
+                )
 
         return PaginatedInvitationResponseDTO(
             invitations=invitation_dtos,
             total_count=total_count,
             page=page,
             limit=limit,
-        )
-
-    async def _enrich_invitation(self, invitation) -> InvitationResponseDTO:
-        """Enriquece una invitation con nombres resueltos."""
-        # Resolver competition_name
-        competition = await self._uow.competitions.find_by_id(invitation.competition_id)
-        competition_name = str(competition.name) if competition else "Unknown"
-
-        # Resolver inviter_name
-        async with self._user_uow:
-            inviter_user = await self._user_uow.users.find_by_id(invitation.inviter_id)
-            inviter_name = (
-                f"{inviter_user.first_name} {inviter_user.last_name}"
-                if inviter_user
-                else "Unknown"
-            )
-
-            # Resolver invitee_name
-            invitee_name = None
-            if invitation.invitee_user_id:
-                invitee_user = await self._user_uow.users.find_by_id(
-                    invitation.invitee_user_id
-                )
-                if invitee_user:
-                    invitee_name = f"{invitee_user.first_name} {invitee_user.last_name}"
-
-        return InvitationResponseDTO(
-            id=invitation.id.value,
-            competition_id=invitation.competition_id.value,
-            competition_name=competition_name,
-            inviter_id=invitation.inviter_id.value,
-            inviter_name=inviter_name,
-            invitee_email=invitation.invitee_email,
-            invitee_user_id=(
-                invitation.invitee_user_id.value if invitation.invitee_user_id else None
-            ),
-            invitee_name=invitee_name,
-            status=invitation.status.value,
-            personal_message=invitation.personal_message,
-            expires_at=invitation.expires_at,
-            responded_at=invitation.responded_at,
-            created_at=invitation.created_at,
-            updated_at=invitation.updated_at,
         )

--- a/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
@@ -76,11 +76,15 @@ class ListMyInvitationsUseCase:
                         continue
                     all_invitations.append(inv)
 
-            # Total count (despues de filtro)
-            total_count = len(all_invitations)
-
-            # Paginar
+            # Paginar desde la lista deduplicada
             paginated = all_invitations[offset : offset + limit]
+
+            # Total count via DB (OR semantics: email OR user_id)
+            total_count = await self._uow.invitations.count_by_invitee(
+                email=user_email,
+                user_id=user_id_vo,
+                status=status_vo,
+            )
 
             # Resolver competition_names dentro del comp UoW
             for inv in paginated:

--- a/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
+++ b/src/modules/competition/application/use_cases/list_my_invitations_use_case.py
@@ -76,15 +76,11 @@ class ListMyInvitationsUseCase:
                         continue
                     all_invitations.append(inv)
 
+            # Total count from in-memory deduped+filtered list (consistent with expiration)
+            total_count = len(all_invitations)
+
             # Paginar desde la lista deduplicada
             paginated = all_invitations[offset : offset + limit]
-
-            # Total count via DB (OR semantics: email OR user_id)
-            total_count = await self._uow.invitations.count_by_invitee(
-                email=user_email,
-                user_id=user_id_vo,
-                status=status_vo,
-            )
 
             # Resolver competition_names dentro del comp UoW
             for inv in paginated:

--- a/src/modules/competition/application/use_cases/respond_to_invitation_use_case.py
+++ b/src/modules/competition/application/use_cases/respond_to_invitation_use_case.py
@@ -1,0 +1,185 @@
+"""Caso de Uso: Responder a una Invitacion (ACCEPT/DECLINE)."""
+
+from src.modules.competition.application.dto.invitation_dto import (
+    RespondInvitationRequestDTO,
+    RespondInvitationResponseDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    InvitationNotFoundError,
+    NotInviteeError,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.events.invitation_accepted_event import (
+    InvitationAcceptedEvent,
+)
+from src.modules.competition.domain.exceptions.competition_violations import (
+    InvalidInvitationStatusViolation,
+)
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.services.competition_policy import CompetitionPolicy
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class RespondToInvitationUseCase:
+    """Permite al invitado aceptar o rechazar una invitacion."""
+
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self, request: RespondInvitationRequestDTO
+    ) -> RespondInvitationResponseDTO:
+        invitation_id = InvitationId(request.invitation_id)
+        current_user_id = UserId(request.user_id)
+        action = request.action.upper()
+
+        if action not in ("ACCEPT", "DECLINE"):
+            raise ValueError(f"Invalid action: {action}. Must be ACCEPT or DECLINE.")
+
+        # Obtener email del usuario actual
+        async with self._user_uow:
+            current_user = await self._user_uow.users.find_by_id(current_user_id)
+            current_user_email = str(current_user.email) if current_user else None
+
+        enrollment_id = None
+
+        async with self._uow:
+            # 1. Buscar y validar invitation
+            invitation = await self._uow.invitations.find_by_id(invitation_id)
+            if not invitation:
+                raise InvitationNotFoundError(
+                    f"Invitation not found: {request.invitation_id}"
+                )
+
+            invitation.check_expiration()
+
+            if not invitation.is_pending():
+                raise InvalidInvitationStatusViolation(
+                    f"Invitation is in status {invitation.status.value}. "
+                    "Only PENDING invitations can be responded to."
+                )
+
+            # 2. Verificar current_user es invitee
+            is_invitee = invitation.is_for_user(current_user_id) or (
+                current_user_email and invitation.is_for_email(current_user_email)
+            )
+            if not is_invitee:
+                raise NotInviteeError("You are not the invitee of this invitation.")
+
+            # 3. Ejecutar accion
+            if action == "ACCEPT":
+                enrollment_id = await self._handle_accept(invitation, current_user_id)
+            else:
+                await self._handle_decline(invitation)
+
+        # 4. Construir respuesta enriquecida
+        return await self._build_response(invitation, enrollment_id)
+
+    async def _handle_accept(self, invitation, current_user_id: UserId):
+        """Procesa la aceptacion de una invitacion."""
+        competition = await self._uow.competitions.find_by_id(invitation.competition_id)
+        if not competition:
+            raise CompetitionNotFoundError(
+                f"Competition not found: {invitation.competition_id}"
+            )
+
+        CompetitionPolicy.can_accept_invitation(competition.status)
+
+        existing_enrollment = await self._uow.enrollments.find_by_user_and_competition(
+            current_user_id, invitation.competition_id
+        )
+        if existing_enrollment and existing_enrollment.is_approved():
+            raise InvalidInvitationStatusViolation(
+                "User is already enrolled in this competition."
+            )
+
+        approved_count = await self._uow.enrollments.count_approved_by_competition(
+            invitation.competition_id
+        )
+        CompetitionPolicy.validate_capacity(
+            approved_count, competition.max_players, invitation.competition_id
+        )
+
+        invitation.accept()
+
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(invitation.competition_id.value),
+            user_id=current_user_id,
+        )
+
+        event = InvitationAcceptedEvent(
+            invitation_id=str(invitation.id),
+            competition_id=str(invitation.competition_id),
+            invitee_user_id=str(current_user_id),
+            enrollment_id=str(enrollment.id.value),
+        )
+        invitation._add_domain_event(event)
+
+        await self._uow.enrollments.add(enrollment)
+        await self._uow.invitations.update(invitation)
+
+        return enrollment.id.value
+
+    async def _handle_decline(self, invitation):
+        """Procesa el rechazo de una invitacion."""
+        invitation.decline()
+        await self._uow.invitations.update(invitation)
+
+    async def _build_response(self, invitation, enrollment_id) -> RespondInvitationResponseDTO:
+        """Construye el DTO de respuesta enriquecido con nombres."""
+        async with self._user_uow:
+            inviter_user = await self._user_uow.users.find_by_id(invitation.inviter_id)
+            inviter_name = (
+                f"{inviter_user.first_name} {inviter_user.last_name}"
+                if inviter_user
+                else "Unknown"
+            )
+
+            invitee_name = None
+            if invitation.invitee_user_id:
+                invitee_user = await self._user_uow.users.find_by_id(
+                    invitation.invitee_user_id
+                )
+                if invitee_user:
+                    invitee_name = f"{invitee_user.first_name} {invitee_user.last_name}"
+
+        async with self._uow:
+            competition = await self._uow.competitions.find_by_id(
+                invitation.competition_id
+            )
+            competition_name = str(competition.name) if competition else "Unknown"
+
+        return RespondInvitationResponseDTO(
+            id=invitation.id.value,
+            competition_id=invitation.competition_id.value,
+            competition_name=competition_name,
+            inviter_id=invitation.inviter_id.value,
+            inviter_name=inviter_name,
+            invitee_email=invitation.invitee_email,
+            invitee_user_id=(
+                invitation.invitee_user_id.value if invitation.invitee_user_id else None
+            ),
+            invitee_name=invitee_name,
+            status=invitation.status.value,
+            personal_message=invitation.personal_message,
+            expires_at=invitation.expires_at,
+            responded_at=invitation.responded_at,
+            created_at=invitation.created_at,
+            updated_at=invitation.updated_at,
+            enrollment_id=enrollment_id,
+        )

--- a/src/modules/competition/application/use_cases/respond_to_invitation_use_case.py
+++ b/src/modules/competition/application/use_cases/respond_to_invitation_use_case.py
@@ -128,7 +128,7 @@ class RespondToInvitationUseCase:
             invitee_user_id=str(current_user_id),
             enrollment_id=str(enrollment.id.value),
         )
-        invitation._add_domain_event(event)
+        invitation.add_domain_event(event)
 
         await self._uow.enrollments.add(enrollment)
         await self._uow.invitations.update(invitation)

--- a/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
@@ -1,0 +1,165 @@
+"""Caso de Uso: Enviar Invitacion por Email."""
+
+from datetime import datetime, timedelta
+
+from src.modules.competition.application.dto.invitation_dto import (
+    InvitationResponseDTO,
+    SendInvitationByEmailRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.exceptions.competition_violations import (
+    AlreadyEnrolledInvitationViolation,
+    DuplicateInvitationViolation,
+    InvitationCompetitionStatusViolation,
+    InvitationRateLimitViolation,
+    SelfInvitationViolation,
+)
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.services.competition_policy import CompetitionPolicy
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.email import Email
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SendInvitationByEmailUseCase:
+    """Envia una invitacion a un email (usuario registrado o no)."""
+
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self, request: SendInvitationByEmailRequestDTO
+    ) -> InvitationResponseDTO:
+        async with self._uow:
+            competition_id = CompetitionId(request.competition_id)
+            inviter_id = UserId(request.inviter_id)
+
+            # 1. Buscar competition
+            competition = await self._uow.competitions.find_by_id(competition_id)
+            if not competition:
+                raise CompetitionNotFoundError(
+                    f"Competition not found: {request.competition_id}"
+                )
+
+            # 2. Verificar creator/admin
+            if not competition.is_creator(inviter_id):
+                raise NotCompetitionCreatorError(
+                    "Only the competition creator can send invitations."
+                )
+
+            # 3. Validar estado de competicion
+            try:
+                CompetitionPolicy.can_send_invitation(competition.status)
+            except InvitationCompetitionStatusViolation:
+                raise
+
+            # 3b. Validar rate limit (max_players invitaciones por hora)
+            one_hour_ago = datetime.now() - timedelta(hours=1)
+            recent_invitations = await self._uow.invitations.count_by_competition(
+                competition_id, since=one_hour_ago
+            )
+            try:
+                CompetitionPolicy.validate_invitation_rate(
+                    recent_invitations, competition.max_players, competition_id
+                )
+            except InvitationRateLimitViolation:
+                raise
+
+            # 4. Buscar user por email (puede no existir)
+            invitee_user_id = None
+            invitee_name = None
+            async with self._user_uow:
+                try:
+                    email_vo = Email(request.invitee_email)
+                    invitee_user = await self._user_uow.users.find_by_email(email_vo)
+                except (ValueError, Exception):
+                    invitee_user = None
+
+                if invitee_user:
+                    invitee_user_id = invitee_user.id
+                    invitee_name = f"{invitee_user.first_name} {invitee_user.last_name}"
+
+                    # 5a. No self-invitation
+                    if inviter_id == invitee_user_id:
+                        raise SelfInvitationViolation(
+                            "Cannot invite yourself to a competition."
+                        )
+
+                    # 5b. Verificar no enrollment activo
+                    async with self._uow:
+                        existing_enrollment = (
+                            await self._uow.enrollments.find_by_user_and_competition(
+                                invitee_user_id, competition_id
+                            )
+                        )
+                        if existing_enrollment and existing_enrollment.is_approved():
+                            raise AlreadyEnrolledInvitationViolation(
+                                f"User with email {request.invitee_email} is already "
+                                f"enrolled in competition {request.competition_id}."
+                            )
+
+            # 6. Verificar no invitation PENDING duplicada
+            existing_invitation = (
+                await self._uow.invitations.find_pending_by_email_and_competition(
+                    request.invitee_email.strip().lower(), competition_id
+                )
+            )
+            if existing_invitation:
+                raise DuplicateInvitationViolation(
+                    f"A pending invitation already exists for {request.invitee_email} "
+                    f"in competition {request.competition_id}."
+                )
+
+            # 7. Crear invitation
+            invitation = Invitation.create(
+                id=InvitationId.generate(),
+                competition_id=competition_id,
+                inviter_id=inviter_id,
+                invitee_email=request.invitee_email,
+                invitee_user_id=invitee_user_id,
+                personal_message=request.personal_message,
+            )
+
+            # 8. Persistir
+            await self._uow.invitations.add(invitation)
+
+        # 9. Retornar DTO enriquecido
+        async with self._user_uow:
+            inviter_user = await self._user_uow.users.find_by_id(inviter_id)
+            inviter_name = (
+                f"{inviter_user.first_name} {inviter_user.last_name}"
+                if inviter_user
+                else "Unknown"
+            )
+
+        return InvitationResponseDTO(
+            id=invitation.id.value,
+            competition_id=invitation.competition_id.value,
+            competition_name=str(competition.name),
+            inviter_id=invitation.inviter_id.value,
+            inviter_name=inviter_name,
+            invitee_email=invitation.invitee_email,
+            invitee_user_id=invitee_user_id.value if invitee_user_id else None,
+            invitee_name=invitee_name,
+            status=invitation.status.value,
+            personal_message=invitation.personal_message,
+            expires_at=invitation.expires_at,
+            responded_at=invitation.responded_at,
+            created_at=invitation.created_at,
+            updated_at=invitation.updated_at,
+        )

--- a/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
@@ -35,6 +35,16 @@ from src.modules.user.domain.value_objects.user_id import UserId
 logger = logging.getLogger(__name__)
 
 
+def _mask_email(email: str) -> str:
+    """Enmascara un email para logging seguro (ej: t***@example.com)."""
+    parts = email.split("@")
+    if len(parts) != 2 or not parts[0]:
+        return "***"
+    local = parts[0]
+    masked_local = local[0] + "***" if len(local) > 1 else "***"
+    return f"{masked_local}@{parts[1]}"
+
+
 class SendInvitationByEmailUseCase:
     """Envia una invitacion a un email (usuario registrado o no)."""
 
@@ -161,7 +171,7 @@ class SendInvitationByEmailUseCase:
             except Exception as e:
                 logger.warning(
                     "Failed to send invitation email to %s: %s",
-                    invitation.invitee_email,
+                    _mask_email(invitation.invitee_email),
                     str(e),
                 )
 

--- a/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
@@ -1,0 +1,158 @@
+"""Caso de Uso: Enviar Invitacion por User ID."""
+
+from datetime import datetime, timedelta
+
+from src.modules.competition.application.dto.invitation_dto import (
+    InvitationResponseDTO,
+    SendInvitationByUserIdRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    InviteeNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.exceptions.competition_violations import (
+    AlreadyEnrolledInvitationViolation,
+    DuplicateInvitationViolation,
+    InvitationCompetitionStatusViolation,
+    InvitationRateLimitViolation,
+    SelfInvitationViolation,
+)
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.services.competition_policy import CompetitionPolicy
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SendInvitationByUserIdUseCase:
+    """Envia una invitacion a un usuario registrado por su user_id."""
+
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self, request: SendInvitationByUserIdRequestDTO
+    ) -> InvitationResponseDTO:
+        async with self._uow:
+            competition_id = CompetitionId(request.competition_id)
+            inviter_id = UserId(request.inviter_id)
+            invitee_user_id = UserId(request.invitee_user_id)
+
+            # 1. Buscar competition
+            competition = await self._uow.competitions.find_by_id(competition_id)
+            if not competition:
+                raise CompetitionNotFoundError(
+                    f"Competition not found: {request.competition_id}"
+                )
+
+            # 2. Verificar creator/admin
+            if not competition.is_creator(inviter_id):
+                raise NotCompetitionCreatorError(
+                    "Only the competition creator can send invitations."
+                )
+
+            # 3. Validar estado de competicion
+            try:
+                CompetitionPolicy.can_send_invitation(competition.status)
+            except InvitationCompetitionStatusViolation:
+                raise
+
+            # 3b. Validar rate limit (max_players invitaciones por hora)
+            one_hour_ago = datetime.now() - timedelta(hours=1)
+            recent_invitations = await self._uow.invitations.count_by_competition(
+                competition_id, since=one_hour_ago
+            )
+            try:
+                CompetitionPolicy.validate_invitation_rate(
+                    recent_invitations, competition.max_players, competition_id
+                )
+            except InvitationRateLimitViolation:
+                raise
+
+            # 4. Buscar invitee user
+            async with self._user_uow:
+                invitee_user = await self._user_uow.users.find_by_id(invitee_user_id)
+                if not invitee_user:
+                    raise InviteeNotFoundError(
+                        f"User not found: {request.invitee_user_id}"
+                    )
+                invitee_email = str(invitee_user.email)
+                invitee_name = f"{invitee_user.first_name} {invitee_user.last_name}"
+
+            # 5. No self-invitation
+            if inviter_id == invitee_user_id:
+                raise SelfInvitationViolation("Cannot invite yourself to a competition.")
+
+            # 6. Verificar no enrollment activo
+            existing_enrollment = await self._uow.enrollments.find_by_user_and_competition(
+                invitee_user_id, competition_id
+            )
+            if existing_enrollment and existing_enrollment.is_approved():
+                raise AlreadyEnrolledInvitationViolation(
+                    f"User {request.invitee_user_id} is already enrolled in competition "
+                    f"{request.competition_id}."
+                )
+
+            # 7. Verificar no invitation PENDING duplicada
+            existing_invitation = (
+                await self._uow.invitations.find_pending_by_email_and_competition(
+                    invitee_email, competition_id
+                )
+            )
+            if existing_invitation:
+                raise DuplicateInvitationViolation(
+                    f"A pending invitation already exists for {invitee_email} "
+                    f"in competition {request.competition_id}."
+                )
+
+            # 8. Crear invitation
+            invitation = Invitation.create(
+                id=InvitationId.generate(),
+                competition_id=competition_id,
+                inviter_id=inviter_id,
+                invitee_email=invitee_email,
+                invitee_user_id=invitee_user_id,
+                personal_message=request.personal_message,
+            )
+
+            # 9. Persistir
+            await self._uow.invitations.add(invitation)
+
+        # 10. Retornar DTO enriquecido
+        # Obtener inviter_name
+        async with self._user_uow:
+            inviter_user = await self._user_uow.users.find_by_id(inviter_id)
+            inviter_name = (
+                f"{inviter_user.first_name} {inviter_user.last_name}"
+                if inviter_user
+                else "Unknown"
+            )
+
+        return InvitationResponseDTO(
+            id=invitation.id.value,
+            competition_id=invitation.competition_id.value,
+            competition_name=str(competition.name),
+            inviter_id=invitation.inviter_id.value,
+            inviter_name=inviter_name,
+            invitee_email=invitation.invitee_email,
+            invitee_user_id=invitation.invitee_user_id.value if invitation.invitee_user_id else None,
+            invitee_name=invitee_name,
+            status=invitation.status.value,
+            personal_message=invitation.personal_message,
+            expires_at=invitation.expires_at,
+            responded_at=invitation.responded_at,
+            created_at=invitation.created_at,
+            updated_at=invitation.updated_at,
+        )

--- a/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
@@ -35,6 +35,16 @@ from src.modules.user.domain.value_objects.user_id import UserId
 logger = logging.getLogger(__name__)
 
 
+def _mask_email(email: str) -> str:
+    """Enmascara un email para logging seguro (ej: t***@example.com)."""
+    parts = email.split("@")
+    if len(parts) != 2 or not parts[0]:
+        return "***"
+    local = parts[0]
+    masked_local = local[0] + "***" if len(local) > 1 else "***"
+    return f"{masked_local}@{parts[1]}"
+
+
 class SendInvitationByUserIdUseCase:
     """Envia una invitacion a un usuario registrado por su user_id."""
 
@@ -153,7 +163,9 @@ class SendInvitationByUserIdUseCase:
                 )
             except Exception as e:
                 logger.warning(
-                    "Failed to send invitation email to %s: %s", invitee_email, str(e)
+                    "Failed to send invitation email to %s: %s",
+                    _mask_email(invitee_email),
+                    str(e),
                 )
 
         return InvitationResponseDTO(

--- a/src/modules/competition/domain/entities/invitation.py
+++ b/src/modules/competition/domain/entities/invitation.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.events.domain_event import DomainEvent
 
+from ..events.invitation_accepted_event import InvitationAcceptedEvent
 from ..events.invitation_created_event import InvitationCreatedEvent
 from ..events.invitation_declined_event import InvitationDeclinedEvent
 from ..exceptions.competition_violations import (
@@ -228,6 +229,13 @@ class Invitation:
         self._status = InvitationStatus.ACCEPTED
         self._responded_at = datetime.now()
         self._updated_at = datetime.now()
+
+        event = InvitationAcceptedEvent(
+            invitation_id=str(self._id),
+            competition_id=str(self._competition_id),
+            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id else "",
+        )
+        self.add_domain_event(event)
 
     def decline(self) -> None:
         """Rechaza la invitacion (PENDING -> DECLINED)."""

--- a/src/modules/competition/domain/entities/invitation.py
+++ b/src/modules/competition/domain/entities/invitation.py
@@ -1,0 +1,297 @@
+"""
+Invitation Entity - Representa una invitacion a participar en una competicion.
+
+Esta entidad gestiona el ciclo de vida de invitaciones enviadas por el creador.
+"""
+
+from datetime import datetime, timedelta
+
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.events.domain_event import DomainEvent
+
+from ..events.invitation_created_event import InvitationCreatedEvent
+from ..events.invitation_declined_event import InvitationDeclinedEvent
+from ..exceptions.competition_violations import (
+    InvalidInvitationStatusViolation,
+    InvitationExpiredViolation,
+)
+from ..value_objects.competition_id import CompetitionId
+from ..value_objects.invitation_id import InvitationId
+from ..value_objects.invitation_status import InvitationStatus
+
+INVITATION_EXPIRATION_DAYS = 7
+MAX_PERSONAL_MESSAGE_LENGTH = 500
+
+
+class Invitation:
+    """
+    Entidad Invitation - Representa una invitacion a una competicion.
+
+    Gestiona:
+    - Envio de invitaciones por email o user_id
+    - Respuesta (aceptar/rechazar)
+    - Expiracion automatica (7 dias)
+
+    Invariantes:
+    - competition_id e inviter_id no pueden ser None
+    - invitee_email no puede ser None ni vacio
+    - expires_at debe ser futuro respecto a created_at
+    - Solo PENDING permite transiciones
+    """
+
+    def __init__(
+        self,
+        id: InvitationId,
+        competition_id: CompetitionId,
+        inviter_id: UserId,
+        invitee_email: str,
+        status: InvitationStatus,
+        expires_at: datetime,
+        invitee_user_id: UserId | None = None,
+        personal_message: str | None = None,
+        responded_at: datetime | None = None,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+        domain_events: list[DomainEvent] | None = None,
+    ):
+        if not invitee_email or not invitee_email.strip():
+            raise ValueError("invitee_email no puede estar vacio")
+
+        if personal_message and len(personal_message) > MAX_PERSONAL_MESSAGE_LENGTH:
+            raise ValueError("personal_message no puede exceder 500 caracteres")
+
+        self._id = id
+        self._competition_id = competition_id
+        self._inviter_id = inviter_id
+        self._invitee_email = invitee_email.strip().lower()
+        self._invitee_user_id = invitee_user_id
+        self._status = status
+        self._personal_message = personal_message
+        self._expires_at = expires_at
+        self._responded_at = responded_at
+        self._created_at = created_at or datetime.now()
+        self._updated_at = updated_at or datetime.now()
+        self._domain_events: list[DomainEvent] = domain_events or []
+
+    # ===========================================
+    # FACTORY METHODS
+    # ===========================================
+
+    @classmethod
+    def create(
+        cls,
+        id: InvitationId,
+        competition_id: CompetitionId,
+        inviter_id: UserId,
+        invitee_email: str,
+        invitee_user_id: UserId | None = None,
+        personal_message: str | None = None,
+    ) -> "Invitation":
+        """Factory method para crear una nueva invitacion con status PENDING."""
+        now = datetime.now()
+        invitation = cls(
+            id=id,
+            competition_id=competition_id,
+            inviter_id=inviter_id,
+            invitee_email=invitee_email,
+            invitee_user_id=invitee_user_id,
+            status=InvitationStatus.PENDING,
+            personal_message=personal_message,
+            expires_at=now + timedelta(days=INVITATION_EXPIRATION_DAYS),
+            created_at=now,
+            updated_at=now,
+        )
+
+        event = InvitationCreatedEvent(
+            invitation_id=str(invitation._id),
+            competition_id=str(invitation._competition_id),
+            inviter_id=str(invitation._inviter_id),
+            invitee_email=invitation._invitee_email,
+        )
+        invitation._add_domain_event(event)
+
+        return invitation
+
+    @classmethod
+    def reconstruct(
+        cls,
+        id: InvitationId,
+        competition_id: CompetitionId,
+        inviter_id: UserId,
+        invitee_email: str,
+        status: InvitationStatus,
+        expires_at: datetime,
+        invitee_user_id: UserId | None = None,
+        personal_message: str | None = None,
+        responded_at: datetime | None = None,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+    ) -> "Invitation":
+        """Reconstruye una invitacion desde la base de datos (sin domain events)."""
+        return cls(
+            id=id,
+            competition_id=competition_id,
+            inviter_id=inviter_id,
+            invitee_email=invitee_email,
+            invitee_user_id=invitee_user_id,
+            status=status,
+            personal_message=personal_message,
+            expires_at=expires_at,
+            responded_at=responded_at,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+    # ===========================================
+    # PROPERTIES (Encapsulacion — solo lectura)
+    # ===========================================
+
+    @property
+    def id(self) -> InvitationId:
+        return self._id
+
+    @property
+    def competition_id(self) -> CompetitionId:
+        return self._competition_id
+
+    @property
+    def inviter_id(self) -> UserId:
+        return self._inviter_id
+
+    @property
+    def invitee_email(self) -> str:
+        return self._invitee_email
+
+    @property
+    def invitee_user_id(self) -> UserId | None:
+        return self._invitee_user_id
+
+    @property
+    def status(self) -> InvitationStatus:
+        return self._status
+
+    @property
+    def personal_message(self) -> str | None:
+        return self._personal_message
+
+    @property
+    def expires_at(self) -> datetime:
+        return self._expires_at
+
+    @property
+    def responded_at(self) -> datetime | None:
+        return self._responded_at
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
+
+    # ===========================================
+    # METODOS DE CONSULTA (QUERIES)
+    # ===========================================
+
+    def is_expired(self) -> bool:
+        """Verifica si la invitacion ha expirado."""
+        return datetime.now() >= self._expires_at
+
+    def is_pending(self) -> bool:
+        """Verifica si la invitacion esta pendiente."""
+        return self._status.is_pending()
+
+    def is_for_user(self, user_id: UserId) -> bool:
+        """Verifica si la invitacion es para el usuario dado (por user_id)."""
+        return self._invitee_user_id is not None and self._invitee_user_id == user_id
+
+    def is_for_email(self, email: str) -> bool:
+        """Verifica si la invitacion es para el email dado."""
+        return self._invitee_email == email.strip().lower()
+
+    # ===========================================
+    # METODOS DE COMANDO (CAMBIOS DE ESTADO)
+    # ===========================================
+
+    def accept(self) -> None:
+        """Acepta la invitacion (PENDING -> ACCEPTED)."""
+        if self.is_expired():
+            self._transition_to_expired()
+            raise InvitationExpiredViolation("Cannot accept an expired invitation.")
+
+        if not self._status.can_transition_to(InvitationStatus.ACCEPTED):
+            raise InvalidInvitationStatusViolation(
+                f"Cannot accept invitation in status {self._status.value}."
+            )
+
+        self._status = InvitationStatus.ACCEPTED
+        self._responded_at = datetime.now()
+        self._updated_at = datetime.now()
+
+    def decline(self) -> None:
+        """Rechaza la invitacion (PENDING -> DECLINED)."""
+        if self.is_expired():
+            self._transition_to_expired()
+            raise InvitationExpiredViolation("Cannot decline an expired invitation.")
+
+        if not self._status.can_transition_to(InvitationStatus.DECLINED):
+            raise InvalidInvitationStatusViolation(
+                f"Cannot decline invitation in status {self._status.value}."
+            )
+
+        self._status = InvitationStatus.DECLINED
+        self._responded_at = datetime.now()
+        self._updated_at = datetime.now()
+
+        event = InvitationDeclinedEvent(
+            invitation_id=str(self._id),
+            competition_id=str(self._competition_id),
+            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id else "",
+        )
+        self._add_domain_event(event)
+
+    def check_expiration(self) -> None:
+        """Verifica y actualiza el estado si la invitacion ha expirado."""
+        if self._status == InvitationStatus.PENDING and self.is_expired():
+            self._transition_to_expired()
+
+    def _transition_to_expired(self) -> None:
+        """Transiciona internamente a EXPIRED."""
+        if self._status == InvitationStatus.PENDING:
+            self._status = InvitationStatus.EXPIRED
+            self._updated_at = datetime.now()
+
+    # ===========================================
+    # DOMAIN EVENTS
+    # ===========================================
+
+    def _add_domain_event(self, event: DomainEvent) -> None:
+        if not hasattr(self, "_domain_events") or self._domain_events is None:
+            self._domain_events: list[DomainEvent] = []
+        self._domain_events.append(event)
+
+    def get_domain_events(self) -> list[DomainEvent]:
+        if not hasattr(self, "_domain_events") or self._domain_events is None:
+            self._domain_events: list[DomainEvent] = []
+        return self._domain_events.copy()
+
+    def clear_domain_events(self) -> None:
+        if hasattr(self, "_domain_events") and self._domain_events is not None:
+            self._domain_events.clear()
+
+    # ===========================================
+    # METODOS ESPECIALES
+    # ===========================================
+
+    def __str__(self) -> str:
+        return (
+            f"Invitation({self._invitee_email} -> Competition {self._competition_id}, "
+            f"{self._status.value})"
+        )
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Invitation) and self._id == other._id
+
+    def __hash__(self) -> int:
+        return hash(self._id)

--- a/src/modules/competition/domain/entities/invitation.py
+++ b/src/modules/competition/domain/entities/invitation.py
@@ -108,7 +108,7 @@ class Invitation:
             inviter_id=str(invitation._inviter_id),
             invitee_email=invitation._invitee_email,
         )
-        invitation._add_domain_event(event)
+        invitation.add_domain_event(event)
 
         return invitation
 
@@ -249,7 +249,7 @@ class Invitation:
             competition_id=str(self._competition_id),
             invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id else "",
         )
-        self._add_domain_event(event)
+        self.add_domain_event(event)
 
     def check_expiration(self) -> None:
         """Verifica y actualiza el estado si la invitacion ha expirado."""
@@ -266,7 +266,8 @@ class Invitation:
     # DOMAIN EVENTS
     # ===========================================
 
-    def _add_domain_event(self, event: DomainEvent) -> None:
+    def add_domain_event(self, event: DomainEvent) -> None:
+        """Registra un evento de dominio en la entidad."""
         if not hasattr(self, "_domain_events") or self._domain_events is None:
             self._domain_events: list[DomainEvent] = []
         self._domain_events.append(event)

--- a/src/modules/competition/domain/entities/invitation.py
+++ b/src/modules/competition/domain/entities/invitation.py
@@ -226,9 +226,10 @@ class Invitation:
                 f"Cannot accept invitation in status {self._status.value}."
             )
 
+        now = datetime.now()
         self._status = InvitationStatus.ACCEPTED
-        self._responded_at = datetime.now()
-        self._updated_at = datetime.now()
+        self._responded_at = now
+        self._updated_at = now
 
         event = InvitationAcceptedEvent(
             invitation_id=str(self._id),
@@ -248,9 +249,10 @@ class Invitation:
                 f"Cannot decline invitation in status {self._status.value}."
             )
 
+        now = datetime.now()
         self._status = InvitationStatus.DECLINED
-        self._responded_at = datetime.now()
-        self._updated_at = datetime.now()
+        self._responded_at = now
+        self._updated_at = now
 
         event = InvitationDeclinedEvent(
             invitation_id=str(self._id),

--- a/src/modules/competition/domain/entities/invitation.py
+++ b/src/modules/competition/domain/entities/invitation.py
@@ -233,7 +233,7 @@ class Invitation:
         event = InvitationAcceptedEvent(
             invitation_id=str(self._id),
             competition_id=str(self._competition_id),
-            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id else "",
+            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id is not None else None,
         )
         self.add_domain_event(event)
 
@@ -255,7 +255,7 @@ class Invitation:
         event = InvitationDeclinedEvent(
             invitation_id=str(self._id),
             competition_id=str(self._competition_id),
-            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id else "",
+            invitee_user_id=str(self._invitee_user_id) if self._invitee_user_id is not None else None,
         )
         self.add_domain_event(event)
 
@@ -276,18 +276,13 @@ class Invitation:
 
     def add_domain_event(self, event: DomainEvent) -> None:
         """Registra un evento de dominio en la entidad."""
-        if not hasattr(self, "_domain_events") or self._domain_events is None:
-            self._domain_events: list[DomainEvent] = []
         self._domain_events.append(event)
 
     def get_domain_events(self) -> list[DomainEvent]:
-        if not hasattr(self, "_domain_events") or self._domain_events is None:
-            self._domain_events: list[DomainEvent] = []
         return self._domain_events.copy()
 
     def clear_domain_events(self) -> None:
-        if hasattr(self, "_domain_events") and self._domain_events is not None:
-            self._domain_events.clear()
+        self._domain_events.clear()
 
     # ===========================================
     # METODOS ESPECIALES

--- a/src/modules/competition/domain/events/invitation_accepted_event.py
+++ b/src/modules/competition/domain/events/invitation_accepted_event.py
@@ -1,0 +1,23 @@
+"""InvitationAcceptedEvent - Se emite cuando se acepta una invitacion."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class InvitationAcceptedEvent(DomainEvent):
+    """
+    Evento emitido cuando un invitado acepta una invitacion.
+
+    Atributos:
+        invitation_id: ID de la invitacion (str UUID)
+        competition_id: ID de la competicion (str UUID)
+        invitee_user_id: ID del usuario que acepto (str UUID)
+        enrollment_id: ID del enrollment creado (str UUID)
+    """
+
+    invitation_id: str
+    competition_id: str
+    invitee_user_id: str
+    enrollment_id: str

--- a/src/modules/competition/domain/events/invitation_accepted_event.py
+++ b/src/modules/competition/domain/events/invitation_accepted_event.py
@@ -18,4 +18,4 @@ class InvitationAcceptedEvent(DomainEvent):
 
     invitation_id: str
     competition_id: str
-    invitee_user_id: str
+    invitee_user_id: str | None

--- a/src/modules/competition/domain/events/invitation_accepted_event.py
+++ b/src/modules/competition/domain/events/invitation_accepted_event.py
@@ -14,10 +14,8 @@ class InvitationAcceptedEvent(DomainEvent):
         invitation_id: ID de la invitacion (str UUID)
         competition_id: ID de la competicion (str UUID)
         invitee_user_id: ID del usuario que acepto (str UUID)
-        enrollment_id: ID del enrollment creado (str UUID)
     """
 
     invitation_id: str
     competition_id: str
     invitee_user_id: str
-    enrollment_id: str

--- a/src/modules/competition/domain/events/invitation_created_event.py
+++ b/src/modules/competition/domain/events/invitation_created_event.py
@@ -1,0 +1,23 @@
+"""InvitationCreatedEvent - Se emite cuando se crea una invitacion."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class InvitationCreatedEvent(DomainEvent):
+    """
+    Evento emitido cuando se crea una invitacion a una competicion.
+
+    Atributos:
+        invitation_id: ID de la invitacion (str UUID)
+        competition_id: ID de la competicion (str UUID)
+        inviter_id: ID del usuario que invita (str UUID)
+        invitee_email: Email del invitado
+    """
+
+    invitation_id: str
+    competition_id: str
+    inviter_id: str
+    invitee_email: str

--- a/src/modules/competition/domain/events/invitation_declined_event.py
+++ b/src/modules/competition/domain/events/invitation_declined_event.py
@@ -1,0 +1,21 @@
+"""InvitationDeclinedEvent - Se emite cuando se rechaza una invitacion."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class InvitationDeclinedEvent(DomainEvent):
+    """
+    Evento emitido cuando un invitado rechaza una invitacion.
+
+    Atributos:
+        invitation_id: ID de la invitacion (str UUID)
+        competition_id: ID de la competicion (str UUID)
+        invitee_user_id: ID del usuario que rechazo (str UUID)
+    """
+
+    invitation_id: str
+    competition_id: str
+    invitee_user_id: str

--- a/src/modules/competition/domain/events/invitation_declined_event.py
+++ b/src/modules/competition/domain/events/invitation_declined_event.py
@@ -18,4 +18,4 @@ class InvitationDeclinedEvent(DomainEvent):
 
     invitation_id: str
     competition_id: str
-    invitee_user_id: str
+    invitee_user_id: str | None

--- a/src/modules/competition/domain/exceptions/competition_violations.py
+++ b/src/modules/competition/domain/exceptions/competition_violations.py
@@ -139,3 +139,50 @@ class MaxDurationExceededViolation(BusinessRuleViolation):
     """
 
     pass
+
+
+# =============================================================================
+# INVITATION VIOLATIONS
+# =============================================================================
+
+
+class DuplicateInvitationViolation(BusinessRuleViolation):
+    """Lanzada cuando ya existe una invitacion PENDING para ese email+competition."""
+
+    pass
+
+
+class InvitationExpiredViolation(BusinessRuleViolation):
+    """Lanzada cuando la invitacion ya ha expirado."""
+
+    pass
+
+
+class InvalidInvitationStatusViolation(BusinessRuleViolation):
+    """Lanzada cuando el estado de la invitacion no permite la operacion."""
+
+    pass
+
+
+class InvitationCompetitionStatusViolation(BusinessRuleViolation):
+    """Lanzada cuando el estado de la competicion no permite invitaciones."""
+
+    pass
+
+
+class SelfInvitationViolation(BusinessRuleViolation):
+    """Lanzada cuando el creador intenta invitarse a si mismo."""
+
+    pass
+
+
+class AlreadyEnrolledInvitationViolation(BusinessRuleViolation):
+    """Lanzada cuando el invitado ya esta inscrito en la competicion."""
+
+    pass
+
+
+class InvitationRateLimitViolation(BusinessRuleViolation):
+    """Lanzada cuando se excede el limite de invitaciones por hora para una competicion."""
+
+    pass

--- a/src/modules/competition/domain/repositories/competition_unit_of_work_interface.py
+++ b/src/modules/competition/domain/repositories/competition_unit_of_work_interface.py
@@ -14,6 +14,7 @@ from src.shared.domain.repositories.unit_of_work_interface import UnitOfWorkInte
 
 from .competition_repository_interface import CompetitionRepositoryInterface
 from .enrollment_repository_interface import EnrollmentRepositoryInterface
+from .invitation_repository_interface import InvitationRepositoryInterface
 from .match_repository_interface import MatchRepositoryInterface
 from .round_repository_interface import RoundRepositoryInterface
 from .team_assignment_repository_interface import TeamAssignmentRepositoryInterface
@@ -61,4 +62,10 @@ class CompetitionUnitOfWorkInterface(UnitOfWorkInterface):
     @abstractmethod
     def team_assignments(self) -> TeamAssignmentRepositoryInterface:
         """Acceso al repositorio de asignaciones de equipos."""
+        pass
+
+    @property
+    @abstractmethod
+    def invitations(self) -> InvitationRepositoryInterface:
+        """Acceso al repositorio de invitaciones."""
         pass

--- a/src/modules/competition/domain/repositories/invitation_repository_interface.py
+++ b/src/modules/competition/domain/repositories/invitation_repository_interface.py
@@ -94,5 +94,11 @@ class InvitationRepositoryInterface(ABC):
         user_id: UserId | None = None,
         status: InvitationStatus | None = None,
     ) -> int:
-        """Cuenta invitaciones para un invitado (email OR user_id, AND status)."""
+        """
+        Cuenta invitaciones para un invitado.
+
+        Matches invitations where invitee_email == email OR invitee_user_id == user_id.
+        If status is provided, it is applied as an additional AND filter.
+        Returns 0 if neither email nor user_id is provided.
+        """
         pass

--- a/src/modules/competition/domain/repositories/invitation_repository_interface.py
+++ b/src/modules/competition/domain/repositories/invitation_repository_interface.py
@@ -94,5 +94,5 @@ class InvitationRepositoryInterface(ABC):
         user_id: UserId | None = None,
         status: InvitationStatus | None = None,
     ) -> int:
-        """Cuenta invitaciones para un invitado (por email y/o user_id)."""
+        """Cuenta invitaciones para un invitado (email OR user_id, AND status)."""
         pass

--- a/src/modules/competition/domain/repositories/invitation_repository_interface.py
+++ b/src/modules/competition/domain/repositories/invitation_repository_interface.py
@@ -1,0 +1,98 @@
+"""
+Invitation Repository Interface - Domain Layer.
+
+Define el contrato para la persistencia de invitaciones siguiendo Clean Architecture.
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from src.modules.user.domain.value_objects.user_id import UserId
+
+from ..entities.invitation import Invitation
+from ..value_objects.competition_id import CompetitionId
+from ..value_objects.invitation_id import InvitationId
+from ..value_objects.invitation_status import InvitationStatus
+
+
+class InvitationRepositoryInterface(ABC):
+    """
+    Interfaz para el repositorio de invitaciones.
+
+    Define las operaciones CRUD y consultas especificas del dominio de invitations.
+    """
+
+    @abstractmethod
+    async def add(self, invitation: Invitation) -> None:
+        """Agrega una nueva invitacion al repositorio."""
+        pass
+
+    @abstractmethod
+    async def update(self, invitation: Invitation) -> None:
+        """Actualiza una invitacion existente en el repositorio."""
+        pass
+
+    @abstractmethod
+    async def find_by_id(self, invitation_id: InvitationId) -> Invitation | None:
+        """Busca una invitacion por su ID unico."""
+        pass
+
+    @abstractmethod
+    async def find_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        """Busca invitaciones de una competicion con filtro opcional de status."""
+        pass
+
+    @abstractmethod
+    async def find_by_invitee_email(
+        self,
+        email: str,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        """Busca invitaciones para un email de invitado."""
+        pass
+
+    @abstractmethod
+    async def find_by_invitee_user_id(
+        self,
+        user_id: UserId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        """Busca invitaciones para un user_id de invitado."""
+        pass
+
+    @abstractmethod
+    async def find_pending_by_email_and_competition(
+        self, email: str, competition_id: CompetitionId
+    ) -> Invitation | None:
+        """Busca una invitacion PENDING para un email+competition especificos."""
+        pass
+
+    @abstractmethod
+    async def count_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """Cuenta invitaciones de una competicion con filtro opcional de status y fecha."""
+        pass
+
+    @abstractmethod
+    async def count_by_invitee(
+        self,
+        email: str | None = None,
+        user_id: UserId | None = None,
+        status: InvitationStatus | None = None,
+    ) -> int:
+        """Cuenta invitaciones para un invitado (por email y/o user_id)."""
+        pass

--- a/src/modules/competition/domain/value_objects/invitation_id.py
+++ b/src/modules/competition/domain/value_objects/invitation_id.py
@@ -1,0 +1,61 @@
+"""
+InvitationId Value Object - Identificador unico de invitacion.
+
+Este Value Object representa la identidad de una invitacion usando UUID.
+"""
+
+import uuid
+from dataclasses import dataclass
+
+
+class InvalidInvitationIdError(Exception):
+    """Excepcion lanzada cuando un InvitationId no es valido."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class InvitationId:
+    """
+    Value Object para identificadores unicos de invitacion.
+
+    Almacena internamente un objeto UUID, garantizando siempre un estado valido.
+    Inmutable y validado automaticamente.
+    """
+
+    value: uuid.UUID
+
+    def __init__(self, value: uuid.UUID | str):
+        val = None
+        if isinstance(value, uuid.UUID):
+            val = value
+        elif isinstance(value, str):
+            try:
+                val = uuid.UUID(value)
+            except ValueError as e:
+                raise InvalidInvitationIdError(f"'{value}' no es un string UUID valido") from e
+        else:
+            raise InvalidInvitationIdError(
+                f"Se esperaba un UUID o un string, pero se recibio {type(value).__name__}"
+            )
+
+        object.__setattr__(self, "value", val)
+
+    @classmethod
+    def generate(cls) -> "InvitationId":
+        """Genera un nuevo InvitationId con un UUID v4 aleatorio."""
+        return cls(uuid.uuid4())
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, InvitationId) and self.value == other.value
+
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, InvitationId):
+            return NotImplemented
+        return self.value < other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)

--- a/src/modules/competition/domain/value_objects/invitation_status.py
+++ b/src/modules/competition/domain/value_objects/invitation_status.py
@@ -1,0 +1,61 @@
+"""
+InvitationStatus Value Object - Estado de una invitacion a una competicion.
+
+Define los estados posibles de una invitacion enviada por el creador.
+"""
+
+from enum import StrEnum
+
+
+class InvitationStatus(StrEnum):
+    """
+    Enum para los estados de una invitacion.
+
+    Estados:
+    - PENDING: Invitacion enviada, pendiente de respuesta
+    - ACCEPTED: Invitacion aceptada por el invitado
+    - DECLINED: Invitacion rechazada por el invitado
+    - EXPIRED: Invitacion expirada (pasaron 7 dias sin respuesta)
+
+    State Machine:
+      PENDING -> ACCEPTED (invitado acepta)
+              -> DECLINED (invitado rechaza)
+              -> EXPIRED  (pasan 7 dias)
+      ACCEPTED, DECLINED, EXPIRED son estados terminales.
+    """
+
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    EXPIRED = "EXPIRED"
+
+    def is_pending(self) -> bool:
+        """Verifica si la invitacion esta pendiente de respuesta."""
+        return self == InvitationStatus.PENDING
+
+    def is_final(self) -> bool:
+        """Verifica si es un estado final (no cambiara mas)."""
+        return self in {
+            InvitationStatus.ACCEPTED,
+            InvitationStatus.DECLINED,
+            InvitationStatus.EXPIRED,
+        }
+
+    def can_transition_to(self, new_status: "InvitationStatus") -> bool:
+        """
+        Verifica si es valida la transicion al nuevo estado.
+
+        Solo PENDING puede transicionar, y solo a ACCEPTED, DECLINED o EXPIRED.
+        """
+        valid_transitions = {
+            InvitationStatus.PENDING: {
+                InvitationStatus.ACCEPTED,
+                InvitationStatus.DECLINED,
+                InvitationStatus.EXPIRED,
+            },
+            InvitationStatus.ACCEPTED: set(),
+            InvitationStatus.DECLINED: set(),
+            InvitationStatus.EXPIRED: set(),
+        }
+
+        return new_status in valid_transitions.get(self, set())

--- a/src/modules/competition/infrastructure/api/v1/invitation_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/invitation_routes.py
@@ -73,7 +73,7 @@ def _validate_status_filter(status_filter: str | None) -> str | None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid status filter: '{status_filter}'. Valid values: {valid}",
-        )
+        ) from None
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/src/modules/competition/infrastructure/api/v1/invitation_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/invitation_routes.py
@@ -1,0 +1,276 @@
+"""
+Invitation Routes - API REST Layer (Infrastructure).
+
+Endpoints FastAPI para gestion de invitaciones siguiendo Clean Architecture.
+"""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, EmailStr, Field
+
+from src.config.dependencies import (
+    get_current_user,
+    get_list_competition_invitations_use_case,
+    get_list_my_invitations_use_case,
+    get_respond_to_invitation_use_case,
+    get_send_invitation_by_email_use_case,
+    get_send_invitation_by_user_id_use_case,
+)
+from src.modules.competition.application.dto.invitation_dto import (
+    PaginatedInvitationResponseDTO,
+    RespondInvitationRequestDTO,
+    RespondInvitationResponseDTO,
+    SendInvitationByEmailRequestDTO,
+    SendInvitationByUserIdRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    InvitationNotFoundError,
+    InviteeNotFoundError,
+    NotCompetitionCreatorError,
+    NotInviteeError,
+)
+from src.modules.competition.application.use_cases.list_competition_invitations_use_case import (
+    ListCompetitionInvitationsUseCase,
+)
+from src.modules.competition.application.use_cases.list_my_invitations_use_case import (
+    ListMyInvitationsUseCase,
+)
+from src.modules.competition.application.use_cases.respond_to_invitation_use_case import (
+    RespondToInvitationUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_email_use_case import (
+    SendInvitationByEmailUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_user_id_use_case import (
+    SendInvitationByUserIdUseCase,
+)
+from src.modules.competition.domain.exceptions.competition_violations import (
+    AlreadyEnrolledInvitationViolation,
+    CompetitionFullViolation,
+    DuplicateInvitationViolation,
+    InvalidInvitationStatusViolation,
+    InvitationCompetitionStatusViolation,
+    InvitationExpiredViolation,
+    InvitationRateLimitViolation,
+    SelfInvitationViolation,
+)
+from src.modules.user.application.dto.user_dto import UserResponseDTO
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ======================================================================================
+# REQUEST BODY MODELS (Presentation Layer)
+# ======================================================================================
+
+
+class SendInvitationByUserIdBody(BaseModel):
+    """Body para enviar invitacion por user_id."""
+
+    invitee_user_id: UUID
+    personal_message: str | None = Field(None, max_length=500)
+
+
+class SendInvitationByEmailBody(BaseModel):
+    """Body para enviar invitacion por email."""
+
+    invitee_email: EmailStr
+    personal_message: str | None = Field(None, max_length=500)
+
+
+class RespondInvitationBody(BaseModel):
+    """Body para responder a una invitacion."""
+
+    action: str = Field(
+        ..., description="Action to perform: ACCEPT or DECLINE", pattern="^(ACCEPT|DECLINE)$"
+    )
+
+
+# ======================================================================================
+# ENDPOINTS
+# ======================================================================================
+
+
+@router.post(
+    "/competitions/{competition_id}/invitations",
+    status_code=status.HTTP_201_CREATED,
+    summary="Send invitation by user ID",
+    description="Creator sends an invitation to a registered user by their user ID.",
+)
+async def send_invitation_by_user_id(
+    competition_id: UUID,
+    body: SendInvitationByUserIdBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: SendInvitationByUserIdUseCase = Depends(
+        get_send_invitation_by_user_id_use_case
+    ),
+):
+    try:
+        request_dto = SendInvitationByUserIdRequestDTO(
+            competition_id=competition_id,
+            inviter_id=current_user.id,
+            invitee_user_id=body.invitee_user_id,
+            personal_message=body.personal_message,
+        )
+        return await use_case.execute(request_dto)
+
+    except CompetitionNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except InviteeNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotCompetitionCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except SelfInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except AlreadyEnrolledInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except DuplicateInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except InvitationRateLimitViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(e)
+        ) from e
+    except InvitationCompetitionStatusViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+
+
+@router.post(
+    "/competitions/{competition_id}/invitations/by-email",
+    status_code=status.HTTP_201_CREATED,
+    summary="Send invitation by email",
+    description="Creator sends an invitation to an email address (registered or not).",
+)
+async def send_invitation_by_email(
+    competition_id: UUID,
+    body: SendInvitationByEmailBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: SendInvitationByEmailUseCase = Depends(
+        get_send_invitation_by_email_use_case
+    ),
+):
+    try:
+        request_dto = SendInvitationByEmailRequestDTO(
+            competition_id=competition_id,
+            inviter_id=current_user.id,
+            invitee_email=body.invitee_email,
+            personal_message=body.personal_message,
+        )
+        return await use_case.execute(request_dto)
+
+    except CompetitionNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotCompetitionCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except SelfInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except AlreadyEnrolledInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except DuplicateInvitationViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except InvitationRateLimitViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(e)
+        ) from e
+    except InvitationCompetitionStatusViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+
+
+@router.get(
+    "/invitations/me",
+    response_model=PaginatedInvitationResponseDTO,
+    summary="List my invitations",
+    description="List invitations received by the authenticated user.",
+)
+async def list_my_invitations(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: ListMyInvitationsUseCase = Depends(get_list_my_invitations_use_case),
+    status_filter: str | None = Query(None, alias="status"),
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+):
+    return await use_case.execute(
+        user_id=str(current_user.id),
+        status_filter=status_filter,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/invitations/{invitation_id}/respond",
+    response_model=RespondInvitationResponseDTO,
+    summary="Respond to invitation",
+    description="Accept or decline an invitation.",
+)
+async def respond_to_invitation(
+    invitation_id: UUID,
+    body: RespondInvitationBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: RespondToInvitationUseCase = Depends(get_respond_to_invitation_use_case),
+):
+    try:
+        request_dto = RespondInvitationRequestDTO(
+            invitation_id=invitation_id,
+            user_id=current_user.id,
+            action=body.action,
+        )
+        return await use_case.execute(request_dto)
+
+    except InvitationNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotInviteeError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except InvalidInvitationStatusViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except InvitationExpiredViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except InvitationCompetitionStatusViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+    except CompetitionFullViolation as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+    except CompetitionNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.get(
+    "/competitions/{competition_id}/invitations",
+    response_model=PaginatedInvitationResponseDTO,
+    summary="List competition invitations",
+    description="List invitations sent for a competition (creator/admin only).",
+)
+async def list_competition_invitations(
+    competition_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: ListCompetitionInvitationsUseCase = Depends(
+        get_list_competition_invitations_use_case
+    ),
+    status_filter: str | None = Query(None, alias="status"),
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+):
+    try:
+        return await use_case.execute(
+            competition_id=str(competition_id),
+            current_user_id=str(current_user.id),
+            is_admin=current_user.is_admin,
+            status_filter=status_filter,
+            page=page,
+            limit=limit,
+        )
+
+    except CompetitionNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotCompetitionCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_invitation_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_invitation_repository.py
@@ -1,0 +1,120 @@
+"""In-Memory Invitation Repository para testing."""
+
+from datetime import datetime
+
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.repositories.invitation_repository_interface import (
+    InvitationRepositoryInterface,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.domain.value_objects.invitation_status import InvitationStatus
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class InMemoryInvitationRepository(InvitationRepositoryInterface):
+    """Implementacion en memoria del repositorio de invitaciones para testing."""
+
+    def __init__(self):
+        self._invitations: dict[InvitationId, Invitation] = {}
+
+    async def add(self, invitation: Invitation) -> None:
+        self._invitations[invitation.id] = invitation
+
+    async def update(self, invitation: Invitation) -> None:
+        if invitation.id in self._invitations:
+            self._invitations[invitation.id] = invitation
+
+    async def find_by_id(self, invitation_id: InvitationId) -> Invitation | None:
+        return self._invitations.get(invitation_id)
+
+    async def find_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        results = [
+            inv
+            for inv in self._invitations.values()
+            if inv.competition_id == competition_id
+            and (status is None or inv.status == status)
+        ]
+        # Sort by created_at desc
+        results.sort(key=lambda x: x.created_at, reverse=True)
+        return results[offset : offset + limit]
+
+    async def find_by_invitee_email(
+        self,
+        email: str,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        normalized_email = email.strip().lower()
+        results = [
+            inv
+            for inv in self._invitations.values()
+            if inv.invitee_email == normalized_email
+            and (status is None or inv.status == status)
+        ]
+        results.sort(key=lambda x: x.created_at, reverse=True)
+        return results[offset : offset + limit]
+
+    async def find_by_invitee_user_id(
+        self,
+        user_id: UserId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        results = [
+            inv
+            for inv in self._invitations.values()
+            if inv.invitee_user_id == user_id
+            and (status is None or inv.status == status)
+        ]
+        results.sort(key=lambda x: x.created_at, reverse=True)
+        return results[offset : offset + limit]
+
+    async def find_pending_by_email_and_competition(
+        self, email: str, competition_id: CompetitionId
+    ) -> Invitation | None:
+        normalized_email = email.strip().lower()
+        for inv in self._invitations.values():
+            if (
+                inv.invitee_email == normalized_email
+                and inv.competition_id == competition_id
+                and inv.status == InvitationStatus.PENDING
+            ):
+                return inv
+        return None
+
+    async def count_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        return sum(
+            1
+            for inv in self._invitations.values()
+            if inv.competition_id == competition_id
+            and (status is None or inv.status == status)
+            and (since is None or inv.created_at >= since)
+        )
+
+    async def count_by_invitee(
+        self,
+        email: str | None = None,
+        user_id: UserId | None = None,
+        status: InvitationStatus | None = None,
+    ) -> int:
+        count = 0
+        for inv in self._invitations.values():
+            if status and inv.status != status:
+                continue
+            if (email and inv.invitee_email == email.strip().lower()) or (user_id and inv.invitee_user_id == user_id):
+                count += 1
+        return count

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_unit_of_work.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_unit_of_work.py
@@ -9,6 +9,9 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
 from src.modules.competition.domain.repositories.enrollment_repository_interface import (
     EnrollmentRepositoryInterface,
 )
+from src.modules.competition.domain.repositories.invitation_repository_interface import (
+    InvitationRepositoryInterface,
+)
 from src.modules.competition.domain.repositories.match_repository_interface import (
     MatchRepositoryInterface,
 )
@@ -27,6 +30,7 @@ from src.shared.infrastructure.persistence.in_memory.in_memory_country_repositor
 
 from .in_memory_competition_repository import InMemoryCompetitionRepository
 from .in_memory_enrollment_repository import InMemoryEnrollmentRepository
+from .in_memory_invitation_repository import InMemoryInvitationRepository
 from .in_memory_match_repository import InMemoryMatchRepository
 from .in_memory_round_repository import InMemoryRoundRepository
 from .in_memory_team_assignment_repository import InMemoryTeamAssignmentRepository
@@ -42,6 +46,7 @@ class InMemoryUnitOfWork(CompetitionUnitOfWorkInterface):
         self._rounds = InMemoryRoundRepository()
         self._matches = InMemoryMatchRepository()
         self._team_assignments = InMemoryTeamAssignmentRepository()
+        self._invitations = InMemoryInvitationRepository()
         self.committed = False
 
     @property
@@ -67,6 +72,10 @@ class InMemoryUnitOfWork(CompetitionUnitOfWorkInterface):
     @property
     def team_assignments(self) -> TeamAssignmentRepositoryInterface:
         return self._team_assignments
+
+    @property
+    def invitations(self) -> InvitationRepositoryInterface:
+        return self._invitations
 
     async def __aenter__(self):
         self.committed = False

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_unit_of_work.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_unit_of_work.py
@@ -15,6 +15,9 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
 from src.modules.competition.domain.repositories.enrollment_repository_interface import (
     EnrollmentRepositoryInterface,
 )
+from src.modules.competition.domain.repositories.invitation_repository_interface import (
+    InvitationRepositoryInterface,
+)
 from src.modules.competition.domain.repositories.match_repository_interface import (
     MatchRepositoryInterface,
 )
@@ -29,6 +32,9 @@ from src.modules.competition.infrastructure.persistence.sqlalchemy.competition_r
 )
 from src.modules.competition.infrastructure.persistence.sqlalchemy.enrollment_repository import (
     SQLAlchemyEnrollmentRepository,
+)
+from src.modules.competition.infrastructure.persistence.sqlalchemy.invitation_repository import (
+    SQLAlchemyInvitationRepository,
 )
 from src.modules.competition.infrastructure.persistence.sqlalchemy.match_repository import (
     SQLAlchemyMatchRepository,
@@ -62,6 +68,7 @@ class SQLAlchemyCompetitionUnitOfWork(CompetitionUnitOfWorkInterface):
         self._rounds = SQLAlchemyRoundRepository(session)
         self._matches = SQLAlchemyMatchRepository(session)
         self._team_assignments = SQLAlchemyTeamAssignmentRepository(session)
+        self._invitations = SQLAlchemyInvitationRepository(session)
 
     @property
     def competitions(self) -> CompetitionRepositoryInterface:
@@ -86,6 +93,10 @@ class SQLAlchemyCompetitionUnitOfWork(CompetitionUnitOfWorkInterface):
     @property
     def team_assignments(self) -> TeamAssignmentRepositoryInterface:
         return self._team_assignments
+
+    @property
+    def invitations(self) -> InvitationRepositoryInterface:
+        return self._invitations
 
     async def __aenter__(self):
         return self

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/invitation_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/invitation_repository.py
@@ -1,0 +1,143 @@
+"""Invitation Repository - SQLAlchemy Implementation."""
+
+from datetime import datetime
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.repositories.invitation_repository_interface import (
+    InvitationRepositoryInterface,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.domain.value_objects.invitation_status import InvitationStatus
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
+    """Implementacion asincrona del repositorio de invitaciones con SQLAlchemy."""
+
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def add(self, invitation: Invitation) -> None:
+        self._session.add(invitation)
+
+    async def update(self, invitation: Invitation) -> None:
+        self._session.add(invitation)
+
+    async def find_by_id(self, invitation_id: InvitationId) -> Invitation | None:
+        return await self._session.get(Invitation, invitation_id)
+
+    async def find_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        conditions = [Invitation._competition_id == competition_id]
+        if status:
+            conditions.append(Invitation._status == status)
+
+        stmt = (
+            select(Invitation)
+            .where(and_(*conditions))
+            .order_by(Invitation._created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_by_invitee_email(
+        self,
+        email: str,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        conditions = [Invitation._invitee_email == email.strip().lower()]
+        if status:
+            conditions.append(Invitation._status == status)
+
+        stmt = (
+            select(Invitation)
+            .where(and_(*conditions))
+            .order_by(Invitation._created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_by_invitee_user_id(
+        self,
+        user_id: UserId,
+        status: InvitationStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Invitation]:
+        conditions = [Invitation._invitee_user_id == user_id]
+        if status:
+            conditions.append(Invitation._status == status)
+
+        stmt = (
+            select(Invitation)
+            .where(and_(*conditions))
+            .order_by(Invitation._created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_pending_by_email_and_competition(
+        self, email: str, competition_id: CompetitionId
+    ) -> Invitation | None:
+        stmt = select(Invitation).where(
+            and_(
+                Invitation._invitee_email == email.strip().lower(),
+                Invitation._competition_id == competition_id,
+                Invitation._status == InvitationStatus.PENDING,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return result.scalars().first()
+
+    async def count_by_competition(
+        self,
+        competition_id: CompetitionId,
+        status: InvitationStatus | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        conditions = [Invitation._competition_id == competition_id]
+        if status:
+            conditions.append(Invitation._status == status)
+        if since:
+            conditions.append(Invitation._created_at >= since)
+
+        stmt = select(func.count()).select_from(Invitation).where(and_(*conditions))
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0
+
+    async def count_by_invitee(
+        self,
+        email: str | None = None,
+        user_id: UserId | None = None,
+        status: InvitationStatus | None = None,
+    ) -> int:
+        conditions = []
+        if email:
+            conditions.append(Invitation._invitee_email == email.strip().lower())
+        if user_id:
+            conditions.append(Invitation._invitee_user_id == user_id)
+        if status:
+            conditions.append(Invitation._status == status)
+
+        if not conditions:
+            return 0
+
+        stmt = select(func.count()).select_from(Invitation).where(and_(*conditions))
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/invitation_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/invitation_repository.py
@@ -37,7 +37,7 @@ class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
         offset: int = 0,
     ) -> list[Invitation]:
         conditions = [Invitation._competition_id == competition_id]
-        if status:
+        if status is not None:
             conditions.append(Invitation._status == status)
 
         stmt = (
@@ -58,7 +58,7 @@ class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
         offset: int = 0,
     ) -> list[Invitation]:
         conditions = [Invitation._invitee_email == email.strip().lower()]
-        if status:
+        if status is not None:
             conditions.append(Invitation._status == status)
 
         stmt = (
@@ -79,7 +79,7 @@ class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
         offset: int = 0,
     ) -> list[Invitation]:
         conditions = [Invitation._invitee_user_id == user_id]
-        if status:
+        if status is not None:
             conditions.append(Invitation._status == status)
 
         stmt = (
@@ -112,9 +112,9 @@ class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
         since: datetime | None = None,
     ) -> int:
         conditions = [Invitation._competition_id == competition_id]
-        if status:
+        if status is not None:
             conditions.append(Invitation._status == status)
-        if since:
+        if since is not None:
             conditions.append(Invitation._created_at >= since)
 
         stmt = select(func.count()).select_from(Invitation).where(and_(*conditions))
@@ -129,16 +129,16 @@ class SQLAlchemyInvitationRepository(InvitationRepositoryInterface):
     ) -> int:
         # Identity conditions use OR (email OR user_id match the same person)
         identity_conditions = []
-        if email:
+        if email is not None:
             identity_conditions.append(Invitation._invitee_email == email.strip().lower())
-        if user_id:
+        if user_id is not None:
             identity_conditions.append(Invitation._invitee_user_id == user_id)
 
         if not identity_conditions:
             return 0
 
         where_clauses = [or_(*identity_conditions)]
-        if status:
+        if status is not None:
             where_clauses.append(Invitation._status == status)
 
         stmt = select(func.count()).select_from(Invitation).where(and_(*where_clauses))

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
@@ -758,14 +758,14 @@ invitations_table = Table(
     Column(
         "inviter_id",
         UserIdDecorator,
-        ForeignKey("users.id"),
+        ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     ),
     Column("invitee_email", String(254), nullable=False),
     Column(
         "invitee_user_id",
         UserIdDecorator,
-        ForeignKey("users.id"),
+        ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     ),
     Column("status", InvitationStatusDecorator, nullable=False),

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -552,8 +552,15 @@ The Ryder Cup Friends Team
         safe_competition = self._sanitize_name(competition_name)
         safe_invitee = self._sanitize_name(invitee_name) if invitee_name else None
 
+        # HTML-escaped variants for HTML template interpolation
+        html_inviter = html.escape(safe_inviter)
+        html_competition = html.escape(safe_competition)
+        html_invitee = html.escape(safe_invitee) if safe_invitee else None
+
         greeting_es = f"Hola {safe_invitee}" if safe_invitee else "Hola"
         greeting_en = f"Hello {safe_invitee}" if safe_invitee else "Hello"
+        greeting_html_es = f"Hola {html_invitee}" if html_invitee else "Hola"
+        greeting_html_en = f"Hello {html_invitee}" if html_invitee else "Hello"
 
         expires_str = expires_at.strftime("%d/%m/%Y")
 
@@ -569,7 +576,7 @@ The Ryder Cup Friends Team
             personal_html_es = f"""
             <div style="background-color: #f0f4f8; border-left: 4px solid #0066cc; padding: 15px; margin: 15px 0;">
                 <p style="margin: 0; font-style: italic;">"{escaped_message}"</p>
-                <p style="margin: 5px 0 0 0; font-size: 13px; color: #666;">- {safe_inviter}</p>
+                <p style="margin: 5px 0 0 0; font-size: 13px; color: #666;">- {html_inviter}</p>
             </div>"""
             personal_html_en = personal_html_es
 
@@ -697,11 +704,11 @@ The Ryder Cup Friends Team
         </div>
         <div class="content">
             <!-- Spanish -->
-            <p>{greeting_es},</p>
-            <p><strong>{safe_inviter}</strong> te ha invitado a participar en la competicion:</p>
+            <p>{greeting_html_es},</p>
+            <p><strong>{html_inviter}</strong> te ha invitado a participar en la competicion:</p>
 
             <div class="info-box">
-                <p style="margin: 0; font-size: 18px; font-weight: bold;">{safe_competition}</p>
+                <p style="margin: 0; font-size: 18px; font-weight: bold;">{html_competition}</p>
                 <p style="margin: 5px 0 0 0; font-size: 13px; color: #666;">Expira el {expires_str}</p>
             </div>
             {personal_html_es}
@@ -713,11 +720,11 @@ The Ryder Cup Friends Team
             <div class="divider"></div>
 
             <!-- English -->
-            <p>{greeting_en},</p>
-            <p><strong>{safe_inviter}</strong> has invited you to join the competition:</p>
+            <p>{greeting_html_en},</p>
+            <p><strong>{html_inviter}</strong> has invited you to join the competition:</p>
 
             <div class="info-box">
-                <p style="margin: 0; font-size: 18px; font-weight: bold;">{safe_competition}</p>
+                <p style="margin: 0; font-size: 18px; font-weight: bold;">{html_competition}</p>
                 <p style="margin: 5px 0 0 0; font-size: 13px; color: #666;">Expires on {expires_str}</p>
             </div>
             {personal_html_en}

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -609,6 +609,7 @@ The Ryder Cup Friends Team
         unregistered_es = ""
         unregistered_en = ""
         unregistered_html_es = ""
+        unregistered_html_en = ""
         if not safe_invitee:
             unregistered_es = (
                 f"\nAun no tienes cuenta? Registrate aqui: {register_link}\n"
@@ -619,7 +620,12 @@ The Ryder Cup Friends Team
             unregistered_html_es = f"""
             <p>Si aun no tienes cuenta, registrate primero:</p>
             <center>
-                <a href="{register_link}" class="button" style="background-color: #28a745;">Registrarme | Register</a>
+                <a href="{register_link}" class="button" style="background-color: #28a745;">Registrarme</a>
+            </center>"""
+            unregistered_html_en = f"""
+            <p>Don't have an account yet? Register first:</p>
+            <center>
+                <a href="{register_link}" class="button" style="background-color: #28a745;">Register</a>
             </center>"""
 
         text_body = f"""
@@ -742,6 +748,7 @@ The Ryder Cup Friends Team
             <center>
                 <a href="{invitations_link}" class="button">View my invitations</a>
             </center>
+            {unregistered_html_en}
 
             <div class="footer">
                 <p>Saludos | Best regards,<br>

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -4,6 +4,7 @@ Email Service - Infrastructure Layer
 Servicio para enviar emails usando Mailgun.
 """
 
+import html
 import logging
 from datetime import datetime
 
@@ -562,12 +563,12 @@ The Ryder Cup Friends Team
         personal_html_es = ""
         personal_html_en = ""
         if personal_message:
-            safe_message = self._sanitize_name(personal_message)
-            personal_es = f'\nMensaje de {safe_inviter}: "{safe_message}"\n'
-            personal_en = f'\nMessage from {safe_inviter}: "{safe_message}"\n'
+            escaped_message = html.escape(personal_message)
+            personal_es = f'\nMensaje de {safe_inviter}: "{personal_message}"\n'
+            personal_en = f'\nMessage from {safe_inviter}: "{personal_message}"\n'
             personal_html_es = f"""
             <div style="background-color: #f0f4f8; border-left: 4px solid #0066cc; padding: 15px; margin: 15px 0;">
-                <p style="margin: 0; font-style: italic;">"{safe_message}"</p>
+                <p style="margin: 0; font-style: italic;">"{escaped_message}"</p>
                 <p style="margin: 5px 0 0 0; font-size: 13px; color: #666;">- {safe_inviter}</p>
             </div>"""
             personal_html_en = personal_html_es
@@ -735,4 +736,5 @@ The Ryder Cup Friends Team
 </html>
         """
 
-        return self._send_email(to_email, subject, text_body, html_body)
+        recipient = f'"{safe_invitee}" <{to_email}>' if safe_invitee else to_email
+        return self._send_email(recipient, subject, text_body, html_body)

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -48,16 +48,7 @@ class EmailService(IEmailService, IInvitationEmailService):
         Returns:
             bool: True si el email se envió correctamente, False en caso contrario
         """
-        # Sanitizar user_name para prevenir inyección de headers (RFC 5322)
-        # Eliminar caracteres especiales que podrían romper el formato de email headers
-        safe_user_name = (
-            user_name.replace("\n", "")
-            .replace("\r", "")
-            .replace('"', "")
-            .replace("<", "")
-            .replace(">", "")
-            .strip()
-        )
+        safe_user_name = self._sanitize_name(user_name)
 
         verification_link = f"{settings.FRONTEND_URL}/verify-email?token={verification_token}"
 
@@ -221,15 +212,7 @@ The Ryder Cup Friends Team
 
         Template bilingüe (ES/EN) con diseño consistente con verify_email.
         """
-        # Sanitizar user_name para prevenir inyección de headers
-        safe_user_name = (
-            user_name.replace("\n", "")
-            .replace("\r", "")
-            .replace('"', "")
-            .replace("<", "")
-            .replace(">", "")
-            .strip()
-        )
+        safe_user_name = self._sanitize_name(user_name)
 
         subject = "Resetea tu contraseña - Ryder Cup Friends | Reset your password"
 
@@ -391,15 +374,7 @@ The Ryder Cup Friends Team
 
         Template bilingüe (ES/EN) con información de seguridad.
         """
-        # Sanitizar user_name para prevenir inyección de headers
-        safe_user_name = (
-            user_name.replace("\n", "")
-            .replace("\r", "")
-            .replace('"', "")
-            .replace("<", "")
-            .replace(">", "")
-            .strip()
-        )
+        safe_user_name = self._sanitize_name(user_name)
 
         subject = (
             "Tu contraseña ha sido cambiada - Ryder Cup Friends | Your password has been changed"

--- a/tests/unit/modules/competition/application/dto/test_invitation_dto.py
+++ b/tests/unit/modules/competition/application/dto/test_invitation_dto.py
@@ -1,0 +1,227 @@
+"""Tests para Invitation DTOs."""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.modules.competition.application.dto.invitation_dto import (
+    InvitationResponseDTO,
+    PaginatedInvitationResponseDTO,
+    RespondInvitationRequestDTO,
+    RespondInvitationResponseDTO,
+    SendInvitationByEmailRequestDTO,
+    SendInvitationByUserIdRequestDTO,
+)
+
+
+class TestSendInvitationByUserIdRequestDTO:
+    """Tests para SendInvitationByUserIdRequestDTO."""
+
+    def test_valid_creation(self):
+        dto = SendInvitationByUserIdRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=uuid4(),
+            invitee_user_id=uuid4(),
+        )
+        assert dto.personal_message is None
+
+    def test_with_personal_message(self):
+        dto = SendInvitationByUserIdRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=uuid4(),
+            invitee_user_id=uuid4(),
+            personal_message="Join my tournament!",
+        )
+        assert dto.personal_message == "Join my tournament!"
+
+    def test_message_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            SendInvitationByUserIdRequestDTO(
+                competition_id=uuid4(),
+                inviter_id=uuid4(),
+                invitee_user_id=uuid4(),
+                personal_message="x" * 501,
+            )
+
+    def test_message_at_max_length(self):
+        dto = SendInvitationByUserIdRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=uuid4(),
+            invitee_user_id=uuid4(),
+            personal_message="x" * 500,
+        )
+        assert len(dto.personal_message) == 500
+
+
+class TestSendInvitationByEmailRequestDTO:
+    """Tests para SendInvitationByEmailRequestDTO."""
+
+    def test_valid_creation(self):
+        dto = SendInvitationByEmailRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=uuid4(),
+            invitee_email="test@example.com",
+        )
+        assert dto.invitee_email == "test@example.com"
+
+    def test_with_personal_message(self):
+        dto = SendInvitationByEmailRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=uuid4(),
+            invitee_email="test@example.com",
+            personal_message="Join us!",
+        )
+        assert dto.personal_message == "Join us!"
+
+    def test_message_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            SendInvitationByEmailRequestDTO(
+                competition_id=uuid4(),
+                inviter_id=uuid4(),
+                invitee_email="test@example.com",
+                personal_message="x" * 501,
+            )
+
+
+class TestRespondInvitationRequestDTO:
+    """Tests para RespondInvitationRequestDTO."""
+
+    def test_accept_action(self):
+        dto = RespondInvitationRequestDTO(
+            invitation_id=uuid4(),
+            user_id=uuid4(),
+            action="ACCEPT",
+        )
+        assert dto.action == "ACCEPT"
+
+    def test_decline_action(self):
+        dto = RespondInvitationRequestDTO(
+            invitation_id=uuid4(),
+            user_id=uuid4(),
+            action="DECLINE",
+        )
+        assert dto.action == "DECLINE"
+
+
+class TestInvitationResponseDTO:
+    """Tests para InvitationResponseDTO."""
+
+    def test_full_creation(self):
+        now = datetime.now()
+        uid = uuid4()
+        dto = InvitationResponseDTO(
+            id=uuid4(),
+            competition_id=uuid4(),
+            competition_name="Test Cup",
+            inviter_id=uuid4(),
+            inviter_name="John Doe",
+            invitee_email="test@test.com",
+            invitee_user_id=uid,
+            invitee_name="Jane Doe",
+            status="PENDING",
+            personal_message="Join!",
+            expires_at=now,
+            responded_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        assert dto.invitee_name == "Jane Doe"
+        assert dto.invitee_user_id == uid
+
+    def test_minimal_creation(self):
+        now = datetime.now()
+        dto = InvitationResponseDTO(
+            id=uuid4(),
+            competition_id=uuid4(),
+            competition_name="Test Cup",
+            inviter_id=uuid4(),
+            inviter_name="John Doe",
+            invitee_email="test@test.com",
+            status="PENDING",
+            expires_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        assert dto.invitee_user_id is None
+        assert dto.invitee_name is None
+        assert dto.personal_message is None
+        assert dto.responded_at is None
+
+
+class TestRespondInvitationResponseDTO:
+    """Tests para RespondInvitationResponseDTO."""
+
+    def test_with_enrollment_id(self):
+        now = datetime.now()
+        eid = uuid4()
+        dto = RespondInvitationResponseDTO(
+            id=uuid4(),
+            competition_id=uuid4(),
+            competition_name="Test Cup",
+            inviter_id=uuid4(),
+            inviter_name="John Doe",
+            invitee_email="test@test.com",
+            status="ACCEPTED",
+            expires_at=now,
+            created_at=now,
+            updated_at=now,
+            enrollment_id=eid,
+        )
+        assert dto.enrollment_id == eid
+
+    def test_without_enrollment_id(self):
+        now = datetime.now()
+        dto = RespondInvitationResponseDTO(
+            id=uuid4(),
+            competition_id=uuid4(),
+            competition_name="Test Cup",
+            inviter_id=uuid4(),
+            inviter_name="John Doe",
+            invitee_email="test@test.com",
+            status="DECLINED",
+            expires_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        assert dto.enrollment_id is None
+
+
+class TestPaginatedInvitationResponseDTO:
+    """Tests para PaginatedInvitationResponseDTO."""
+
+    def test_empty_list(self):
+        dto = PaginatedInvitationResponseDTO(
+            invitations=[],
+            total_count=0,
+            page=1,
+            limit=20,
+        )
+        assert dto.invitations == []
+        assert dto.total_count == 0
+
+    def test_with_invitations(self):
+        now = datetime.now()
+        inv_dto = InvitationResponseDTO(
+            id=uuid4(),
+            competition_id=uuid4(),
+            competition_name="Test Cup",
+            inviter_id=uuid4(),
+            inviter_name="John Doe",
+            invitee_email="test@test.com",
+            status="PENDING",
+            expires_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        dto = PaginatedInvitationResponseDTO(
+            invitations=[inv_dto],
+            total_count=1,
+            page=1,
+            limit=20,
+        )
+        assert len(dto.invitations) == 1
+        assert dto.total_count == 1
+        assert dto.page == 1
+        assert dto.limit == 20

--- a/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
@@ -1,0 +1,222 @@
+"""Tests para ListCompetitionInvitationsUseCase."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.list_competition_invitations_use_case import (
+    ListCompetitionInvitationsUseCase,
+)
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as CompetitionInMemoryUoW,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as UserInMemoryUoW,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestListCompetitionInvitationsUseCase:
+    """Tests para listar invitaciones de una competicion."""
+
+    @pytest.fixture
+    def comp_uow(self):
+        return CompetitionInMemoryUoW()
+
+    @pytest.fixture
+    def user_uow(self):
+        return UserInMemoryUoW()
+
+    async def _create_user(self, user_uow, email="user@test.com", first_name="Test", last_name="User"):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    async def _create_active_competition(self, comp_uow, creator_id, name="Test Cup"):
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name=name,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        created = await create_uc.execute(request, creator_id)
+
+        async with comp_uow:
+            competition = await comp_uow.competitions.find_by_id(CompetitionId(created.id))
+            competition.activate()
+            await comp_uow.competitions.update(competition)
+            await comp_uow.commit()
+
+        return created
+
+    async def _add_invitation(self, comp_uow, competition_id, inviter_id, invitee_email, invitee_user_id=None):
+        invitation = Invitation.create(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(competition_id),
+            inviter_id=inviter_id,
+            invitee_email=invitee_email,
+            invitee_user_id=invitee_user_id,
+        )
+        async with comp_uow:
+            await comp_uow.invitations.add(invitation)
+            await comp_uow.commit()
+        return invitation
+
+    async def test_list_empty(self, comp_uow, user_uow):
+        """Competition sin invitaciones retorna lista vacia."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+        )
+
+        assert result.total_count == 0
+        assert result.invitations == []
+
+    async def test_list_invitations_as_creator(self, comp_uow, user_uow):
+        """Creator puede listar invitaciones de su competicion."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="Creator", last_name="Boss")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        await self._add_invitation(comp_uow, created.id, creator.id, "player1@test.com")
+        await self._add_invitation(comp_uow, created.id, creator.id, "player2@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+        )
+
+        assert result.total_count == 2
+        assert len(result.invitations) == 2
+
+    async def test_list_invitations_as_admin(self, comp_uow, user_uow):
+        """Admin puede listar invitaciones de cualquier competicion."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        admin = await self._create_user(user_uow, email="admin@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        await self._add_invitation(comp_uow, created.id, creator.id, "player1@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(admin.id.value),
+            is_admin=True,
+        )
+
+        assert result.total_count == 1
+
+    async def test_should_raise_competition_not_found(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+
+        with pytest.raises(CompetitionNotFoundError):
+            await uc.execute(
+                competition_id=str(uuid4()),
+                current_user_id=str(creator.id.value),
+            )
+
+    async def test_should_raise_not_creator(self, comp_uow, user_uow):
+        """No-creator sin admin lanza NotCompetitionCreatorError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        other = await self._create_user(user_uow, email="other@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+
+        with pytest.raises(NotCompetitionCreatorError):
+            await uc.execute(
+                competition_id=str(created.id),
+                current_user_id=str(other.id.value),
+                is_admin=False,
+            )
+
+    async def test_list_with_status_filter(self, comp_uow, user_uow):
+        """Filtrar por status funciona."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        await self._add_invitation(comp_uow, created.id, creator.id, "player1@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        # PENDING (hay una)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+            status_filter="PENDING",
+        )
+        assert result.total_count == 1
+
+        # ACCEPTED (ninguna)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+            status_filter="ACCEPTED",
+        )
+        assert result.total_count == 0
+
+    async def test_list_with_pagination(self, comp_uow, user_uow):
+        """Paginacion funciona correctamente."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        for i in range(5):
+            await self._add_invitation(comp_uow, created.id, creator.id, f"player{i}@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+            page=1,
+            limit=2,
+        )
+
+        assert len(result.invitations) == 2
+        assert result.page == 1
+        assert result.limit == 2
+
+    async def test_invitations_enriched_with_names(self, comp_uow, user_uow):
+        """Las invitaciones incluyen inviter_name y competition_name."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="John", last_name="Doe")
+        created = await self._create_active_competition(comp_uow, creator.id, name="Champions Cup")
+
+        await self._add_invitation(comp_uow, created.id, creator.id, "player@test.com")
+
+        uc = ListCompetitionInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(
+            competition_id=str(created.id),
+            current_user_id=str(creator.id.value),
+        )
+
+        assert result.invitations[0].inviter_name == "John Doe"
+        assert result.invitations[0].competition_name == "Champions Cup"

--- a/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
@@ -202,6 +202,7 @@ class TestListCompetitionInvitationsUseCase:
         )
 
         assert len(result.invitations) == 2
+        assert result.total_count == 5
         assert result.page == 1
         assert result.limit == 2
 

--- a/tests/unit/modules/competition/application/use_cases/test_list_my_invitations_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_list_my_invitations_use_case.py
@@ -1,0 +1,181 @@
+"""Tests para ListMyInvitationsUseCase."""
+
+from datetime import date
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.list_my_invitations_use_case import (
+    ListMyInvitationsUseCase,
+)
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as CompetitionInMemoryUoW,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as UserInMemoryUoW,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestListMyInvitationsUseCase:
+    """Tests para listar invitaciones del usuario actual."""
+
+    @pytest.fixture
+    def comp_uow(self):
+        return CompetitionInMemoryUoW()
+
+    @pytest.fixture
+    def user_uow(self):
+        return UserInMemoryUoW()
+
+    async def _create_user(self, user_uow, email="user@test.com", first_name="Test", last_name="User"):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    async def _create_active_competition(self, comp_uow, creator_id, name="Test Cup"):
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name=name,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        created = await create_uc.execute(request, creator_id)
+
+        async with comp_uow:
+            competition = await comp_uow.competitions.find_by_id(CompetitionId(created.id))
+            competition.activate()
+            await comp_uow.competitions.update(competition)
+            await comp_uow.commit()
+
+        return created
+
+    async def _add_invitation(self, comp_uow, competition_id, inviter_id, invitee_email, invitee_user_id=None):
+        invitation = Invitation.create(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(competition_id),
+            inviter_id=inviter_id,
+            invitee_email=invitee_email,
+            invitee_user_id=invitee_user_id,
+        )
+        async with comp_uow:
+            await comp_uow.invitations.add(invitation)
+            await comp_uow.commit()
+        return invitation
+
+    async def test_list_empty_invitations(self, comp_uow, user_uow):
+        """Usuario sin invitaciones retorna lista vacia."""
+        user = await self._create_user(user_uow, email="lonely@test.com")
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(user_id=str(user.id.value))
+
+        assert result.total_count == 0
+        assert result.invitations == []
+        assert result.page == 1
+        assert result.limit == 20
+
+    async def test_list_invitations_by_email(self, comp_uow, user_uow):
+        """Lista invitaciones encontradas por email del invitee."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="Creator", last_name="Boss")
+        invitee = await self._create_user(user_uow, email="invitee@test.com", first_name="Invitee", last_name="Player")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        await self._add_invitation(
+            comp_uow, created.id, creator.id, "invitee@test.com", invitee.id
+        )
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(user_id=str(invitee.id.value))
+
+        assert result.total_count == 1
+        assert len(result.invitations) == 1
+        assert result.invitations[0].invitee_email == "invitee@test.com"
+        assert result.invitations[0].competition_name == "Test Cup"
+
+    async def test_list_multiple_invitations(self, comp_uow, user_uow):
+        """Lista multiples invitaciones para un usuario."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        comp1 = await self._create_active_competition(comp_uow, creator.id, name="Cup 1")
+        comp2 = await self._create_active_competition(comp_uow, creator.id, name="Cup 2")
+
+        await self._add_invitation(comp_uow, comp1.id, creator.id, "invitee@test.com", invitee.id)
+        await self._add_invitation(comp_uow, comp2.id, creator.id, "invitee@test.com", invitee.id)
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(user_id=str(invitee.id.value))
+
+        assert result.total_count == 2
+
+    async def test_list_with_status_filter(self, comp_uow, user_uow):
+        """Filtrar invitaciones por status."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        await self._add_invitation(
+            comp_uow, created.id, creator.id, "invitee@test.com", invitee.id
+        )
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        # Filtrar por PENDING
+        result = await uc.execute(user_id=str(invitee.id.value), status_filter="PENDING")
+        assert result.total_count == 1
+
+        # Filtrar por ACCEPTED (ninguna)
+        result = await uc.execute(user_id=str(invitee.id.value), status_filter="ACCEPTED")
+        assert result.total_count == 0
+
+    async def test_list_with_pagination(self, comp_uow, user_uow):
+        """Paginacion funciona correctamente."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+
+        for i in range(5):
+            comp = await self._create_active_competition(comp_uow, creator.id, name=f"Cup {i}")
+            await self._add_invitation(comp_uow, comp.id, creator.id, "invitee@test.com", invitee.id)
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        # Page 1, limit 2
+        result = await uc.execute(user_id=str(invitee.id.value), page=1, limit=2)
+        assert result.total_count == 5
+        assert len(result.invitations) == 2
+        assert result.page == 1
+        assert result.limit == 2
+
+    async def test_deduplicates_email_and_user_id_results(self, comp_uow, user_uow):
+        """No duplica invitaciones encontradas por email y por user_id."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        # Invitacion con email Y user_id (encontrada por ambas busquedas)
+        await self._add_invitation(
+            comp_uow, created.id, creator.id, "invitee@test.com", invitee.id
+        )
+
+        uc = ListMyInvitationsUseCase(comp_uow, user_uow)
+        result = await uc.execute(user_id=str(invitee.id.value))
+
+        # Debe ser 1, no 2 (deduplicado)
+        assert result.total_count == 1

--- a/tests/unit/modules/competition/application/use_cases/test_respond_to_invitation_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_respond_to_invitation_use_case.py
@@ -1,0 +1,256 @@
+"""Tests para RespondToInvitationUseCase."""
+
+from datetime import date, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.dto.invitation_dto import (
+    RespondInvitationRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    InvitationNotFoundError,
+    NotInviteeError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.respond_to_invitation_use_case import (
+    RespondToInvitationUseCase,
+)
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.exceptions.competition_violations import (
+    InvalidInvitationStatusViolation,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.domain.value_objects.invitation_status import (
+    InvitationStatus,
+)
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as CompetitionInMemoryUoW,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as UserInMemoryUoW,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestRespondToInvitationUseCase:
+    """Tests para responder a una invitacion."""
+
+    @pytest.fixture
+    def comp_uow(self):
+        return CompetitionInMemoryUoW()
+
+    @pytest.fixture
+    def user_uow(self):
+        return UserInMemoryUoW()
+
+    async def _create_user(self, user_uow, email="user@test.com", first_name="Test", last_name="User"):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    async def _create_active_competition(self, comp_uow, creator_id, max_players=24):
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=max_players,
+        )
+        created = await create_uc.execute(request, creator_id)
+
+        async with comp_uow:
+            competition = await comp_uow.competitions.find_by_id(CompetitionId(created.id))
+            competition.activate()
+            await comp_uow.competitions.update(competition)
+            await comp_uow.commit()
+
+        return created
+
+    async def _create_pending_invitation(self, comp_uow, competition_id, inviter_id, invitee_user_id, invitee_email):
+        """Helper: crea una invitacion PENDING en el repo."""
+        invitation = Invitation.create(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(competition_id),
+            inviter_id=inviter_id,
+            invitee_email=invitee_email,
+            invitee_user_id=invitee_user_id,
+        )
+        async with comp_uow:
+            await comp_uow.invitations.add(invitation)
+            await comp_uow.commit()
+        return invitation
+
+    async def test_accept_invitation_successfully(self, comp_uow, user_uow):
+        """Happy path: aceptar invitacion crea enrollment."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="Creator", last_name="Boss")
+        invitee = await self._create_user(user_uow, email="invitee@test.com", first_name="Invitee", last_name="Player")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        invitation = await self._create_pending_invitation(
+            comp_uow, created.id, creator.id, invitee.id, "invitee@test.com"
+        )
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=invitee.id.value,
+            action="ACCEPT",
+        )
+        result = await uc.execute(request)
+
+        assert result.status == "ACCEPTED"
+        assert result.enrollment_id is not None
+        assert result.inviter_name == "Creator Boss"
+        assert result.invitee_name == "Invitee Player"
+
+    async def test_decline_invitation_successfully(self, comp_uow, user_uow):
+        """Happy path: rechazar invitacion."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        invitation = await self._create_pending_invitation(
+            comp_uow, created.id, creator.id, invitee.id, "invitee@test.com"
+        )
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=invitee.id.value,
+            action="DECLINE",
+        )
+        result = await uc.execute(request)
+
+        assert result.status == "DECLINED"
+        assert result.enrollment_id is None
+
+    async def test_should_raise_invitation_not_found(self, comp_uow, user_uow):
+        """Invitacion inexistente lanza InvitationNotFoundError."""
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=uuid4(),
+            user_id=invitee.id.value,
+            action="ACCEPT",
+        )
+
+        with pytest.raises(InvitationNotFoundError):
+            await uc.execute(request)
+
+    async def test_should_raise_not_invitee(self, comp_uow, user_uow):
+        """Usuario que no es invitee lanza NotInviteeError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        other = await self._create_user(user_uow, email="other@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        invitation = await self._create_pending_invitation(
+            comp_uow, created.id, creator.id, invitee.id, "invitee@test.com"
+        )
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=other.id.value,
+            action="ACCEPT",
+        )
+
+        with pytest.raises(NotInviteeError):
+            await uc.execute(request)
+
+    async def test_should_raise_invalid_status_for_already_accepted(self, comp_uow, user_uow):
+        """Invitacion ya aceptada lanza InvalidInvitationStatusViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        # Crear invitacion ya ACCEPTED
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(created.id),
+            inviter_id=creator.id,
+            invitee_email="invitee@test.com",
+            invitee_user_id=invitee.id,
+            status=InvitationStatus.ACCEPTED,
+            expires_at=datetime.now() + timedelta(days=7),
+            responded_at=datetime.now(),
+        )
+        async with comp_uow:
+            await comp_uow.invitations.add(invitation)
+            await comp_uow.commit()
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=invitee.id.value,
+            action="ACCEPT",
+        )
+
+        with pytest.raises(InvalidInvitationStatusViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_invalid_action(self, comp_uow, user_uow):
+        """Accion invalida lanza ValueError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        invitation = await self._create_pending_invitation(
+            comp_uow, created.id, creator.id, invitee.id, "invitee@test.com"
+        )
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=invitee.id.value,
+            action="INVALID",
+        )
+
+        with pytest.raises(ValueError, match="Invalid action"):
+            await uc.execute(request)
+
+    async def test_accept_by_email_match(self, comp_uow, user_uow):
+        """Invitee puede responder si el email coincide (sin invitee_user_id)."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        # Invitacion sin invitee_user_id (solo email)
+        invitation = Invitation.create(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(created.id),
+            inviter_id=creator.id,
+            invitee_email="invitee@test.com",
+            invitee_user_id=None,
+        )
+        async with comp_uow:
+            await comp_uow.invitations.add(invitation)
+            await comp_uow.commit()
+
+        uc = RespondToInvitationUseCase(comp_uow, user_uow)
+        request = RespondInvitationRequestDTO(
+            invitation_id=invitation.id.value,
+            user_id=invitee.id.value,
+            action="ACCEPT",
+        )
+        result = await uc.execute(request)
+        assert result.status == "ACCEPTED"
+        assert result.enrollment_id is not None

--- a/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_email_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_email_use_case.py
@@ -1,0 +1,248 @@
+"""Tests para SendInvitationByEmailUseCase."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.dto.invitation_dto import (
+    SendInvitationByEmailRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_email_use_case import (
+    SendInvitationByEmailUseCase,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.exceptions.competition_violations import (
+    AlreadyEnrolledInvitationViolation,
+    DuplicateInvitationViolation,
+    InvitationRateLimitViolation,
+    SelfInvitationViolation,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as CompetitionInMemoryUoW,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as UserInMemoryUoW,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSendInvitationByEmailUseCase:
+    """Tests para enviar invitacion por email."""
+
+    @pytest.fixture
+    def comp_uow(self):
+        return CompetitionInMemoryUoW()
+
+    @pytest.fixture
+    def user_uow(self):
+        return UserInMemoryUoW()
+
+    async def _create_user(self, user_uow, email="user@test.com", first_name="Test", last_name="User"):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    async def _create_active_competition(self, comp_uow, creator_id):
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        created = await create_uc.execute(request, creator_id)
+
+        async with comp_uow:
+            competition = await comp_uow.competitions.find_by_id(CompetitionId(created.id))
+            competition.activate()
+            await comp_uow.competitions.update(competition)
+            await comp_uow.commit()
+
+        return created
+
+    async def test_should_send_invitation_to_registered_user(self, comp_uow, user_uow):
+        """Happy path: enviar invitacion a un email de usuario registrado."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="Creator", last_name="Boss")
+        invitee = await self._create_user(user_uow, email="invitee@test.com", first_name="Invitee", last_name="Player")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="invitee@test.com",
+        )
+        result = await uc.execute(request)
+
+        assert result.status == "PENDING"
+        assert result.invitee_email == "invitee@test.com"
+        assert result.invitee_user_id == invitee.id.value
+        assert result.invitee_name == "Invitee Player"
+
+    async def test_should_send_invitation_to_unregistered_email(self, comp_uow, user_uow):
+        """Happy path: invitacion a email no registrado (invitee_user_id=None)."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="unregistered@test.com",
+        )
+        result = await uc.execute(request)
+
+        assert result.status == "PENDING"
+        assert result.invitee_email == "unregistered@test.com"
+        assert result.invitee_user_id is None
+        assert result.invitee_name is None
+
+    async def test_should_raise_competition_not_found(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=creator.id.value,
+            invitee_email="test@test.com",
+        )
+
+        with pytest.raises(CompetitionNotFoundError):
+            await uc.execute(request)
+
+    async def test_should_raise_not_creator(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        other = await self._create_user(user_uow, email="other@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=other.id.value,
+            invitee_email="someone@test.com",
+        )
+
+        with pytest.raises(NotCompetitionCreatorError):
+            await uc.execute(request)
+
+    async def test_should_raise_self_invitation(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="creator@test.com",
+        )
+
+        with pytest.raises(SelfInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_already_enrolled(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(created.id),
+            user_id=invitee.id,
+        )
+        async with comp_uow:
+            await comp_uow.enrollments.add(enrollment)
+            await comp_uow.commit()
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="invitee@test.com",
+        )
+
+        with pytest.raises(AlreadyEnrolledInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_duplicate_invitation(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="unregistered@test.com",
+        )
+
+        await uc.execute(request)
+
+        with pytest.raises(DuplicateInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_send_with_personal_message(self, comp_uow, user_uow):
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="new@test.com",
+            personal_message="Welcome!",
+        )
+        result = await uc.execute(request)
+        assert result.personal_message == "Welcome!"
+
+    async def test_should_raise_rate_limit_when_max_players_reached(self, comp_uow, user_uow):
+        """Exceder max_players invitaciones por hora lanza InvitationRateLimitViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+        competition_id = CompetitionId(created.id)
+
+        # Crear 24 invitaciones (max_players=24) directamente en repo
+        for i in range(24):
+            inv = Invitation.create(
+                id=InvitationId.generate(),
+                competition_id=competition_id,
+                inviter_id=creator.id,
+                invitee_email=f"player{i}@test.com",
+            )
+            async with comp_uow:
+                await comp_uow.invitations.add(inv)
+                await comp_uow.commit()
+
+        # La invitacion 25 debe fallar por rate limit
+        uc = SendInvitationByEmailUseCase(comp_uow, user_uow)
+        request = SendInvitationByEmailRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_email="extra@test.com",
+        )
+
+        with pytest.raises(InvitationRateLimitViolation):
+            await uc.execute(request)

--- a/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
@@ -1,0 +1,293 @@
+"""Tests para SendInvitationByUserIdUseCase."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.dto.invitation_dto import (
+    SendInvitationByUserIdRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    InviteeNotFoundError,
+    NotCompetitionCreatorError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.send_invitation_by_user_id_use_case import (
+    SendInvitationByUserIdUseCase,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.exceptions.competition_violations import (
+    AlreadyEnrolledInvitationViolation,
+    DuplicateInvitationViolation,
+    InvitationCompetitionStatusViolation,
+    InvitationRateLimitViolation,
+    SelfInvitationViolation,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as CompetitionInMemoryUoW,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as UserInMemoryUoW,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSendInvitationByUserIdUseCase:
+    """Tests para enviar invitacion por user_id."""
+
+    @pytest.fixture
+    def comp_uow(self):
+        return CompetitionInMemoryUoW()
+
+    @pytest.fixture
+    def user_uow(self):
+        return UserInMemoryUoW()
+
+    async def _create_user(self, user_uow, email="user@test.com", first_name="Test", last_name="User"):
+        """Helper: crea un usuario en user_uow."""
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    async def _create_active_competition(self, comp_uow, creator_id):
+        """Helper: crea y activa una competicion."""
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        created = await create_uc.execute(request, creator_id)
+
+        async with comp_uow:
+            competition = await comp_uow.competitions.find_by_id(CompetitionId(created.id))
+            competition.activate()
+            await comp_uow.competitions.update(competition)
+            await comp_uow.commit()
+
+        return created
+
+    async def test_should_send_invitation_successfully(self, comp_uow, user_uow):
+        """Happy path: enviar invitacion a un usuario registrado."""
+        creator = await self._create_user(user_uow, email="creator@test.com", first_name="Creator", last_name="User")
+        invitee = await self._create_user(user_uow, email="invitee@test.com", first_name="Invitee", last_name="Player")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=invitee.id.value,
+            personal_message="Join my tournament!",
+        )
+        result = await uc.execute(request)
+
+        assert result.status == "PENDING"
+        assert result.invitee_email == "invitee@test.com"
+        assert result.invitee_user_id == invitee.id.value
+        assert result.personal_message == "Join my tournament!"
+        assert result.competition_name == "Test Cup"
+        assert result.inviter_name == "Creator User"
+        assert result.invitee_name == "Invitee Player"
+
+    async def test_should_raise_competition_not_found(self, comp_uow, user_uow):
+        """Competition inexistente lanza CompetitionNotFoundError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=uuid4(),
+            inviter_id=creator.id.value,
+            invitee_user_id=uuid4(),
+        )
+
+        with pytest.raises(CompetitionNotFoundError):
+            await uc.execute(request)
+
+    async def test_should_raise_not_creator(self, comp_uow, user_uow):
+        """No-creator lanza NotCompetitionCreatorError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        other = await self._create_user(user_uow, email="other@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=other.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+
+        with pytest.raises(NotCompetitionCreatorError):
+            await uc.execute(request)
+
+    async def test_should_raise_invitee_not_found(self, comp_uow, user_uow):
+        """Invitee inexistente lanza InviteeNotFoundError."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=uuid4(),
+        )
+
+        with pytest.raises(InviteeNotFoundError):
+            await uc.execute(request)
+
+    async def test_should_raise_self_invitation(self, comp_uow, user_uow):
+        """Auto-invitacion lanza SelfInvitationViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=creator.id.value,
+        )
+
+        with pytest.raises(SelfInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_already_enrolled(self, comp_uow, user_uow):
+        """Invitee ya inscrito lanza AlreadyEnrolledInvitationViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        # Crear enrollment aprobado para invitee
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(created.id),
+            user_id=invitee.id,
+        )
+        async with comp_uow:
+            await comp_uow.enrollments.add(enrollment)
+            await comp_uow.commit()
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+
+        with pytest.raises(AlreadyEnrolledInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_duplicate_invitation(self, comp_uow, user_uow):
+        """Segunda invitacion PENDING al mismo email lanza DuplicateInvitationViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+
+        # Primera invitacion
+        await uc.execute(request)
+
+        # Segunda invitacion al mismo usuario
+        with pytest.raises(DuplicateInvitationViolation):
+            await uc.execute(request)
+
+    async def test_should_raise_competition_status_violation_for_draft(self, comp_uow, user_uow):
+        """Competition en DRAFT no permite invitaciones."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+
+        # Crear competition sin activar (queda en DRAFT)
+        create_uc = CreateCompetitionUseCase(comp_uow)
+        request = CreateCompetitionRequestDTO(
+            name="Draft Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        created = await create_uc.execute(request, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        send_req = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+
+        with pytest.raises(InvitationCompetitionStatusViolation):
+            await uc.execute(send_req)
+
+    async def test_should_send_without_personal_message(self, comp_uow, user_uow):
+        """Invitacion sin mensaje personal es valida."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+        result = await uc.execute(request)
+        assert result.personal_message is None
+
+    async def test_should_raise_rate_limit_when_max_players_reached(self, comp_uow, user_uow):
+        """Exceder max_players invitaciones por hora lanza InvitationRateLimitViolation."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+        competition_id = CompetitionId(created.id)
+
+        # Crear 24 invitaciones (max_players=24) directamente en repo
+        for i in range(24):
+            inv = Invitation.create(
+                id=InvitationId.generate(),
+                competition_id=competition_id,
+                inviter_id=creator.id,
+                invitee_email=f"player{i}@test.com",
+            )
+            async with comp_uow:
+                await comp_uow.invitations.add(inv)
+                await comp_uow.commit()
+
+        # La invitacion 25 debe fallar por rate limit
+        new_invitee = await self._create_user(user_uow, email="extra@test.com")
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=creator.id.value,
+            invitee_user_id=new_invitee.id.value,
+        )
+
+        with pytest.raises(InvitationRateLimitViolation):
+            await uc.execute(request)

--- a/tests/unit/modules/competition/domain/entities/test_invitation.py
+++ b/tests/unit/modules/competition/domain/entities/test_invitation.py
@@ -1,0 +1,491 @@
+"""Tests para Invitation Entity."""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.entities.invitation import (
+    INVITATION_EXPIRATION_DAYS,
+    MAX_PERSONAL_MESSAGE_LENGTH,
+    Invitation,
+)
+from src.modules.competition.domain.events.invitation_created_event import (
+    InvitationCreatedEvent,
+)
+from src.modules.competition.domain.events.invitation_declined_event import (
+    InvitationDeclinedEvent,
+)
+from src.modules.competition.domain.exceptions.competition_violations import (
+    InvalidInvitationStatusViolation,
+    InvitationExpiredViolation,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.domain.value_objects.invitation_status import (
+    InvitationStatus,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# ==========================================================================
+# Fixtures helpers
+# ==========================================================================
+
+def _make_invitation(**overrides):
+    """Helper para crear invitaciones con valores por defecto."""
+    defaults = {
+        "id": InvitationId.generate(),
+        "competition_id": CompetitionId(uuid4()),
+        "inviter_id": UserId(uuid4()),
+        "invitee_email": "player@example.com",
+        "invitee_user_id": None,
+        "personal_message": None,
+    }
+    defaults.update(overrides)
+    return Invitation.create(**defaults)
+
+
+def _make_expired_invitation(**overrides):
+    """Helper para crear invitaciones expiradas (reconstruidas)."""
+    defaults = {
+        "id": InvitationId.generate(),
+        "competition_id": CompetitionId(uuid4()),
+        "inviter_id": UserId(uuid4()),
+        "invitee_email": "expired@example.com",
+        "status": InvitationStatus.PENDING,
+        "expires_at": datetime.now() - timedelta(days=1),
+        "created_at": datetime.now() - timedelta(days=8),
+        "updated_at": datetime.now() - timedelta(days=8),
+    }
+    defaults.update(overrides)
+    return Invitation.reconstruct(**defaults)
+
+
+# ==========================================================================
+# Creation Tests
+# ==========================================================================
+
+class TestInvitationCreate:
+    """Tests para el factory method create."""
+
+    def test_create_sets_pending_status(self):
+        invitation = _make_invitation()
+        assert invitation.status == InvitationStatus.PENDING
+
+    def test_create_sets_expiration(self):
+        before = datetime.now()
+        invitation = _make_invitation()
+        after = datetime.now()
+        expected_min = before + timedelta(days=INVITATION_EXPIRATION_DAYS)
+        expected_max = after + timedelta(days=INVITATION_EXPIRATION_DAYS)
+        assert expected_min <= invitation.expires_at <= expected_max
+
+    def test_create_sets_timestamps(self):
+        before = datetime.now()
+        invitation = _make_invitation()
+        assert invitation.created_at >= before
+        assert invitation.updated_at >= before
+
+    def test_create_stores_email_normalized(self):
+        invitation = _make_invitation(invitee_email="  Player@Example.COM  ")
+        assert invitation.invitee_email == "player@example.com"
+
+    def test_create_with_invitee_user_id(self):
+        user_id = UserId(uuid4())
+        invitation = _make_invitation(invitee_user_id=user_id)
+        assert invitation.invitee_user_id == user_id
+
+    def test_create_with_personal_message(self):
+        invitation = _make_invitation(personal_message="Join my tournament!")
+        assert invitation.personal_message == "Join my tournament!"
+
+    def test_create_without_personal_message(self):
+        invitation = _make_invitation()
+        assert invitation.personal_message is None
+
+    def test_create_emits_invitation_created_event(self):
+        invitation = _make_invitation()
+        events = invitation.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], InvitationCreatedEvent)
+
+    def test_create_event_has_correct_fields(self):
+        comp_id = CompetitionId(uuid4())
+        inviter_id = UserId(uuid4())
+        invitation = _make_invitation(
+            competition_id=comp_id,
+            inviter_id=inviter_id,
+            invitee_email="test@test.com",
+        )
+        event = invitation.get_domain_events()[0]
+        assert event.competition_id == str(comp_id)
+        assert event.inviter_id == str(inviter_id)
+        assert event.invitee_email == "test@test.com"
+
+    def test_create_responded_at_is_none(self):
+        invitation = _make_invitation()
+        assert invitation.responded_at is None
+
+
+class TestInvitationCreateValidation:
+    """Tests para validaciones en la creacion."""
+
+    def test_empty_email_raises(self):
+        with pytest.raises(ValueError, match="invitee_email no puede estar vacio"):
+            _make_invitation(invitee_email="")
+
+    def test_whitespace_email_raises(self):
+        with pytest.raises(ValueError, match="invitee_email no puede estar vacio"):
+            _make_invitation(invitee_email="   ")
+
+    def test_message_too_long_raises(self):
+        long_message = "x" * (MAX_PERSONAL_MESSAGE_LENGTH + 1)
+        with pytest.raises(ValueError, match="personal_message no puede exceder"):
+            _make_invitation(personal_message=long_message)
+
+    def test_message_at_max_length_is_valid(self):
+        message = "x" * MAX_PERSONAL_MESSAGE_LENGTH
+        invitation = _make_invitation(personal_message=message)
+        assert len(invitation.personal_message) == MAX_PERSONAL_MESSAGE_LENGTH
+
+
+# ==========================================================================
+# Reconstruct Tests
+# ==========================================================================
+
+class TestInvitationReconstruct:
+    """Tests para el factory method reconstruct."""
+
+    def test_reconstruct_preserves_all_fields(self):
+        inv_id = InvitationId.generate()
+        comp_id = CompetitionId(uuid4())
+        inviter = UserId(uuid4())
+        invitee = UserId(uuid4())
+        now = datetime.now()
+
+        invitation = Invitation.reconstruct(
+            id=inv_id,
+            competition_id=comp_id,
+            inviter_id=inviter,
+            invitee_email="test@test.com",
+            status=InvitationStatus.ACCEPTED,
+            expires_at=now + timedelta(days=7),
+            invitee_user_id=invitee,
+            personal_message="Hello",
+            responded_at=now,
+            created_at=now - timedelta(days=1),
+            updated_at=now,
+        )
+
+        assert invitation.id == inv_id
+        assert invitation.competition_id == comp_id
+        assert invitation.inviter_id == inviter
+        assert invitation.invitee_user_id == invitee
+        assert invitation.status == InvitationStatus.ACCEPTED
+        assert invitation.personal_message == "Hello"
+
+    def test_reconstruct_does_not_emit_events(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.PENDING,
+            expires_at=datetime.now() + timedelta(days=7),
+        )
+        assert invitation.get_domain_events() == []
+
+
+# ==========================================================================
+# Properties Tests
+# ==========================================================================
+
+class TestInvitationProperties:
+    """Tests para las properties de lectura."""
+
+    def test_id_property(self):
+        inv_id = InvitationId.generate()
+        invitation = _make_invitation(id=inv_id)
+        assert invitation.id == inv_id
+
+    def test_competition_id_property(self):
+        comp_id = CompetitionId(uuid4())
+        invitation = _make_invitation(competition_id=comp_id)
+        assert invitation.competition_id == comp_id
+
+    def test_inviter_id_property(self):
+        inviter = UserId(uuid4())
+        invitation = _make_invitation(inviter_id=inviter)
+        assert invitation.inviter_id == inviter
+
+    def test_invitee_email_property(self):
+        invitation = _make_invitation(invitee_email="test@example.com")
+        assert invitation.invitee_email == "test@example.com"
+
+
+# ==========================================================================
+# Query Methods Tests
+# ==========================================================================
+
+class TestInvitationQueries:
+    """Tests para metodos de consulta."""
+
+    def test_is_expired_when_not_expired(self):
+        invitation = _make_invitation()
+        assert not invitation.is_expired()
+
+    def test_is_expired_when_expired(self):
+        invitation = _make_expired_invitation()
+        assert invitation.is_expired()
+
+    def test_is_pending_when_pending(self):
+        invitation = _make_invitation()
+        assert invitation.is_pending()
+
+    def test_is_pending_when_accepted(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.ACCEPTED,
+            expires_at=datetime.now() + timedelta(days=7),
+        )
+        assert not invitation.is_pending()
+
+    def test_is_for_user_matches(self):
+        user_id = UserId(uuid4())
+        invitation = _make_invitation(invitee_user_id=user_id)
+        assert invitation.is_for_user(user_id)
+
+    def test_is_for_user_does_not_match_different_user(self):
+        invitation = _make_invitation(invitee_user_id=UserId(uuid4()))
+        assert not invitation.is_for_user(UserId(uuid4()))
+
+    def test_is_for_user_false_when_no_user_id(self):
+        invitation = _make_invitation()
+        assert not invitation.is_for_user(UserId(uuid4()))
+
+    def test_is_for_email_matches(self):
+        invitation = _make_invitation(invitee_email="test@example.com")
+        assert invitation.is_for_email("test@example.com")
+
+    def test_is_for_email_case_insensitive(self):
+        invitation = _make_invitation(invitee_email="test@example.com")
+        assert invitation.is_for_email("TEST@EXAMPLE.COM")
+
+    def test_is_for_email_trims_whitespace(self):
+        invitation = _make_invitation(invitee_email="test@example.com")
+        assert invitation.is_for_email("  test@example.com  ")
+
+    def test_is_for_email_does_not_match_different(self):
+        invitation = _make_invitation(invitee_email="test@example.com")
+        assert not invitation.is_for_email("other@example.com")
+
+
+# ==========================================================================
+# Command Methods Tests
+# ==========================================================================
+
+class TestInvitationAccept:
+    """Tests para el metodo accept()."""
+
+    def test_accept_changes_status_to_accepted(self):
+        invitation = _make_invitation()
+        invitation.accept()
+        assert invitation.status == InvitationStatus.ACCEPTED
+
+    def test_accept_sets_responded_at(self):
+        invitation = _make_invitation()
+        before = datetime.now()
+        invitation.accept()
+        assert invitation.responded_at is not None
+        assert invitation.responded_at >= before
+
+    def test_accept_updates_updated_at(self):
+        invitation = _make_invitation()
+        old_updated = invitation.updated_at
+        invitation.accept()
+        assert invitation.updated_at >= old_updated
+
+    def test_accept_expired_raises_and_transitions(self):
+        invitation = _make_expired_invitation()
+        with pytest.raises(InvitationExpiredViolation):
+            invitation.accept()
+        assert invitation.status == InvitationStatus.EXPIRED
+
+    def test_accept_already_accepted_raises(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.ACCEPTED,
+            expires_at=datetime.now() + timedelta(days=7),
+        )
+        with pytest.raises(InvalidInvitationStatusViolation):
+            invitation.accept()
+
+    def test_accept_declined_raises(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.DECLINED,
+            expires_at=datetime.now() + timedelta(days=7),
+        )
+        with pytest.raises(InvalidInvitationStatusViolation):
+            invitation.accept()
+
+
+class TestInvitationDecline:
+    """Tests para el metodo decline()."""
+
+    def test_decline_changes_status_to_declined(self):
+        invitation = _make_invitation()
+        invitation.decline()
+        assert invitation.status == InvitationStatus.DECLINED
+
+    def test_decline_sets_responded_at(self):
+        invitation = _make_invitation()
+        invitation.decline()
+        assert invitation.responded_at is not None
+
+    def test_decline_emits_declined_event(self):
+        invitation = _make_invitation()
+        invitation.clear_domain_events()
+        invitation.decline()
+        events = invitation.get_domain_events()
+        declined_events = [e for e in events if isinstance(e, InvitationDeclinedEvent)]
+        assert len(declined_events) == 1
+
+    def test_decline_event_has_correct_fields(self):
+        comp_id = CompetitionId(uuid4())
+        invitee_id = UserId(uuid4())
+        invitation = _make_invitation(
+            competition_id=comp_id,
+            invitee_user_id=invitee_id,
+        )
+        invitation.clear_domain_events()
+        invitation.decline()
+        event = invitation.get_domain_events()[0]
+        assert event.competition_id == str(comp_id)
+        assert event.invitee_user_id == str(invitee_id)
+
+    def test_decline_expired_raises(self):
+        invitation = _make_expired_invitation()
+        with pytest.raises(InvitationExpiredViolation):
+            invitation.decline()
+
+    def test_decline_already_declined_raises(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.DECLINED,
+            expires_at=datetime.now() + timedelta(days=7),
+        )
+        with pytest.raises(InvalidInvitationStatusViolation):
+            invitation.decline()
+
+
+class TestInvitationCheckExpiration:
+    """Tests para check_expiration()."""
+
+    def test_check_expiration_transitions_pending_to_expired(self):
+        invitation = _make_expired_invitation()
+        invitation.check_expiration()
+        assert invitation.status == InvitationStatus.EXPIRED
+
+    def test_check_expiration_does_nothing_if_not_expired(self):
+        invitation = _make_invitation()
+        invitation.check_expiration()
+        assert invitation.status == InvitationStatus.PENDING
+
+    def test_check_expiration_does_nothing_for_accepted(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.ACCEPTED,
+            expires_at=datetime.now() - timedelta(days=1),
+        )
+        invitation.check_expiration()
+        assert invitation.status == InvitationStatus.ACCEPTED
+
+    def test_check_expiration_does_nothing_for_declined(self):
+        invitation = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=CompetitionId(uuid4()),
+            inviter_id=UserId(uuid4()),
+            invitee_email="test@test.com",
+            status=InvitationStatus.DECLINED,
+            expires_at=datetime.now() - timedelta(days=1),
+        )
+        invitation.check_expiration()
+        assert invitation.status == InvitationStatus.DECLINED
+
+
+# ==========================================================================
+# Domain Events Tests
+# ==========================================================================
+
+class TestInvitationDomainEvents:
+    """Tests para el manejo de domain events."""
+
+    def test_get_domain_events_returns_copy(self):
+        invitation = _make_invitation()
+        events1 = invitation.get_domain_events()
+        events2 = invitation.get_domain_events()
+        assert events1 == events2
+        assert events1 is not events2
+
+    def test_clear_domain_events(self):
+        invitation = _make_invitation()
+        assert len(invitation.get_domain_events()) > 0
+        invitation.clear_domain_events()
+        assert invitation.get_domain_events() == []
+
+
+# ==========================================================================
+# Special Methods Tests
+# ==========================================================================
+
+class TestInvitationSpecialMethods:
+    """Tests para __str__, __eq__, __hash__."""
+
+    def test_str_representation(self):
+        invitation = _make_invitation(invitee_email="test@test.com")
+        result = str(invitation)
+        assert "test@test.com" in result
+        assert "PENDING" in result
+
+    def test_eq_same_id(self):
+        inv_id = InvitationId.generate()
+        inv1 = _make_invitation(id=inv_id)
+        inv2 = _make_invitation(id=inv_id)
+        assert inv1 == inv2
+
+    def test_eq_different_id(self):
+        inv1 = _make_invitation()
+        inv2 = _make_invitation()
+        assert inv1 != inv2
+
+    def test_eq_different_type(self):
+        invitation = _make_invitation()
+        assert invitation != "not-an-invitation"
+
+    def test_hash_same_id(self):
+        inv_id = InvitationId.generate()
+        inv1 = _make_invitation(id=inv_id)
+        inv2 = _make_invitation(id=inv_id)
+        assert hash(inv1) == hash(inv2)
+
+    def test_usable_in_set(self):
+        inv_id = InvitationId.generate()
+        inv1 = _make_invitation(id=inv_id)
+        inv2 = _make_invitation(id=inv_id)
+        assert len({inv1, inv2}) == 1

--- a/tests/unit/modules/competition/domain/events/test_invitation_events.py
+++ b/tests/unit/modules/competition/domain/events/test_invitation_events.py
@@ -57,7 +57,6 @@ class TestInvitationAcceptedEvent:
             invitation_id="inv-1",
             competition_id="comp-1",
             invitee_user_id="user-2",
-            enrollment_id="enr-1",
         )
         assert isinstance(event, DomainEvent)
 
@@ -66,12 +65,10 @@ class TestInvitationAcceptedEvent:
             invitation_id="inv-1",
             competition_id="comp-1",
             invitee_user_id="user-2",
-            enrollment_id="enr-1",
         )
         assert event.invitation_id == "inv-1"
         assert event.competition_id == "comp-1"
         assert event.invitee_user_id == "user-2"
-        assert event.enrollment_id == "enr-1"
 
 
 class TestInvitationDeclinedEvent:

--- a/tests/unit/modules/competition/domain/events/test_invitation_events.py
+++ b/tests/unit/modules/competition/domain/events/test_invitation_events.py
@@ -70,6 +70,23 @@ class TestInvitationAcceptedEvent:
         assert event.competition_id == "comp-1"
         assert event.invitee_user_id == "user-2"
 
+    def test_is_frozen(self):
+        event = InvitationAcceptedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+        )
+        with pytest.raises(AttributeError):
+            event.invitation_id = "changed"
+
+    def test_invitee_user_id_can_be_none_for_unregistered(self):
+        event = InvitationAcceptedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id=None,
+        )
+        assert event.invitee_user_id is None
+
 
 class TestInvitationDeclinedEvent:
     """Tests para InvitationDeclinedEvent."""
@@ -91,6 +108,15 @@ class TestInvitationDeclinedEvent:
         assert event.invitation_id == "inv-1"
         assert event.competition_id == "comp-1"
         assert event.invitee_user_id == "user-2"
+
+    def test_is_frozen(self):
+        event = InvitationDeclinedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+        )
+        with pytest.raises(AttributeError):
+            event.invitation_id = "changed"
 
     def test_invitee_user_id_can_be_none_for_unregistered(self):
         event = InvitationDeclinedEvent(

--- a/tests/unit/modules/competition/domain/events/test_invitation_events.py
+++ b/tests/unit/modules/competition/domain/events/test_invitation_events.py
@@ -92,10 +92,10 @@ class TestInvitationDeclinedEvent:
         assert event.competition_id == "comp-1"
         assert event.invitee_user_id == "user-2"
 
-    def test_invitee_user_id_can_be_empty_for_unregistered(self):
+    def test_invitee_user_id_can_be_none_for_unregistered(self):
         event = InvitationDeclinedEvent(
             invitation_id="inv-1",
             competition_id="comp-1",
-            invitee_user_id="",
+            invitee_user_id=None,
         )
-        assert event.invitee_user_id == ""
+        assert event.invitee_user_id is None

--- a/tests/unit/modules/competition/domain/events/test_invitation_events.py
+++ b/tests/unit/modules/competition/domain/events/test_invitation_events.py
@@ -1,0 +1,104 @@
+"""Tests para Domain Events de Invitation."""
+
+import pytest
+
+from src.modules.competition.domain.events.invitation_accepted_event import (
+    InvitationAcceptedEvent,
+)
+from src.modules.competition.domain.events.invitation_created_event import (
+    InvitationCreatedEvent,
+)
+from src.modules.competition.domain.events.invitation_declined_event import (
+    InvitationDeclinedEvent,
+)
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+class TestInvitationCreatedEvent:
+    """Tests para InvitationCreatedEvent."""
+
+    def test_is_domain_event(self):
+        event = InvitationCreatedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            inviter_id="user-1",
+            invitee_email="test@test.com",
+        )
+        assert isinstance(event, DomainEvent)
+
+    def test_stores_all_fields(self):
+        event = InvitationCreatedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            inviter_id="user-1",
+            invitee_email="test@test.com",
+        )
+        assert event.invitation_id == "inv-1"
+        assert event.competition_id == "comp-1"
+        assert event.inviter_id == "user-1"
+        assert event.invitee_email == "test@test.com"
+
+    def test_is_frozen(self):
+        event = InvitationCreatedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            inviter_id="user-1",
+            invitee_email="test@test.com",
+        )
+        with pytest.raises(AttributeError):
+            event.invitation_id = "changed"
+
+
+class TestInvitationAcceptedEvent:
+    """Tests para InvitationAcceptedEvent."""
+
+    def test_is_domain_event(self):
+        event = InvitationAcceptedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+            enrollment_id="enr-1",
+        )
+        assert isinstance(event, DomainEvent)
+
+    def test_stores_all_fields(self):
+        event = InvitationAcceptedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+            enrollment_id="enr-1",
+        )
+        assert event.invitation_id == "inv-1"
+        assert event.competition_id == "comp-1"
+        assert event.invitee_user_id == "user-2"
+        assert event.enrollment_id == "enr-1"
+
+
+class TestInvitationDeclinedEvent:
+    """Tests para InvitationDeclinedEvent."""
+
+    def test_is_domain_event(self):
+        event = InvitationDeclinedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+        )
+        assert isinstance(event, DomainEvent)
+
+    def test_stores_all_fields(self):
+        event = InvitationDeclinedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="user-2",
+        )
+        assert event.invitation_id == "inv-1"
+        assert event.competition_id == "comp-1"
+        assert event.invitee_user_id == "user-2"
+
+    def test_invitee_user_id_can_be_empty_for_unregistered(self):
+        event = InvitationDeclinedEvent(
+            invitation_id="inv-1",
+            competition_id="comp-1",
+            invitee_user_id="",
+        )
+        assert event.invitee_user_id == ""

--- a/tests/unit/modules/competition/domain/services/test_competition_policy_invitations.py
+++ b/tests/unit/modules/competition/domain/services/test_competition_policy_invitations.py
@@ -1,0 +1,98 @@
+"""Tests para CompetitionPolicy - metodos de invitaciones."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.exceptions.competition_violations import (
+    InvitationCompetitionStatusViolation,
+    InvitationRateLimitViolation,
+)
+from src.modules.competition.domain.services.competition_policy import CompetitionPolicy
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_status import (
+    CompetitionStatus,
+)
+
+
+class TestCanSendInvitation:
+    """Tests para CompetitionPolicy.can_send_invitation()."""
+
+    def test_active_allows_send(self):
+        CompetitionPolicy.can_send_invitation(CompetitionStatus.ACTIVE)
+
+    def test_closed_allows_send(self):
+        CompetitionPolicy.can_send_invitation(CompetitionStatus.CLOSED)
+
+    def test_in_progress_allows_send(self):
+        CompetitionPolicy.can_send_invitation(CompetitionStatus.IN_PROGRESS)
+
+    def test_draft_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="DRAFT"):
+            CompetitionPolicy.can_send_invitation(CompetitionStatus.DRAFT)
+
+    def test_completed_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="COMPLETED"):
+            CompetitionPolicy.can_send_invitation(CompetitionStatus.COMPLETED)
+
+    def test_cancelled_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="CANCELLED"):
+            CompetitionPolicy.can_send_invitation(CompetitionStatus.CANCELLED)
+
+
+class TestCanAcceptInvitation:
+    """Tests para CompetitionPolicy.can_accept_invitation()."""
+
+    def test_active_allows_accept(self):
+        CompetitionPolicy.can_accept_invitation(CompetitionStatus.ACTIVE)
+
+    def test_closed_allows_accept(self):
+        CompetitionPolicy.can_accept_invitation(CompetitionStatus.CLOSED)
+
+    def test_in_progress_allows_accept(self):
+        CompetitionPolicy.can_accept_invitation(CompetitionStatus.IN_PROGRESS)
+
+    def test_draft_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="DRAFT"):
+            CompetitionPolicy.can_accept_invitation(CompetitionStatus.DRAFT)
+
+    def test_completed_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="COMPLETED"):
+            CompetitionPolicy.can_accept_invitation(CompetitionStatus.COMPLETED)
+
+    def test_cancelled_raises(self):
+        with pytest.raises(InvitationCompetitionStatusViolation, match="CANCELLED"):
+            CompetitionPolicy.can_accept_invitation(CompetitionStatus.CANCELLED)
+
+
+class TestValidateInvitationRate:
+    """Tests para CompetitionPolicy.validate_invitation_rate()."""
+
+    def test_under_limit_passes(self):
+        comp_id = CompetitionId(uuid4())
+        CompetitionPolicy.validate_invitation_rate(10, 24, comp_id)
+
+    def test_zero_invitations_passes(self):
+        comp_id = CompetitionId(uuid4())
+        CompetitionPolicy.validate_invitation_rate(0, 24, comp_id)
+
+    def test_one_below_limit_passes(self):
+        comp_id = CompetitionId(uuid4())
+        CompetitionPolicy.validate_invitation_rate(23, 24, comp_id)
+
+    def test_at_limit_raises(self):
+        comp_id = CompetitionId(uuid4())
+        with pytest.raises(InvitationRateLimitViolation, match="24/24"):
+            CompetitionPolicy.validate_invitation_rate(24, 24, comp_id)
+
+    def test_above_limit_raises(self):
+        comp_id = CompetitionId(uuid4())
+        with pytest.raises(InvitationRateLimitViolation, match="30/24"):
+            CompetitionPolicy.validate_invitation_rate(30, 24, comp_id)
+
+    def test_small_competition_limit(self):
+        """Competicion de 4 jugadores, limite es 4 por hora."""
+        comp_id = CompetitionId(uuid4())
+        CompetitionPolicy.validate_invitation_rate(3, 4, comp_id)
+        with pytest.raises(InvitationRateLimitViolation):
+            CompetitionPolicy.validate_invitation_rate(4, 4, comp_id)

--- a/tests/unit/modules/competition/domain/value_objects/test_invitation_id.py
+++ b/tests/unit/modules/competition/domain/value_objects/test_invitation_id.py
@@ -1,0 +1,133 @@
+"""Tests para InvitationId Value Object."""
+
+import uuid
+
+import pytest
+
+from src.modules.competition.domain.value_objects.invitation_id import (
+    InvalidInvitationIdError,
+    InvitationId,
+)
+
+
+class TestInvitationIdCreation:
+    """Tests para la creacion de InvitationId."""
+
+    def test_create_from_uuid(self):
+        """Crea InvitationId desde un objeto UUID."""
+        uid = uuid.uuid4()
+        invitation_id = InvitationId(uid)
+        assert invitation_id.value == uid
+
+    def test_create_from_string(self):
+        """Crea InvitationId desde un string UUID valido."""
+        uid = uuid.uuid4()
+        invitation_id = InvitationId(str(uid))
+        assert invitation_id.value == uid
+
+    def test_create_from_invalid_string_raises(self):
+        """String no-UUID lanza InvalidInvitationIdError."""
+        with pytest.raises(InvalidInvitationIdError):
+            InvitationId("not-a-uuid")
+
+    def test_create_from_empty_string_raises(self):
+        """String vacio lanza InvalidInvitationIdError."""
+        with pytest.raises(InvalidInvitationIdError):
+            InvitationId("")
+
+    def test_create_from_int_raises(self):
+        """Tipo no soportado lanza InvalidInvitationIdError."""
+        with pytest.raises(InvalidInvitationIdError):
+            InvitationId(123)
+
+    def test_create_from_none_raises(self):
+        """None lanza InvalidInvitationIdError."""
+        with pytest.raises(InvalidInvitationIdError):
+            InvitationId(None)
+
+
+class TestInvitationIdGenerate:
+    """Tests para el factory method generate."""
+
+    def test_generate_creates_valid_id(self):
+        """generate() crea un InvitationId valido."""
+        invitation_id = InvitationId.generate()
+        assert isinstance(invitation_id, InvitationId)
+        assert isinstance(invitation_id.value, uuid.UUID)
+
+    def test_generate_creates_unique_ids(self):
+        """generate() crea IDs unicos."""
+        id1 = InvitationId.generate()
+        id2 = InvitationId.generate()
+        assert id1 != id2
+
+
+class TestInvitationIdEquality:
+    """Tests para igualdad y hash."""
+
+    def test_same_uuid_are_equal(self):
+        """Dos InvitationId con el mismo UUID son iguales."""
+        uid = uuid.uuid4()
+        id1 = InvitationId(uid)
+        id2 = InvitationId(uid)
+        assert id1 == id2
+
+    def test_different_uuid_are_not_equal(self):
+        """Dos InvitationId con distinto UUID no son iguales."""
+        id1 = InvitationId.generate()
+        id2 = InvitationId.generate()
+        assert id1 != id2
+
+    def test_not_equal_to_other_type(self):
+        """InvitationId no es igual a otro tipo."""
+        invitation_id = InvitationId.generate()
+        assert invitation_id != "some-string"
+
+    def test_hash_consistency(self):
+        """IDs iguales tienen el mismo hash."""
+        uid = uuid.uuid4()
+        id1 = InvitationId(uid)
+        id2 = InvitationId(uid)
+        assert hash(id1) == hash(id2)
+
+    def test_usable_in_set(self):
+        """InvitationId puede usarse en sets."""
+        uid = uuid.uuid4()
+        id1 = InvitationId(uid)
+        id2 = InvitationId(uid)
+        assert len({id1, id2}) == 1
+
+
+class TestInvitationIdStr:
+    """Tests para representacion string."""
+
+    def test_str_returns_uuid_string(self):
+        """str() retorna el UUID como string."""
+        uid = uuid.uuid4()
+        invitation_id = InvitationId(uid)
+        assert str(invitation_id) == str(uid)
+
+
+class TestInvitationIdOrdering:
+    """Tests para comparacion."""
+
+    def test_lt_comparison(self):
+        """InvitationId soporta comparacion menor-que."""
+        id1 = InvitationId(uuid.UUID("00000000-0000-0000-0000-000000000001"))
+        id2 = InvitationId(uuid.UUID("00000000-0000-0000-0000-000000000002"))
+        assert id1 < id2
+
+    def test_lt_with_non_invitation_id(self):
+        """Comparar con otro tipo retorna NotImplemented."""
+        invitation_id = InvitationId.generate()
+        assert invitation_id.__lt__("string") is NotImplemented
+
+
+class TestInvitationIdFrozen:
+    """Tests para inmutabilidad."""
+
+    def test_is_frozen(self):
+        """InvitationId es inmutable (frozen dataclass)."""
+        invitation_id = InvitationId.generate()
+        with pytest.raises(AttributeError):
+            invitation_id.value = uuid.uuid4()

--- a/tests/unit/modules/competition/domain/value_objects/test_invitation_status.py
+++ b/tests/unit/modules/competition/domain/value_objects/test_invitation_status.py
@@ -1,0 +1,105 @@
+"""Tests para InvitationStatus Value Object."""
+
+from src.modules.competition.domain.value_objects.invitation_status import (
+    InvitationStatus,
+)
+
+
+class TestInvitationStatusValues:
+    """Tests para los valores del enum."""
+
+    def test_pending_value(self):
+        assert InvitationStatus.PENDING == "PENDING"
+
+    def test_accepted_value(self):
+        assert InvitationStatus.ACCEPTED == "ACCEPTED"
+
+    def test_declined_value(self):
+        assert InvitationStatus.DECLINED == "DECLINED"
+
+    def test_expired_value(self):
+        assert InvitationStatus.EXPIRED == "EXPIRED"
+
+    def test_has_four_states(self):
+        assert len(InvitationStatus) == 4
+
+
+class TestInvitationStatusTransitions:
+    """Tests para transiciones de estado."""
+
+    def test_pending_can_transition_to_accepted(self):
+        assert InvitationStatus.PENDING.can_transition_to(InvitationStatus.ACCEPTED)
+
+    def test_pending_can_transition_to_declined(self):
+        assert InvitationStatus.PENDING.can_transition_to(InvitationStatus.DECLINED)
+
+    def test_pending_can_transition_to_expired(self):
+        assert InvitationStatus.PENDING.can_transition_to(InvitationStatus.EXPIRED)
+
+    def test_pending_cannot_transition_to_pending(self):
+        assert not InvitationStatus.PENDING.can_transition_to(InvitationStatus.PENDING)
+
+    def test_accepted_cannot_transition(self):
+        """ACCEPTED es estado terminal."""
+        assert not InvitationStatus.ACCEPTED.can_transition_to(InvitationStatus.PENDING)
+        assert not InvitationStatus.ACCEPTED.can_transition_to(InvitationStatus.DECLINED)
+        assert not InvitationStatus.ACCEPTED.can_transition_to(InvitationStatus.EXPIRED)
+
+    def test_declined_cannot_transition(self):
+        """DECLINED es estado terminal."""
+        assert not InvitationStatus.DECLINED.can_transition_to(InvitationStatus.PENDING)
+        assert not InvitationStatus.DECLINED.can_transition_to(InvitationStatus.ACCEPTED)
+        assert not InvitationStatus.DECLINED.can_transition_to(InvitationStatus.EXPIRED)
+
+    def test_expired_cannot_transition(self):
+        """EXPIRED es estado terminal."""
+        assert not InvitationStatus.EXPIRED.can_transition_to(InvitationStatus.PENDING)
+        assert not InvitationStatus.EXPIRED.can_transition_to(InvitationStatus.ACCEPTED)
+        assert not InvitationStatus.EXPIRED.can_transition_to(InvitationStatus.DECLINED)
+
+
+class TestInvitationStatusQueries:
+    """Tests para metodos de consulta."""
+
+    def test_pending_is_pending(self):
+        assert InvitationStatus.PENDING.is_pending()
+
+    def test_accepted_is_not_pending(self):
+        assert not InvitationStatus.ACCEPTED.is_pending()
+
+    def test_declined_is_not_pending(self):
+        assert not InvitationStatus.DECLINED.is_pending()
+
+    def test_expired_is_not_pending(self):
+        assert not InvitationStatus.EXPIRED.is_pending()
+
+    def test_pending_is_not_final(self):
+        assert not InvitationStatus.PENDING.is_final()
+
+    def test_accepted_is_final(self):
+        assert InvitationStatus.ACCEPTED.is_final()
+
+    def test_declined_is_final(self):
+        assert InvitationStatus.DECLINED.is_final()
+
+    def test_expired_is_final(self):
+        assert InvitationStatus.EXPIRED.is_final()
+
+
+class TestInvitationStatusSemantics:
+    """Tests para verificar la semantica de los estados."""
+
+    def test_only_pending_allows_transitions(self):
+        """Solo PENDING permite transiciones a otros estados."""
+        for status in InvitationStatus:
+            if status == InvitationStatus.PENDING:
+                assert not status.is_final()
+            else:
+                assert status.is_final()
+
+    def test_all_terminal_states_have_no_transitions(self):
+        """Todos los estados terminales tienen 0 transiciones validas."""
+        terminal_states = [InvitationStatus.ACCEPTED, InvitationStatus.DECLINED, InvitationStatus.EXPIRED]
+        for state in terminal_states:
+            for target in InvitationStatus:
+                assert not state.can_transition_to(target)

--- a/tests/unit/modules/competition/infrastructure/persistence/test_in_memory_invitation_repository.py
+++ b/tests/unit/modules/competition/infrastructure/persistence/test_in_memory_invitation_repository.py
@@ -1,0 +1,323 @@
+"""Tests para InMemoryInvitationRepository."""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.invitation_id import InvitationId
+from src.modules.competition.domain.value_objects.invitation_status import (
+    InvitationStatus,
+)
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_invitation_repository import (
+    InMemoryInvitationRepository,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_invitation(
+    invitee_email="test@test.com",
+    competition_id=None,
+    inviter_id=None,
+    invitee_user_id=None,
+    status=InvitationStatus.PENDING,
+):
+    """Helper para crear invitaciones con reconstruccion."""
+    return Invitation.reconstruct(
+        id=InvitationId.generate(),
+        competition_id=competition_id or CompetitionId(uuid4()),
+        inviter_id=inviter_id or UserId(uuid4()),
+        invitee_email=invitee_email,
+        invitee_user_id=invitee_user_id,
+        status=status,
+        expires_at=datetime.now() + timedelta(days=7),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+class TestInMemoryInvitationRepositoryAdd:
+    """Tests para add()."""
+
+    async def test_add_and_find_by_id(self):
+        repo = InMemoryInvitationRepository()
+        invitation = _make_invitation()
+        await repo.add(invitation)
+        found = await repo.find_by_id(invitation.id)
+        assert found is not None
+        assert found.id == invitation.id
+
+    async def test_find_by_id_returns_none_for_nonexistent(self):
+        repo = InMemoryInvitationRepository()
+        found = await repo.find_by_id(InvitationId.generate())
+        assert found is None
+
+
+class TestInMemoryInvitationRepositoryUpdate:
+    """Tests para update()."""
+
+    async def test_update_existing(self):
+        repo = InMemoryInvitationRepository()
+        invitation = _make_invitation()
+        await repo.add(invitation)
+        invitation.accept()
+        await repo.update(invitation)
+        found = await repo.find_by_id(invitation.id)
+        assert found.status == InvitationStatus.ACCEPTED
+
+    async def test_update_nonexistent_does_nothing(self):
+        repo = InMemoryInvitationRepository()
+        invitation = _make_invitation()
+        await repo.update(invitation)
+        found = await repo.find_by_id(invitation.id)
+        assert found is None
+
+
+class TestInMemoryInvitationRepositoryFindByCompetition:
+    """Tests para find_by_competition()."""
+
+    async def test_find_by_competition_returns_matches(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv1 = _make_invitation(invitee_email="a@test.com", competition_id=comp_id)
+        inv2 = _make_invitation(invitee_email="b@test.com", competition_id=comp_id)
+        inv3 = _make_invitation(invitee_email="c@test.com")  # Different competition
+        await repo.add(inv1)
+        await repo.add(inv2)
+        await repo.add(inv3)
+
+        results = await repo.find_by_competition(comp_id)
+        assert len(results) == 2
+
+    async def test_find_by_competition_with_status_filter(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        pending = _make_invitation(invitee_email="a@test.com", competition_id=comp_id)
+        accepted = _make_invitation(
+            invitee_email="b@test.com",
+            competition_id=comp_id,
+            status=InvitationStatus.ACCEPTED,
+        )
+        await repo.add(pending)
+        await repo.add(accepted)
+
+        results = await repo.find_by_competition(comp_id, status=InvitationStatus.PENDING)
+        assert len(results) == 1
+        assert results[0].status == InvitationStatus.PENDING
+
+    async def test_find_by_competition_with_limit_offset(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        for i in range(5):
+            inv = _make_invitation(invitee_email=f"player{i}@test.com", competition_id=comp_id)
+            await repo.add(inv)
+
+        results = await repo.find_by_competition(comp_id, limit=2, offset=1)
+        assert len(results) == 2
+
+
+class TestInMemoryInvitationRepositoryFindByEmail:
+    """Tests para find_by_invitee_email()."""
+
+    async def test_find_by_email(self):
+        repo = InMemoryInvitationRepository()
+        inv = _make_invitation(invitee_email="test@example.com")
+        await repo.add(inv)
+
+        results = await repo.find_by_invitee_email("test@example.com")
+        assert len(results) == 1
+
+    async def test_find_by_email_normalizes(self):
+        repo = InMemoryInvitationRepository()
+        inv = _make_invitation(invitee_email="test@example.com")
+        await repo.add(inv)
+
+        results = await repo.find_by_invitee_email("  TEST@EXAMPLE.COM  ")
+        assert len(results) == 1
+
+    async def test_find_by_email_with_status_filter(self):
+        repo = InMemoryInvitationRepository()
+        pending = _make_invitation(invitee_email="test@example.com")
+        accepted = _make_invitation(
+            invitee_email="test@example.com",
+            status=InvitationStatus.ACCEPTED,
+        )
+        await repo.add(pending)
+        await repo.add(accepted)
+
+        results = await repo.find_by_invitee_email("test@example.com", status=InvitationStatus.PENDING)
+        assert len(results) == 1
+
+
+class TestInMemoryInvitationRepositoryFindByUserId:
+    """Tests para find_by_invitee_user_id()."""
+
+    async def test_find_by_user_id(self):
+        repo = InMemoryInvitationRepository()
+        user_id = UserId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", invitee_user_id=user_id)
+        await repo.add(inv)
+
+        results = await repo.find_by_invitee_user_id(user_id)
+        assert len(results) == 1
+
+    async def test_find_by_user_id_does_not_match_different(self):
+        repo = InMemoryInvitationRepository()
+        user_id = UserId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", invitee_user_id=user_id)
+        await repo.add(inv)
+
+        results = await repo.find_by_invitee_user_id(UserId(uuid4()))
+        assert len(results) == 0
+
+
+class TestInMemoryInvitationRepositoryFindPending:
+    """Tests para find_pending_by_email_and_competition()."""
+
+    async def test_find_pending_returns_match(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", competition_id=comp_id)
+        await repo.add(inv)
+
+        result = await repo.find_pending_by_email_and_competition("test@test.com", comp_id)
+        assert result is not None
+        assert result.id == inv.id
+
+    async def test_find_pending_returns_none_for_accepted(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv = _make_invitation(
+            invitee_email="test@test.com",
+            competition_id=comp_id,
+            status=InvitationStatus.ACCEPTED,
+        )
+        await repo.add(inv)
+
+        result = await repo.find_pending_by_email_and_competition("test@test.com", comp_id)
+        assert result is None
+
+    async def test_find_pending_normalizes_email(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", competition_id=comp_id)
+        await repo.add(inv)
+
+        result = await repo.find_pending_by_email_and_competition("  TEST@TEST.COM  ", comp_id)
+        assert result is not None
+
+    async def test_find_pending_returns_none_for_different_competition(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", competition_id=comp_id)
+        await repo.add(inv)
+
+        result = await repo.find_pending_by_email_and_competition("test@test.com", CompetitionId(uuid4()))
+        assert result is None
+
+
+class TestInMemoryInvitationRepositoryCounting:
+    """Tests para count_by_competition() y count_by_invitee()."""
+
+    async def test_count_by_competition(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv1 = _make_invitation(invitee_email="a@test.com", competition_id=comp_id)
+        inv2 = _make_invitation(invitee_email="b@test.com", competition_id=comp_id)
+        await repo.add(inv1)
+        await repo.add(inv2)
+
+        count = await repo.count_by_competition(comp_id)
+        assert count == 2
+
+    async def test_count_by_competition_with_status(self):
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+        inv1 = _make_invitation(invitee_email="a@test.com", competition_id=comp_id)
+        inv2 = _make_invitation(
+            invitee_email="b@test.com",
+            competition_id=comp_id,
+            status=InvitationStatus.ACCEPTED,
+        )
+        await repo.add(inv1)
+        await repo.add(inv2)
+
+        count = await repo.count_by_competition(comp_id, status=InvitationStatus.PENDING)
+        assert count == 1
+
+    async def test_count_by_competition_with_since_filter(self):
+        """Filtro 'since' excluye invitaciones antiguas."""
+        repo = InMemoryInvitationRepository()
+        comp_id = CompetitionId(uuid4())
+
+        # Invitacion reciente (hace 30 min)
+        recent = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=comp_id,
+            inviter_id=UserId(uuid4()),
+            invitee_email="recent@test.com",
+            status=InvitationStatus.PENDING,
+            expires_at=datetime.now() + timedelta(days=7),
+            created_at=datetime.now() - timedelta(minutes=30),
+            updated_at=datetime.now(),
+        )
+
+        # Invitacion antigua (hace 2 horas)
+        old = Invitation.reconstruct(
+            id=InvitationId.generate(),
+            competition_id=comp_id,
+            inviter_id=UserId(uuid4()),
+            invitee_email="old@test.com",
+            status=InvitationStatus.PENDING,
+            expires_at=datetime.now() + timedelta(days=7),
+            created_at=datetime.now() - timedelta(hours=2),
+            updated_at=datetime.now(),
+        )
+
+        await repo.add(recent)
+        await repo.add(old)
+
+        # Sin filtro: 2
+        count_all = await repo.count_by_competition(comp_id)
+        assert count_all == 2
+
+        # Con filtro ultima hora: solo 1
+        one_hour_ago = datetime.now() - timedelta(hours=1)
+        count_recent = await repo.count_by_competition(comp_id, since=one_hour_ago)
+        assert count_recent == 1
+
+    async def test_count_by_invitee_email(self):
+        repo = InMemoryInvitationRepository()
+        inv = _make_invitation(invitee_email="test@test.com")
+        await repo.add(inv)
+
+        count = await repo.count_by_invitee(email="test@test.com")
+        assert count == 1
+
+    async def test_count_by_invitee_user_id(self):
+        repo = InMemoryInvitationRepository()
+        user_id = UserId(uuid4())
+        inv = _make_invitation(invitee_email="test@test.com", invitee_user_id=user_id)
+        await repo.add(inv)
+
+        count = await repo.count_by_invitee(user_id=user_id)
+        assert count == 1
+
+    async def test_count_by_invitee_with_status(self):
+        repo = InMemoryInvitationRepository()
+        user_id = UserId(uuid4())
+        inv1 = _make_invitation(invitee_email="test@test.com", invitee_user_id=user_id)
+        inv2 = _make_invitation(
+            invitee_email="test@test.com",
+            invitee_user_id=user_id,
+            status=InvitationStatus.DECLINED,
+        )
+        await repo.add(inv1)
+        await repo.add(inv2)
+
+        count = await repo.count_by_invitee(user_id=user_id, status=InvitationStatus.PENDING)
+        assert count == 1

--- a/tests/unit/modules/competition/infrastructure/persistence/test_in_memory_unit_of_work_invitations.py
+++ b/tests/unit/modules/competition/infrastructure/persistence/test_in_memory_unit_of_work_invitations.py
@@ -1,0 +1,34 @@
+"""Tests para InMemoryUnitOfWork - invitations property."""
+
+import pytest
+
+from src.modules.competition.domain.repositories.invitation_repository_interface import (
+    InvitationRepositoryInterface,
+)
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+
+class TestInMemoryUnitOfWorkInvitations:
+    """Tests para verificar la property invitations del UoW."""
+
+    def setup_method(self):
+        self.uow = InMemoryUnitOfWork()
+
+    def test_invitations_property_returns_correct_interface(self):
+        """La property invitations retorna InvitationRepositoryInterface."""
+        assert isinstance(self.uow.invitations, InvitationRepositoryInterface)
+
+    @pytest.mark.asyncio
+    async def test_context_manager_with_invitations_repo(self):
+        """El UoW funciona como context manager con el repo de invitations."""
+        async with self.uow as uow:
+            assert uow.invitations is not None
+        assert self.uow.committed is True
+
+    def test_invitations_repo_is_same_instance(self):
+        """Multiples accesos retornan la misma instancia."""
+        repo1 = self.uow.invitations
+        repo2 = self.uow.invitations
+        assert repo1 is repo2


### PR DESCRIPTION
## Summary
- Complete Invitations module with 5 REST API endpoints for competition invitation management
- Full Clean Architecture implementation: domain entities, VOs, events, use cases, SQLAlchemy mappers, API routes
- Business logic rate limiting: max `max_players` invitations per hour per competition
- Auto-enrollment on invitation acceptance (creates APPROVED enrollment)
- On-read lazy expiration check for pending invitations

## Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/v1/competitions/{id}/invitations` | Send invitation by user ID |
| POST | `/api/v1/competitions/{id}/invitations/by-email` | Send invitation by email |
| GET | `/api/v1/invitations/me` | List my received invitations |
| POST | `/api/v1/invitations/{id}/respond` | Accept or decline invitation |
| GET | `/api/v1/competitions/{id}/invitations` | List competition invitations (creator/admin) |

## New Files (20+)
- **Domain**: Invitation entity, InvitationId/InvitationStatus VOs, 3 domain events, 6 violations
- **Application**: 5 use cases, 6 DTOs, 3 application exceptions
- **Infrastructure**: SQLAlchemy mapper + migration, 2 repository implementations, API routes, DI config

## Test plan
- [x] 201 new unit tests covering domain, application, and infrastructure layers
- [x] 1,641 total unit tests passing (0 failures)
- [x] Ruff linting clean
- [ ] Integration tests with real DB (deferred to next block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full competition invitations: send by user ID or email (optional personal message), list (paginated) as creator or recipient, and respond (accept/decline).
  * Accepting an invitation can create an enrollment; invitations auto-expire after 7 days.
  * Bilingual (ES/EN) invitation emails (non-blocking delivery), rate limits, and prevention of duplicate pending invites.

* **Chores**
  * Database migration to add invitations table and indexes.

* **Tests**
  * Extensive unit tests covering DTOs, domain, use cases, repositories, and API flows.

* **Documentation**
  * ROADMAP updated to reflect Invitations and Google OAuth completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->