### PR TITLE
chore(release): Merge hotfix security upgrades into develop

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,15 +10,12 @@ ignore:
   SNYK-PYTHON-SETUPTOOLS-7448482:
     - '*':
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2024-6345)'
-        expires: '2026-04-01T00:00:00.000Z'
   SNYK-PYTHON-SETUPTOOLS-3180412:
     - '*':
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2022-40897)'
-        expires: '2026-04-01T00:00:00.000Z'
   SNYK-PYTHON-SETUPTOOLS-9964606:
     - '*':
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2025-47273)'
-        expires: '2026-04-01T00:00:00.000Z'
 
 # Patch settings - none needed as all vulnerabilities are resolved via upgrades
 patch: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,9 @@ bcrypt==4.2.0
 # PyJWT - Librería para crear y verificar tokens JWT (JSON Web Tokens)
 # Alternativa activamente mantenida a python-jose, elimina dependencias vulnerables
 # (pyasn1, ecdsa). Soporte completo para HS256, RS256, etc.
-PyJWT==2.10.1
+# Actualizado a 2.12.0 para resolver:
+# - CVE HIGH: Improper Verification of Cryptographic Signature (CVSS 8.7)
+PyJWT==2.12.0
 
 # slowapi - Rate limiting para FastAPI
 # Protege contra brute force, DoS y abuso de API limitando peticiones por IP
@@ -103,7 +105,11 @@ filelock==3.20.3
 # - CVE-2025-61920 (DoS via large base64 tokens)
 # - CVE-2025-62706 (DoS via zip bomb decompression)
 # - CVE-2025-68158 (Login CSRF vulnerability - fixed in 1.6.6)
-authlib==1.6.6
+# Actualizado a 1.6.9 para resolver nuevas alertas Snyk:
+# - CRITICAL (CVSS 9.3): Improper Verification of Cryptographic Signature (x2, fixed in 1.6.7 + 1.6.9)
+# - HIGH (CVSS 8.7): Not Failing Securely - Failing Open (fixed in 1.6.9)
+# - HIGH (CVSS 8.3): Timing Attack (fixed in 1.6.9)
+authlib==1.6.9
 
 # setuptools - Build system y package installer (dependencia transitiva de safety)
 # Fijada explícitamente para resolver:
@@ -136,7 +142,9 @@ httpx==0.27.0
 
 # requests - Cliente HTTP síncrono estándar de Python
 # Utilizado para integración con servicios externos (Mailgun, RFEG)
-requests==2.32.4
+# Actualizado a 2.33.0 para resolver:
+# - MEDIUM (CVSS 4.1): Insecure Temporary File (CWE-377)
+requests==2.33.0
 
 # pytest - Framework de testing moderno y potente
 # Más simple que unittest, mejor output de errores, fixtures potentes

--- a/src/shared/infrastructure/http/sentry_middleware.py
+++ b/src/shared/infrastructure/http/sentry_middleware.py
@@ -25,9 +25,9 @@ OWASP Coverage:
 
 import logging
 
+import jwt
 import sentry_sdk
 from fastapi import Request
-import jwt
 from jwt.exceptions import InvalidTokenError
 from starlette.middleware.base import BaseHTTPMiddleware
 


### PR DESCRIPTION
## Summary

Propagates hotfix changes from `main` into `develop` following GitFlow.

Changes included:
- `authlib` 1.6.6 → 1.6.9 (4 Critical/High Snyk alerts resolved)
- `PyJWT` 2.10.1 → 2.12.0 (1 High Snyk alert resolved)
- `requests` 2.32.4 → 2.33.0 (1 Medium Snyk alert resolved)
- `.snyk`: removed `expires` from setuptools ignore entries
- `sentry_middleware.py`: fixed import ordering (Ruff I001)

Refs: #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated PyJWT, authlib, and requests dependencies to newer versions.
  * Removed expiration dates from security advisory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->