### PR TITLE
fix(scoring): Fix SINGLES WHS differential, leaderboard 0 points and MAX_SCORE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+**Scoring — Match Play Calculation (SINGLES)**
+
+- **SINGLES differential handicap**: `GenerateMatchesUseCase._build_singles_match_players()` now applies the WHS differential approach for Match Play, identical to FOURBALL and FOURSOMES. Only the higher-PH player receives strokes (the difference between both PHs), allocated on the hardest holes (lowest SI first). Previously both players received their individual PHs, causing strokes to cancel out on shared holes and fall on the wrong (less important) holes.
+- Individual Playing Handicap values are preserved in `MatchPlayer.playing_handicap` for scorecard display; only `strokes_received` reflects the differential.
+
+**Leaderboard — Points showing 0 for completed matches**
+
+- `GetLeaderboardUseCase`: Added defensive fallback — when a completed match has `winner=None` (invalid stored result), the use case now recomputes the result from hole scores via `_compute_decided_result()`. Prevents 0-point totals caused by manual match completion with an empty/invalid result.
+- `UpdateMatchStatusUseCase._handle_complete()`: Now validates that `result.winner` is `"A"`, `"B"`, or `"HALVED"` before persisting. Raises `InvalidActionError` for any other value, preventing corrupt results from being stored.
+
+### Changed
+
+- `HoleScore.MAX_SCORE`: Raised from 9 to 15 to support scores above 9 (accessible via the "Other..." option in the frontend number pad).
+- `SubmitHoleScoreBodyDTO`: Updated `own_score` and `marked_score` field validation from `le=9` to `le=15`.
+
 ### Added
 
 **Backward Competition State Transitions**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,18 @@
 # Roadmap - RyderCupFriends Backend
 
-> **Versión:** 2.0.14 | **Tests:** 1,902 unit + 256 integration (1 skipped) | **Endpoints:** 82 | **OWASP:** 9.4/10
+> **Versión:** 2.0.15 | **Tests:** 1,022 unit (branch) | **Endpoints:** 82 | **OWASP:** 9.4/10
 >
-> **Last Updated:** Feb 24, 2026
+> **Last Updated:** Jun 18, 2026
+
+---
+
+## En progreso: Bugfixes Scoring (branch `bugfix/scoring-matchplay-calculation`)
+
+### Correcciones producción ✅
+
+- **SINGLES WHS differential**: `_build_singles_match_players()` calcula strokes recibidos como diferencia de PHs. Solo el jugador con PH mayor recibe golpes (= PH_alto − PH_bajo) en los hoyos más difíciles (menor SI primero). PH individual preservado para visualización.
+- **Leaderboard 0 puntos**: `GetLeaderboardUseCase` valida el campo `winner` almacenado; si es nulo o inválido, recalcula el resultado desde los scores. `UpdateMatchStatusUseCase` exige `winner ∈ {A, B, HALVED}` al completar un partido.
+- **MAX_SCORE 9 → 15**: `HoleScore.set_own_score()`, `set_marker_score()` y `SubmitHoleScoreBodyDTO` aceptan hasta 15 golpes (panel numérico frontend permite entrada manual).
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ fastapi==0.136.3
 
 # starlette - ASGI framework (dependencia transitiva de fastapi)
 # Pinado explícitamente a 1.3.1 para resolver:
-# - PYSEC-2026-161 (HTTP Request Smuggling, fixed in 1.0.1)
-# - CVE-2026-54282 (fixed in 1.3.0)
+# - PYSEC-2026-161 (Host header validation, fixed in 1.0.1)
+# - CVE-2026-54282 (fixed in 1.3.1)
 # - CVE-2026-54283 (fixed in 1.3.1)
 starlette==1.3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,11 @@
 fastapi==0.136.3
 
 # starlette - ASGI framework (dependencia transitiva de fastapi)
-# Pinado explícitamente a 1.2.1 para resolver PYSEC-2026-161 (HTTP Request Smuggling)
-# Fix disponible desde 1.0.1; fastapi 0.136.3 es compatible con starlette 1.x
-starlette==1.2.1
+# Pinado explícitamente a 1.3.1 para resolver:
+# - PYSEC-2026-161 (HTTP Request Smuggling, fixed in 1.0.1)
+# - CVE-2026-54282 (fixed in 1.3.0)
+# - CVE-2026-54283 (fixed in 1.3.1)
+starlette==1.3.1
 
 # Uvicorn - Servidor ASGI de alto rendimiento para ejecutar aplicaciones FastAPI
 # [standard] incluye extras: watchfiles (auto-reload), websockets, colorama (logs coloridos)

--- a/src/modules/competition/application/dto/scoring_dto.py
+++ b/src/modules/competition/application/dto/scoring_dto.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel, Field
 class SubmitHoleScoreBodyDTO(BaseModel):
     """Body del request para registrar score de un hoyo."""
 
-    own_score: int | None = Field(None, ge=1, le=9)
+    own_score: int | None = Field(None, ge=1, le=15)
     marked_player_id: str
-    marked_score: int | None = Field(None, ge=1, le=9)
+    marked_score: int | None = Field(None, ge=1, le=15)
 
 
 class RoundInfoDTO(BaseModel):

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -293,21 +293,14 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index, user_gender_map,
                 )
             else:
-                # SINGLES: allowance individual por jugador
-                team_a_match_players = [
-                    self._build_match_player(
-                        uid, enrollment_map, tee_ratings, calculator, allowance,
-                        is_scratch, user_handicap_map, holes_by_stroke_index, user_gender_map,
-                    )
-                    for uid in a_players_ids
-                ]
-                team_b_match_players = [
-                    self._build_match_player(
-                        uid, enrollment_map, tee_ratings, calculator, allowance,
-                        is_scratch, user_handicap_map, holes_by_stroke_index, user_gender_map,
-                    )
-                    for uid in b_players_ids
-                ]
+                # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
+                a_player, b_player = self._build_singles_match_players(
+                    a_players_ids[0], b_players_ids[0], enrollment_map, tee_ratings,
+                    calculator, allowance, is_scratch, user_handicap_map,
+                    holes_by_stroke_index, user_gender_map,
+                )
+                team_a_match_players = [a_player]
+                team_b_match_players = [b_player]
 
             match = Match.create(
                 round_id=round_entity.id,
@@ -367,21 +360,14 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index, user_gender_map,
                 )
             else:
-                # SINGLES: allowance individual por jugador
-                team_a_match_players = [
-                    self._build_match_player(
-                        uid, enrollment_map, tee_ratings, calculator, allowance,
-                        is_scratch, user_handicap_map, holes_by_stroke_index, user_gender_map,
-                    )
-                    for uid in a_ids
-                ]
-                team_b_match_players = [
-                    self._build_match_player(
-                        uid, enrollment_map, tee_ratings, calculator, allowance,
-                        is_scratch, user_handicap_map, holes_by_stroke_index, user_gender_map,
-                    )
-                    for uid in b_ids
-                ]
+                # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
+                a_player, b_player = self._build_singles_match_players(
+                    a_ids[0], b_ids[0], enrollment_map, tee_ratings,
+                    calculator, allowance, is_scratch, user_handicap_map,
+                    holes_by_stroke_index, user_gender_map,
+                )
+                team_a_match_players = [a_player]
+                team_b_match_players = [b_player]
 
             match = Match.create(
                 round_id=round_entity.id,
@@ -565,6 +551,85 @@ class GenerateMatchesUseCase:
         team_a_players = [build_player(uid) for uid in team_a_ids]
         team_b_players = [build_player(uid) for uid in team_b_ids]
         return team_a_players, team_b_players
+
+    def _build_singles_match_players(
+        self,
+        a_player_id,
+        b_player_id,
+        enrollment_map,
+        tee_ratings,
+        calculator,
+        allowance,
+        is_scratch,
+        user_handicap_map,
+        holes_by_stroke_index,
+        user_gender_map,
+    ) -> tuple["MatchPlayer", "MatchPlayer"]:
+        """
+        Construye MatchPlayers para SINGLES usando el método diferencial WHS.
+
+        WHS Match Play: solo el jugador con mayor Playing Handicap recibe golpes.
+        Los golpes recibidos = (PH_alto - PH_bajo) en los hoyos más difíciles (menor SI).
+        El jugador con menor PH juega off scratch (0 golpes recibidos).
+        El PH individual de cada jugador se conserva en playing_handicap para display.
+
+        Returns:
+            (match_player_a, match_player_b)
+        """
+        tee_cat_a, tee_gen_a, tee_rating_a, hi_a = self._resolve_player_data(
+            a_player_id, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
+        )
+        tee_cat_b, tee_gen_b, tee_rating_b, hi_b = self._resolve_player_data(
+            b_player_id, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
+        )
+
+        if is_scratch:
+            return (
+                MatchPlayer.create(
+                    user_id=a_player_id, playing_handicap=0, tee_category=tee_cat_a,
+                    strokes_received=[], tee_gender=tee_gen_a,
+                ),
+                MatchPlayer.create(
+                    user_id=b_player_id, playing_handicap=0, tee_category=tee_cat_b,
+                    strokes_received=[], tee_gender=tee_gen_b,
+                ),
+            )
+
+        if not tee_rating_a:
+            raise TeeCategoryNotFoundError(
+                f"No se encontró tee rating para categoría '{tee_cat_a.value}' "
+                f"(gender: {tee_gen_a}) en el campo de golf"
+            )
+        if not tee_rating_b:
+            raise TeeCategoryNotFoundError(
+                f"No se encontró tee rating para categoría '{tee_cat_b.value}' "
+                f"(gender: {tee_gen_b}) en el campo de golf"
+            )
+
+        ph_a = calculator.calculate(hi_a, tee_rating_a, allowance)
+        ph_b = calculator.calculate(hi_b, tee_rating_b, allowance)
+
+        diff = ph_a - ph_b
+        if diff > 0:
+            strokes_a = calculator.compute_strokes_received(diff, holes_by_stroke_index)
+            strokes_b: list[int] = []
+        elif diff < 0:
+            strokes_a = []
+            strokes_b = calculator.compute_strokes_received(-diff, holes_by_stroke_index)
+        else:
+            strokes_a = []
+            strokes_b = []
+
+        return (
+            MatchPlayer.create(
+                user_id=a_player_id, playing_handicap=ph_a, tee_category=tee_cat_a,
+                strokes_received=strokes_a, tee_gender=tee_gen_a,
+            ),
+            MatchPlayer.create(
+                user_id=b_player_id, playing_handicap=ph_b, tee_category=tee_cat_b,
+                strokes_received=strokes_b, tee_gender=tee_gen_b,
+            ),
+        )
 
     def _build_foursomes_match_players(
         self,

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -280,7 +280,23 @@ class GenerateMatchesUseCase:
             a_players_ids = team_a_ids[start:end]
             b_players_ids = team_b_ids[start:end]
 
-            if match_format == MatchFormat.FOURBALL:
+            if match_format == MatchFormat.SINGLES:
+                # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
+                a_player, b_player = self._build_singles_match_players(
+                    a_players_ids[0],
+                    b_players_ids[0],
+                    enrollment_map,
+                    tee_ratings,
+                    calculator,
+                    allowance,
+                    is_scratch,
+                    user_handicap_map,
+                    holes_by_stroke_index,
+                    user_gender_map,
+                )
+                team_a_match_players = [a_player]
+                team_b_match_players = [b_player]
+            elif match_format == MatchFormat.FOURBALL:
                 team_a_match_players, team_b_match_players = self._build_fourball_match_players(
                     a_players_ids,
                     b_players_ids,
@@ -307,22 +323,7 @@ class GenerateMatchesUseCase:
                     user_gender_map,
                 )
             else:
-                # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
-                a_player, b_player = self._build_singles_match_players(
-                    a_players_ids[0],
-                    b_players_ids[0],
-                    enrollment_map,
-                    tee_ratings,
-                    calculator,
-                    allowance,
-                    is_scratch,
-                    user_handicap_map,
-                    holes_by_stroke_index,
-                    user_gender_map,
-                )
-                team_a_match_players = [a_player]
-                team_b_match_players = [b_player]
-
+                raise ValueError(f"Formato de partido no soportado: {match_format.value}")
             match = Match.create(
                 round_id=round_entity.id,
                 match_number=i + 1,
@@ -394,7 +395,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                 )
-            else:
+            elif match_format == MatchFormat.SINGLES:
                 # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
                 a_player, b_player = self._build_singles_match_players(
                     a_ids[0],
@@ -410,6 +411,8 @@ class GenerateMatchesUseCase:
                 )
                 team_a_match_players = [a_player]
                 team_b_match_players = [b_player]
+            else:
+                raise ValueError(f"Formato de partido no soportado: {match_format.value}")
 
             match = Match.create(
                 round_id=round_entity.id,

--- a/src/modules/competition/application/use_cases/get_leaderboard_use_case.py
+++ b/src/modules/competition/application/use_cases/get_leaderboard_use_case.py
@@ -74,8 +74,17 @@ class GetLeaderboardUseCase:
                     result_dto = None
 
                     if match.is_finished() and match.result:
+                        stored_winner = match.result.get("winner")
+                        if stored_winner in ("A", "B", "HALVED"):
+                            score_result = match.result
+                        else:
+                            # Fallback: recalculate from hole scores when winner is invalid
+                            score_result = await self._compute_decided_result(
+                                match, round_entity.match_format
+                            ) or {"winner": "HALVED", "score": "AS"}
+
                         points = self._scoring_service.calculate_ryder_cup_points(
-                            match.result, match.status.value
+                            score_result, match.status.value
                         )
                         total_a_points += points["team_a"]
                         total_b_points += points["team_b"]

--- a/src/modules/competition/application/use_cases/get_leaderboard_use_case.py
+++ b/src/modules/competition/application/use_cases/get_leaderboard_use_case.py
@@ -72,11 +72,13 @@ class GetLeaderboardUseCase:
                     result_dto = None
 
                     if match.is_finished() and match.result:
-                        stored_winner = match.result.get("winner")
-                        if stored_winner in ("A", "B", "HALVED"):
-                            score_result = match.result
-                        else:
-                            # Fallback: recalculate from hole scores when winner is invalid
+                        score_result = None
+                        if isinstance(match.result, dict) and match.result:
+                            stored_winner = match.result.get("winner")
+                            if stored_winner in ("A", "B", "HALVED"):
+                                score_result = match.result
+
+                        if not score_result:
                             score_result = await self._compute_decided_result(
                                 match, round_entity.match_format
                             ) or {"winner": "HALVED", "score": "AS"}

--- a/src/modules/competition/application/use_cases/update_match_status_use_case.py
+++ b/src/modules/competition/application/use_cases/update_match_status_use_case.py
@@ -129,6 +129,11 @@ class UpdateMatchStatusUseCase:
         """Ejecuta COMPLETE: match.complete() + auto-complete round."""
         if request.result is None:
             raise InvalidActionError("Se requiere 'result' para completar un partido")
+        winner = request.result.get("winner") if isinstance(request.result, dict) else None
+        if winner not in ("A", "B", "HALVED"):
+            raise InvalidActionError(
+                "El resultado debe incluir 'winner' con valor 'A', 'B' o 'HALVED'"
+            )
         try:
             match.complete(request.result)
         except ValueError as e:

--- a/src/modules/competition/domain/entities/hole_score.py
+++ b/src/modules/competition/domain/entities/hole_score.py
@@ -15,7 +15,7 @@ from src.modules.competition.domain.value_objects.validation_status import (
 from src.modules.user.domain.value_objects.user_id import UserId
 
 MIN_SCORE = 1
-MAX_SCORE = 9
+MAX_SCORE = 15
 MIN_HOLE = 1
 MAX_HOLE = 18
 

--- a/src/modules/competition/domain/entities/hole_score.py
+++ b/src/modules/competition/domain/entities/hole_score.py
@@ -33,7 +33,7 @@ class HoleScore:
     Invariantes:
     - hole_number debe estar entre 1 y 18
     - team debe ser "A" o "B"
-    - Scores deben estar entre 1-9 o None (picked up)
+    - Scores deben estar entre 1 y 15 o None (picked up)
     - strokes_received debe ser >= 0 (normalmente 0-2, puede ser > 1 si PH > 18)
     """
 

--- a/tests/unit/modules/competition/application/dto/test_scoring_dto.py
+++ b/tests/unit/modules/competition/application/dto/test_scoring_dto.py
@@ -48,8 +48,8 @@ class TestSubmitHoleScoreBodyDTO:
         assert dto.own_score == 1
 
     def test_max_score(self):
-        dto = SubmitHoleScoreBodyDTO(own_score=9, marked_player_id="abc", marked_score=9)
-        assert dto.own_score == 9
+        dto = SubmitHoleScoreBodyDTO(own_score=15, marked_player_id="abc", marked_score=15)
+        assert dto.own_score == 15
 
 
 class TestScoringViewResponseDTO:

--- a/tests/unit/modules/competition/application/dto/test_scoring_dto.py
+++ b/tests/unit/modules/competition/application/dto/test_scoring_dto.py
@@ -39,9 +39,9 @@ class TestSubmitHoleScoreBodyDTO:
         with pytest.raises(ValidationError):
             SubmitHoleScoreBodyDTO(own_score=0, marked_player_id="abc", marked_score=5)
 
-    def test_score_above_9_raises(self):
+    def test_score_above_max_raises(self):
         with pytest.raises(ValidationError):
-            SubmitHoleScoreBodyDTO(own_score=10, marked_player_id="abc", marked_score=5)
+            SubmitHoleScoreBodyDTO(own_score=16, marked_player_id="abc", marked_score=5)
 
     def test_min_score(self):
         dto = SubmitHoleScoreBodyDTO(own_score=1, marked_player_id="abc", marked_score=1)

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -827,6 +827,83 @@ class TestGenerateMatchesUseCase:
             "Strokes must fall on the hardest holes (lowest SI first)"
         )
 
+    async def test_singles_differential_strokes_only_higher_ph_receives_reversed(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica el método diferencial WHS para SINGLES con los handicaps invertidos.
+
+        Given: Jugador A con HI=9 (PH bajo) vs jugador B con HI=18 (PH alto),
+               campo par 72, slope 113, course_rating 72.0 (CH = HI), allowance 100%
+        When: Se genera el partido SINGLES
+        Then: Solo el jugador con mayor PH (B) recibe golpes (la diferencia).
+              El jugador con menor PH (A) no recibe ningún golpe.
+              El numero de golpes del jugador B = PH_B - PH_A
+        """
+        # Arrange
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        team_a_ids, team_b_ids = await self._create_teams_and_enrollments_with_tees(
+            uow, competition, 1, 1, TeeCategory.AMATEUR
+        )
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        # A tiene HI=9, B tiene HI=18 → diferencial = 9 golpes para B
+        handicap_by_uid = {
+            str(team_a_ids[0].value): 9.0,
+            str(team_b_ids[0].value): 18.0,
+        }
+
+        async def mock_find_user(uid):
+            hc = handicap_by_uid.get(str(uid.value), 0.0)
+            return self._build_mock_user(uid, hc, Gender.MALE)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        # Act
+        response = await use_case.execute(request, creator_id)
+
+        # Assert
+        assert response.matches_generated == 1
+        matches = await uow.matches.find_by_round(round_entity.id)
+        assert len(matches) == 1
+        m = matches[0]
+
+        player_a = m.team_a_players[0]
+        player_b = m.team_b_players[0]
+
+        # PH individuales: B tiene mayor PH
+        assert player_b.playing_handicap > player_a.playing_handicap
+
+        # Solo el jugador con mayor PH (B) recibe golpes (el diferencial)
+        diff = player_b.playing_handicap - player_a.playing_handicap
+        assert len(player_b.strokes_received) == diff, (
+            "Higher-PH player (B) should receive exactly (PH_B - PH_A) strokes"
+        )
+        assert len(player_a.strokes_received) == 0, (
+            "Lower-PH player (A) must receive 0 strokes in WHS match play"
+        )
+
+        # Los golpes caen en los hoyos con menor stroke index (más difíciles)
+        expected_holes = list(range(1, diff + 1))
+        assert sorted(player_b.strokes_received) == expected_holes, (
+            "Strokes must fall on the hardest holes (lowest SI first)"
+        )
+
     async def test_should_use_custom_handicap_over_user_handicap(
         self,
         uow: InMemoryUnitOfWork,

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -695,11 +695,12 @@ class TestGenerateMatchesUseCase:
         user_repo: AsyncMock,
     ):
         """
-        Verifica que en modo HANDICAP se calculan playing_handicap y strokes_received.
+        Verifica que en modo HANDICAP se calculan playing_handicap usando metodo diferencial WHS.
 
-        Given: Competicion HANDICAP con campo de golf (AMATEUR tee) y jugadores con handicap
-        When: Se generan partidos automaticamente
-        Then: Todos los jugadores tienen playing_handicap > 0 y strokes_received no vacio
+        Given: Competicion HANDICAP, jugadores con mismo handicap (HI=15)
+        When: Se generan partidos SINGLES automaticamente
+        Then: Ambos jugadores tienen playing_handicap > 0 (PH individual para display),
+              pero ninguno recibe golpes (diferencial = 0 cuando PHs son iguales).
         """
         # Arrange
         competition = await self._create_handicap_competition(uow, creator_id)
@@ -714,7 +715,7 @@ class TestGenerateMatchesUseCase:
         mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
         gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
 
-        # Mock user_repo para devolver usuarios con handicap
+        # Todos los jugadores con el mismo handicap → diferencial = 0
         async def mock_find_user(uid):
             return self._build_mock_user(uid, 15.0)
 
@@ -735,16 +736,96 @@ class TestGenerateMatchesUseCase:
         matches = await uow.matches.find_by_round(round_entity.id)
         assert len(matches) == 2
         for m in matches:
-            for p in m.team_a_players:
+            # PH individual se conserva para display aunque diferencial sea 0
+            for p in (*m.team_a_players, *m.team_b_players):
                 assert p.playing_handicap > 0, (
                     "HANDICAP mode should produce non-zero playing_handicap"
                 )
-                assert len(p.strokes_received) > 0, "HANDICAP mode should produce strokes_received"
-            for p in m.team_b_players:
-                assert p.playing_handicap > 0, (
-                    "HANDICAP mode should produce non-zero playing_handicap"
-                )
-                assert len(p.strokes_received) > 0, "HANDICAP mode should produce strokes_received"
+            # Igual PH → diferencial = 0 → nadie recibe golpes (WHS match play correcto)
+            total_strokes = sum(
+                len(p.strokes_received) for p in (*m.team_a_players, *m.team_b_players)
+            )
+            assert total_strokes == 0, (
+                "Equal PHs → differential = 0 → no strokes for either player"
+            )
+
+    async def test_singles_differential_strokes_only_higher_ph_receives(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica el método diferencial WHS para SINGLES match play.
+
+        Given: Jugador A con HI=18 (PH alto) vs jugador B con HI=9 (PH bajo),
+               campo par 72, slope 113, course_rating 72.0 (CH = HI), allowance 100%
+        When: Se genera el partido SINGLES
+        Then: Solo el jugador con mayor PH recibe golpes (la diferencia).
+              El jugador con menor PH no recibe ningún golpe.
+              El numero de golpes del jugador A = PH_A - PH_B
+        """
+        # Arrange
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        team_a_ids, team_b_ids = await self._create_teams_and_enrollments_with_tees(
+            uow, competition, 1, 1, TeeCategory.AMATEUR
+        )
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        # A tiene HI=18, B tiene HI=9 → diferencial = 9 golpes para A
+        handicap_by_uid = {
+            str(team_a_ids[0].value): 18.0,
+            str(team_b_ids[0].value): 9.0,
+        }
+
+        async def mock_find_user(uid):
+            hc = handicap_by_uid.get(str(uid.value), 0.0)
+            return self._build_mock_user(uid, hc, Gender.MALE)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        # Act
+        response = await use_case.execute(request, creator_id)
+
+        # Assert
+        assert response.matches_generated == 1
+        matches = await uow.matches.find_by_round(round_entity.id)
+        assert len(matches) == 1
+        m = matches[0]
+
+        player_a = m.team_a_players[0]
+        player_b = m.team_b_players[0]
+
+        # PH individuales se conservan para display
+        assert player_a.playing_handicap > player_b.playing_handicap
+
+        # Solo el jugador con mayor PH recibe golpes (el diferencial)
+        diff = player_a.playing_handicap - player_b.playing_handicap
+        assert len(player_a.strokes_received) == diff, (
+            "Higher-PH player should receive exactly (PH_A - PH_B) strokes"
+        )
+        assert len(player_b.strokes_received) == 0, (
+            "Lower-PH player must receive 0 strokes in WHS match play"
+        )
+
+        # Los golpes caen en los hoyos con menor stroke index (más difíciles)
+        # El campo de mock tiene SI 1..18, por lo que los primeros `diff` hoyos reciben golpe
+        expected_holes = list(range(1, diff + 1))
+        assert sorted(player_a.strokes_received) == expected_holes, (
+            "Strokes must fall on the hardest holes (lowest SI first)"
+        )
 
     async def test_should_use_custom_handicap_over_user_handicap(
         self,

--- a/tests/unit/modules/competition/domain/entities/test_hole_score.py
+++ b/tests/unit/modules/competition/domain/entities/test_hole_score.py
@@ -133,6 +133,13 @@ class TestHoleScoreSetOwnScore:
         with pytest.raises(ValueError, match="Score must be between"):
             hs.set_own_score(16)
 
+    def test_set_own_score_max_accepted(self, match_id, player_id):
+        """Boundary: score of 15 (MAX_SCORE) must be accepted."""
+        hs = _create_hole_score(match_id, player_id)
+        hs.set_own_score(15)
+        assert hs.own_score == 15
+        assert hs.own_submitted is True
+
     def test_set_own_score_overwrites(self, match_id, player_id):
         """Puede sobrescribir score existente."""
         hs = _create_hole_score(match_id, player_id)
@@ -165,6 +172,13 @@ class TestHoleScoreSetMarkerScore:
         hs = _create_hole_score(match_id, player_id)
         with pytest.raises(ValueError, match="Score must be between"):
             hs.set_marker_score(16)
+
+    def test_set_marker_score_max_accepted(self, match_id, player_id):
+        """Boundary: marker score of 15 (MAX_SCORE) must be accepted."""
+        hs = _create_hole_score(match_id, player_id)
+        hs.set_marker_score(15)
+        assert hs.marker_score == 15
+        assert hs.marker_submitted is True
 
 
 class TestHoleScoreValidation:

--- a/tests/unit/modules/competition/domain/entities/test_hole_score.py
+++ b/tests/unit/modules/competition/domain/entities/test_hole_score.py
@@ -128,10 +128,10 @@ class TestHoleScoreSetOwnScore:
         with pytest.raises(ValueError, match="Score must be between"):
             hs.set_own_score(0)
 
-    def test_set_own_score_10_raises(self, match_id, player_id):
+    def test_set_own_score_above_max_raises(self, match_id, player_id):
         hs = _create_hole_score(match_id, player_id)
         with pytest.raises(ValueError, match="Score must be between"):
-            hs.set_own_score(10)
+            hs.set_own_score(16)
 
     def test_set_own_score_overwrites(self, match_id, player_id):
         """Puede sobrescribir score existente."""
@@ -161,10 +161,10 @@ class TestHoleScoreSetMarkerScore:
         with pytest.raises(ValueError, match="Score must be between"):
             hs.set_marker_score(0)
 
-    def test_set_marker_score_10_raises(self, match_id, player_id):
+    def test_set_marker_score_above_max_raises(self, match_id, player_id):
         hs = _create_hole_score(match_id, player_id)
         with pytest.raises(ValueError, match="Score must be between"):
-            hs.set_marker_score(10)
+            hs.set_marker_score(16)
 
 
 class TestHoleScoreValidation:


### PR DESCRIPTION
## Summary

- **SINGLES handicap**: fixed WHS match play differential — only the higher-PH player receives strokes equal to the PH difference, allocated on the hardest holes (lowest SI first). Previously both players received their individual PHs, causing strokes to fall on the wrong holes.
- **Leaderboard showing 0 points**: `GetLeaderboardUseCase` now validates the stored `winner` field and recomputes the result from hole scores when null. `UpdateMatchStatusUseCase` now enforces `winner ∈ {A, B, HALVED}` before persisting a completed match.
- **MAX_SCORE 9 → 15**: `HoleScore`, `SubmitHoleScoreBodyDTO` and affected tests updated to support scores up to 15 (frontend numpad manual entry).

## Test plan

- [ ] Generate SINGLES matches with players of different handicap (e.g. HI=18 vs HI=9) — verify only the higher-PH player receives strokes on the lowest SI holes
- [ ] Manually complete a match from the creator UI — leaderboard must show correct points (not 0)
- [ ] Attempt to submit score=16 via the API — must return 422
- [ ] `source .venv/bin/activate && pytest tests/unit/ -q` → 1022 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed leaderboard generation to safely handle completed matches with missing/invalid winner data by recomputing results.
  * Added stronger validation when completing a match to prevent saving invalid or corrupt match outcomes.

* **Enhancements**
  * Increased maximum hole score limit from 9 to 15 (including submission validation).
  * Updated Singles Handicap scoring: strokes are now allocated only to the higher playing handicap player, using the WHS differential approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->