### PR TITLE
feat(scoring): Scoring improvements, max playing handicap cap, and admin bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+**Login — Handicap Refresh Not Prompted for Non-Spanish Users (HM-2)**
+
+- `LoginUserUseCase`: `needs_handicap` was only ever computed inside the `country_code == "ES"` branch, so non-Spanish users (or users without a `country_code`) never got prompted to enter their handicap, even though the frontend `HandicapRequestModal` already had a "manual" tab built for exactly that case.
+- New behavior: on every login, if the handicap wasn't already refreshed **today** (`handicap_updated_at.date() != today`), Spanish users get an automatic, silent RFEG lookup; everyone else (non-ES, no country, or failed/empty RFEG result) gets `needs_handicap=True` so the frontend shows the modal.
+- Extracted the refresh logic into `LoginUserUseCase._refresh_handicap()` to keep `execute()` within complexity limits.
+- 2 existing tests updated (`test_non_es_user_no_rfeg_call_needs_handicap_true`, `test_no_country_user_needs_handicap_true`) to assert the corrected behavior; 2 new tests added for the daily-refresh gate.
+
 **Scoring — Best Ball Player Determinism (FOURBALL)**
 
 - `SQLAlchemyHoleScoreRepository.find_by_match()`: Added secondary `ORDER BY _player_user_id ASC` to guarantee consistent row order within each hole. Previously, when two players on the same team had equal net scores, PostgreSQL could return their rows in non-deterministic physical order after updates/vacuums, causing `find_best_ball_player()` to return a different player on each request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Affected routes: `GET /scoring-view`, `POST /scores/holes/{n}`, `POST /scorecard/submit`, `PUT /concede`.
 - Admin creator-bypass extended to `CreateRoundUseCase`, `DirectEnrollPlayerUseCase`, `HandleEnrollmentUseCase` (approve/reject), `SetCustomHandicapUseCase`, and `SendInvitationByUserIdUseCase`: admins can now perform these actions on any competition without being its creator.
 
+**Enrollment — Revert Custom Handicap to RFEG**
+
+- New endpoint `DELETE /api/v1/enrollments/{enrollment_id}/handicap` + `RemoveCustomHandicapUseCase`: lets the creator (or an admin) clear a player's custom handicap, reverting the enrollment to using their official (RFEG-sourced) handicap.
+- `CompetitionStatus.allows_handicap_edits()`: setting **and** removing a custom handicap are now restricted to competitions in `DRAFT`, `ACTIVE`, or `CLOSED` — once a competition reaches `IN_PROGRESS` (matches already generated and handicaps snapshotted), neither action is allowed. Raises `HandicapEditNotAllowedError` (400) otherwise. Applied to both `SetCustomHandicapUseCase` and the new `RemoveCustomHandicapUseCase`.
+- Frontend: the revert-to-RFEG button only appears inside the handicap edit form, and only for enrollments with a custom handicap belonging to Spanish players (`country_code == "ES"`), since RFEG only covers Spain.
+
 ---
 
 ## [2.0.16] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - All scoring routes now accept an admin user regardless of whether they are a player in the match. Check updated from "user must be in match" to "user must be in match OR is_admin".
 - Affected routes: `GET /scoring-view`, `POST /scores/holes/{n}`, `POST /scorecard/submit`, `PUT /concede`.
+- Admin creator-bypass extended to `CreateRoundUseCase`, `DirectEnrollPlayerUseCase`, `HandleEnrollmentUseCase` (approve/reject), `SetCustomHandicapUseCase`, and `SendInvitationByUserIdUseCase`: admins can now perform these actions on any competition without being its creator.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [Unreleased] — feature/scoring-improvements
+
+### Fixed
+
+**Scoring — Best Ball Player Determinism (FOURBALL)**
+
+- `SQLAlchemyHoleScoreRepository.find_by_match()`: Added secondary `ORDER BY _player_user_id ASC` to guarantee consistent row order within each hole. Previously, when two players on the same team had equal net scores, PostgreSQL could return their rows in non-deterministic physical order after updates/vacuums, causing `find_best_ball_player()` to return a different player on each request.
+- `ScoringService.find_best_ball_player()`: When two players on the same team tie on net score, the method now returns **both player IDs** (as a list) instead of a single ID. The DTO field `best_ball_player_a` / `best_ball_player_b` becomes a list to support the "Nombre1 y Nombre2" display in the frontend.
+
+**Scoring — Leaderboard Result for Halved Matches**
+
+- `calculate_match_result()`: When a match finishes AS (All Square), `winner` is now set to `"HALVED"` and `score` to `"AS"`. The frontend was previously displaying "Equipo X gana AS" because a non-empty `winner` string always triggered the `wins` translation key.
+
+### Added
+
+**Competition — Playing Handicap Limit**
+
+- New optional field `max_playing_handicap: int | None` on the `Competition` entity. When set, `PlayingHandicapCalculator.calculate()` caps the result at this value before returning it.
+- Alembic migration: adds nullable column `max_playing_handicap INTEGER` to `competitions` table.
+- `CompetitionRequestDTO` / `CompetitionResponseDTO`: includes new field with validation `ge=1, le=54`.
+- `CreateCompetitionUseCase` / `UpdateCompetitionUseCase`: propagate the new field.
+- API: `POST /api/v1/competitions` and `PUT /api/v1/competitions/{id}` accept `max_playing_handicap`.
+
+**Admin — Full Access to Scoring and Match Actions**
+
+- All scoring routes now accept an admin user regardless of whether they are a player in the match. Check updated from "user must be in match" to "user must be in match OR is_admin".
+- Affected routes: `GET /scoring-view`, `POST /scores/holes/{n}`, `POST /scorecard/submit`, `PUT /concede`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Version](https://img.shields.io/badge/version-2.0.14-blue?style=for-the-badge&logo=semver)](.)
+[![Version](https://img.shields.io/badge/version-2.0.17-blue?style=for-the-badge&logo=semver)](.)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12-3776AB?style=for-the-badge&logo=python&logoColor=white)](.)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.125.0-009688?style=for-the-badge&logo=fastapi&logoColor=white)](.)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791?style=for-the-badge&logo=postgresql&logoColor=white)](.)
@@ -29,7 +29,7 @@
 
 ### 🎯 Key Highlights
 
-- ✅ **82 REST API endpoints** fully documented (Swagger UI)
+- ✅ **83 REST API endpoints** fully documented (Swagger UI)
 - ✅ **2,158 tests** passing (100% success rate, ~90s execution)
 - ✅ **OWASP Top 10 Score: 9.4/10** - Production-grade security
 - ✅ **Clean Architecture** - 3-layer separation with DDD patterns
@@ -213,6 +213,15 @@ SENTRY_DSN=<your-sentry-dsn>  # Optional but recommended
 
 ### What's New
 
+**v2.0.17 (Jul 2026) — Scoring Improvements**
+- ✅ **Handicap Revert to RFEG**: New `DELETE /enrollments/{id}/handicap` lets creator/admin clear a custom handicap, reverting to the official RFEG value
+- ✅ **Handicap Edit Gating**: Setting/removing custom handicaps only allowed in DRAFT/ACTIVE/CLOSED (blocked once matches are generated)
+- ✅ **Auto Handicap Refresh on Login**: Daily silent RFEG lookup for Spanish players; `needs_handicap` flag for the rest
+- ✅ **Admin Full Access**: Admins bypass creator-only checks across scoring and match management use cases
+- ✅ **Playing Handicap Limit**: Optional `max_playing_handicap` cap (1–54) per competition
+- ✅ **Best Ball Determinism**: Deterministic tie-break + returns both tied player IDs in Fourball
+- ✅ **1 new endpoint**, 51 new tests (1,966 total unit)
+
 **v2.0.14 (Feb 24, 2026)**
 - ✅ **Backward State Transitions**: Revert IN_PROGRESS→CLOSED, reopen CLOSED→ACTIVE
 - ✅ **2 new endpoints**, 29 new tests (2,158 total)
@@ -377,7 +386,7 @@ See [ADR-021](docs/architecture/decisions/ADR-021-github-actions-ci-cd-pipeline.
 
 ## 📡 API Endpoints
 
-### Available Endpoints (82 total)
+### Available Endpoints (83 total)
 
 <details>
 <summary><b>Authentication (11 endpoints)</b></summary>
@@ -455,7 +464,7 @@ See [ADR-021](docs/architecture/decisions/ADR-021-github-actions-ci-cd-pipeline.
 </details>
 
 <details>
-<summary><b>Enrollment Management (8 endpoints)</b></summary>
+<summary><b>Enrollment Management (9 endpoints)</b></summary>
 
 - `POST /api/v1/competitions/{id}/enrollments`
 - `POST /api/v1/competitions/{id}/enrollments/direct`
@@ -465,6 +474,7 @@ See [ADR-021](docs/architecture/decisions/ADR-021-github-actions-ci-cd-pipeline.
 - `POST /api/v1/enrollments/{id}/cancel`
 - `POST /api/v1/enrollments/{id}/withdraw`
 - `PUT /api/v1/enrollments/{id}/handicap`
+- `DELETE /api/v1/enrollments/{id}/handicap` - Revert to official RFEG handicap
 </details>
 
 <details>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap - RyderCupFriends Backend
 
-> **Versión:** 2.0.16 | **Tests:** 1,915 unit (branch) | **Endpoints:** 82 | **OWASP:** 9.4/10
+> **Versión:** 2.0.16 | **Tests:** 1,966 unit (branch) | **Endpoints:** 83 | **OWASP:** 9.4/10
 >
-> **Last Updated:** Jul 2, 2026
+> **Last Updated:** Jul 6, 2026
 
 ---
 
@@ -12,11 +12,11 @@
 
 #### Módulo Gestión de Hándicaps
 - **Actualizar hándicap RFEG al inscribir jugador** (H1): al aprobar la inscripción de un jugador (`EnrollmentApprovedEvent`), si `country_code == 'ES'`, lanzar consulta asíncrona a RFEG y actualizar `user.handicap + handicap_updated_at`.
-- **Actualizar hándicap RFEG en login** (H2): al autenticarse un usuario con `country_code == 'ES'`, consultar RFEG en background. Si no se localiza o la nacionalidad es distinta de ES, generar un item de tipo `HANDICAP_REQUIRED` (tabla `attention_items` o equivalente) para revisión manual por el propio usuario.
-- **Hándicap personalizado por competición** (H3): extender el campo `custom_handicap` existente en `Enrollment` con flag `custom_handicap_set_by_creator`. Nuevo endpoint `PUT /api/v1/competitions/{id}/enrollments/{enrollment_id}/handicap` accesible solo por creator/admin. `PlayingHandicapCalculator` usa `custom_handicap` cuando está definido.
 
 ### Completado ✅
 
+- **Auto-refresh hándicap RFEG en login** (H2): `LoginUserUseCase` consulta RFEG en background para usuarios españoles si el hándicap no se refrescó hoy; el resto de casos (no ES, sin país, o RFEG vacío/fallido) recibe `needs_handicap=True` para mostrar el modal en frontend.
+- **Hándicap personalizado por competición + revertir a RFEG** (H3): `SetCustomHandicapUseCase` (existente) y nuevo `RemoveCustomHandicapUseCase` (`DELETE /api/v1/enrollments/{id}/handicap`) permiten al creator/admin fijar o revertir el hándicap de un jugador. Ambas acciones quedan bloqueadas (`HandicapEditNotAllowedError`) una vez la competición pasa a `IN_PROGRESS` (hándicaps ya snapshotados en los partidos).
 - **"Equipo X gana AS"** (#1): fix aplicado en frontend (`LeaderboardView`). El backend ya producía `winner="HALVED"` correctamente; no requirió cambios.
 - **Best ball no determinístico (FOURBALL)** (#3): `find_by_match` añade `ORDER BY _player_user_id ASC` como clave secundaria. `find_best_ball_player` devuelve lista de IDs cuando hay empate dentro del equipo; el DTO `best_ball_player_a/b` pasa de `str | None` a `list[str]`.
 - **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración Alembic + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap; si el hándicap de juego calculado supera el límite, se usa el valor limitado.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,14 @@
 # Roadmap - RyderCupFriends Backend
 
-> **Versión:** 2.0.15 | **Tests:** 1,022 unit (branch) | **Endpoints:** 82 | **OWASP:** 9.4/10
+> **Versión:** 2.0.16 | **Tests:** 1,915 unit (branch) | **Endpoints:** 82 | **OWASP:** 9.4/10
 >
-> **Last Updated:** Jun 18, 2026
+> **Last Updated:** Jul 2, 2026
 
 ---
 
 ## En progreso: Scoring Improvements (branch `feature/scoring-improvements`)
 
 ### Pendiente de implementar
-
-#### Scoring fixes
-- **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap; si el hándicap de juego calculado supera el límite, se usa el valor limitado.
-- **Admin acceso total a scoring** (#5): rutas de scoring aceptan admin sin estar en el partido (`is_admin OR player_in_match`).
 
 #### Módulo Gestión de Hándicaps
 - **Actualizar hándicap RFEG al inscribir jugador** (H1): al aprobar la inscripción de un jugador (`EnrollmentApprovedEvent`), si `country_code == 'ES'`, lanzar consulta asíncrona a RFEG y actualizar `user.handicap + handicap_updated_at`.
@@ -21,8 +17,10 @@
 
 ### Completado ✅
 
-- **Best ball no determinístico (FOURBALL)** (#3): `find_by_match` añade `ORDER BY _player_user_id ASC` como clave secundaria. `find_best_ball_player` devuelve lista de IDs cuando hay empate dentro del equipo; el DTO `best_ball_player_a/b` pasa de `str | None` a `list[str]`.
 - **"Equipo X gana AS"** (#1): fix aplicado en frontend (`LeaderboardView`). El backend ya producía `winner="HALVED"` correctamente; no requirió cambios.
+- **Best ball no determinístico (FOURBALL)** (#3): `find_by_match` añade `ORDER BY _player_user_id ASC` como clave secundaria. `find_best_ball_player` devuelve lista de IDs cuando hay empate dentro del equipo; el DTO `best_ball_player_a/b` pasa de `str | None` a `list[str]`.
+- **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración Alembic + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap; si el hándicap de juego calculado supera el límite, se usa el valor limitado.
+- **Admin acceso total a scoring** (#5): todas las rutas de scoring (`GET /scoring-view`, `POST /scores/holes/{n}`, `POST /scorecard/submit`, `PUT /concede`) aceptan admin sin estar en el partido (`is_admin OR player_in_match`).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,14 @@
 
 ### Pendiente de implementar
 
-- **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap.
+#### Scoring fixes
+- **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap; si el hándicap de juego calculado supera el límite, se usa el valor limitado.
 - **Admin acceso total a scoring** (#5): rutas de scoring aceptan admin sin estar en el partido (`is_admin OR player_in_match`).
+
+#### Módulo Gestión de Hándicaps
+- **Actualizar hándicap RFEG al inscribir jugador** (H1): al aprobar la inscripción de un jugador (`EnrollmentApprovedEvent`), si `country_code == 'ES'`, lanzar consulta asíncrona a RFEG y actualizar `user.handicap + handicap_updated_at`.
+- **Actualizar hándicap RFEG en login** (H2): al autenticarse un usuario con `country_code == 'ES'`, consultar RFEG en background. Si no se localiza o la nacionalidad es distinta de ES, generar un item de tipo `HANDICAP_REQUIRED` (tabla `attention_items` o equivalente) para revisión manual por el propio usuario.
+- **Hándicap personalizado por competición** (H3): extender el campo `custom_handicap` existente en `Enrollment` con flag `custom_handicap_set_by_creator`. Nuevo endpoint `PUT /api/v1/competitions/{id}/enrollments/{enrollment_id}/handicap` accesible solo por creator/admin. `PlayingHandicapCalculator` usa `custom_handicap` cuando está definido.
 
 ### Completado ✅
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,21 @@
 
 ---
 
-## En progreso: Bugfixes Scoring (branch `bugfix/scoring-matchplay-calculation`)
+## En progreso: Scoring Improvements (branch `feature/scoring-improvements`)
+
+### Pendiente de implementar
+
+- **Límite hándicap de juego** (#4): campo `max_playing_handicap` en `Competition` + migración + propagación en use cases y DTOs. `PlayingHandicapCalculator.calculate()` aplica el cap.
+- **Admin acceso total a scoring** (#5): rutas de scoring aceptan admin sin estar en el partido (`is_admin OR player_in_match`).
+
+### Completado ✅
+
+- **Best ball no determinístico (FOURBALL)** (#3): `find_by_match` añade `ORDER BY _player_user_id ASC` como clave secundaria. `find_best_ball_player` devuelve lista de IDs cuando hay empate dentro del equipo; el DTO `best_ball_player_a/b` pasa de `str | None` a `list[str]`.
+- **"Equipo X gana AS"** (#1): fix aplicado en frontend (`LeaderboardView`). El backend ya producía `winner="HALVED"` correctamente; no requirió cambios.
+
+---
+
+## Completado: Bugfixes Scoring (branch `bugfix/scoring-matchplay-calculation`)
 
 ### Correcciones producción ✅
 

--- a/alembic/versions/117fa75bd4ee_make_handicap_updated_at_timezone_aware.py
+++ b/alembic/versions/117fa75bd4ee_make_handicap_updated_at_timezone_aware.py
@@ -1,0 +1,38 @@
+"""make_handicap_updated_at_timezone_aware
+
+Revision ID: 117fa75bd4ee
+Revises: 2acbed9e2365
+Create Date: 2026-07-04 00:54:12.443720
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '117fa75bd4ee'
+down_revision: Union[str, None] = '2acbed9e2365'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Existing values were written with naive datetime.now() on a server that
+    # runs in UTC, so they are reinterpreted as UTC rather than converted.
+    op.execute(
+        "ALTER TABLE users "
+        "ALTER COLUMN handicap_updated_at "
+        "TYPE TIMESTAMP WITH TIME ZONE "
+        "USING handicap_updated_at AT TIME ZONE 'UTC'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE users "
+        "ALTER COLUMN handicap_updated_at "
+        "TYPE TIMESTAMP WITHOUT TIME ZONE "
+        "USING handicap_updated_at AT TIME ZONE 'UTC'"
+    )

--- a/alembic/versions/2acbed9e2365_merge_scoring_and_max_handicap_heads.py
+++ b/alembic/versions/2acbed9e2365_merge_scoring_and_max_handicap_heads.py
@@ -1,0 +1,26 @@
+"""merge scoring and max handicap heads
+
+Revision ID: 2acbed9e2365
+Revises: a1b2c3d4e5f6, a3d5e7f1b2c4
+Create Date: 2026-07-01 21:09:32.472668
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2acbed9e2365'
+down_revision: Union[str, None] = ('a1b2c3d4e5f6', 'a3d5e7f1b2c4')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/a1b2c3d4e5f6_add_max_playing_handicap_to_competitions.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_max_playing_handicap_to_competitions.py
@@ -1,0 +1,27 @@
+"""Add max_playing_handicap to competitions table
+
+Revision ID: a1b2c3d4e5f6
+Revises: f6b8c4d2e3a5
+Create Date: 2026-07-01 14:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f6b8c4d2e3a5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "competitions",
+        sa.Column("max_playing_handicap", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("competitions", "max_playing_handicap")

--- a/docs/API.md
+++ b/docs/API.md
@@ -83,7 +83,7 @@ Teams & Generation (3 endpoints) ⭐ Sprint 2
 ├── POST   /api/v1/competitions/rounds/{id}/matches/generate # Generate matches for round
 └── POST   /api/v1/competitions/{id}/schedule/configure # Configure schedule (auto/manual)
 
-Enrollment Management (8 endpoints)
+Enrollment Management (9 endpoints)
 ├── POST /api/v1/competitions/{id}/enrollments      # Request enrollment
 ├── POST /api/v1/competitions/{id}/enrollments/direct # Direct enroll (creator only)
 ├── GET  /api/v1/competitions/{id}/enrollments      # List enrollments
@@ -91,7 +91,8 @@ Enrollment Management (8 endpoints)
 ├── POST /api/v1/enrollments/{id}/reject            # Reject enrollment
 ├── POST /api/v1/enrollments/{id}/cancel            # Cancel enrollment
 ├── POST /api/v1/enrollments/{id}/withdraw          # Withdraw from competition
-└── PUT  /api/v1/enrollments/{id}/handicap          # Set custom handicap
+├── PUT  /api/v1/enrollments/{id}/handicap          # Set custom handicap
+└── DELETE /api/v1/enrollments/{id}/handicap        # Revert to official RFEG handicap
 
 Country Management (2 endpoints)
 ├── GET  /api/v1/countries               # List all countries
@@ -614,6 +615,7 @@ SCHEDULED → IN_PROGRESS → COMPLETED
 | `/enrollments/{id}/cancel` | POST | Yes | Cancel request/invitation |
 | `/enrollments/{id}/withdraw` | POST | Yes | Withdraw from competition |
 | `/enrollments/{id}/handicap` | PUT | Yes | Set custom handicap |
+| `/enrollments/{id}/handicap` | DELETE | Yes | Revert to official RFEG handicap |
 
 ### Main Fields
 
@@ -629,8 +631,13 @@ SCHEDULED → IN_PROGRESS → COMPLETED
 
 **Set Custom Handicap:**
 - `custom_handicap` (float, required, -10.0 to 54.0)
-- Only creator can set
+- Creator or admin can set
 - Override of user's official handicap
+- Only allowed while competition is in DRAFT, ACTIVE or CLOSED (raises `HandicapEditNotAllowedError` in IN_PROGRESS+)
+
+**Revert Custom Handicap (DELETE):**
+- Creator or admin can clear the enrollment's `custom_handicap`, reverting it to the player's official (RFEG-sourced) handicap
+- Same status gate as Set Custom Handicap (DRAFT/ACTIVE/CLOSED only)
 
 ### Query Parameters (List)
 

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -1219,6 +1219,7 @@ def get_generate_matches_use_case(
     gc_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
     scoring_service: ScoringService = Depends(get_scoring_service),
+    handicap_service: HandicapService = Depends(get_handicap_service),
 ) -> GenerateMatchesUseCase:
     """Proveedor del caso de uso GenerateMatchesUseCase (cross-module: Competition + GolfCourse + User)."""
     return GenerateMatchesUseCase(
@@ -1227,6 +1228,7 @@ def get_generate_matches_use_case(
         user_repository=user_uow.users,
         handicap_calculator=PlayingHandicapCalculator(),
         scoring_service=scoring_service,
+        handicap_service=handicap_service,
     )
 
 

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -92,6 +92,9 @@ from src.modules.competition.application.use_cases.list_my_invitations_use_case 
 from src.modules.competition.application.use_cases.reassign_match_players_use_case import (
     ReassignMatchPlayersUseCase,
 )
+from src.modules.competition.application.use_cases.remove_custom_handicap_use_case import (
+    RemoveCustomHandicapUseCase,
+)
 from src.modules.competition.application.use_cases.remove_golf_course_use_case import (
     RemoveGolfCourseFromCompetitionUseCase,
 )
@@ -1127,6 +1130,13 @@ def get_set_custom_handicap_use_case(
 ) -> SetCustomHandicapUseCase:
     """Proveedor del caso de uso SetCustomHandicapUseCase."""
     return SetCustomHandicapUseCase(uow)
+
+
+def get_remove_custom_handicap_use_case(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+) -> RemoveCustomHandicapUseCase:
+    """Proveedor del caso de uso RemoveCustomHandicapUseCase."""
+    return RemoveCustomHandicapUseCase(uow)
 
 
 def get_list_enrollments_use_case(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -510,6 +510,7 @@ def get_login_user_use_case(
     uow: UserUnitOfWorkInterface = Depends(get_uow),
     token_service: ITokenService = Depends(get_token_service),
     register_device_use_case: RegisterDeviceUseCase = Depends(get_register_device_use_case),
+    handicap_service: HandicapService = Depends(get_handicap_service),
 ) -> LoginUserUseCase:
     """
     Proveedor del caso de uso LoginUserUseCase.
@@ -518,10 +519,11 @@ def get_login_user_use_case(
     1. Depende de `get_uow` para obtener una Unit of Work.
     2. Depende de `get_token_service` para generación de tokens JWT.
     3. Depende de `get_register_device_use_case` para device fingerprinting (v1.13.0).
-    4. Crea una instancia de `LoginUserUseCase` con esas dependencias.
-    5. Devuelve la instancia lista para ser usada por el endpoint de la API.
+    4. Depende de `get_handicap_service` para fetch RFEG en login (HM-2a).
+    5. Crea una instancia de `LoginUserUseCase` con esas dependencias.
+    6. Devuelve la instancia lista para ser usada por el endpoint de la API.
     """
-    return LoginUserUseCase(uow, token_service, register_device_use_case)
+    return LoginUserUseCase(uow, token_service, register_device_use_case, handicap_service)
 
 
 def get_logout_user_use_case(

--- a/src/modules/competition/application/dto/competition_dto.py
+++ b/src/modules/competition/application/dto/competition_dto.py
@@ -115,7 +115,7 @@ class CreateCompetitionRequestDTO(BaseModel):
 
     # Límite de hándicap de juego
     max_playing_handicap: int | None = Field(
-        None, ge=1, le=54, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+        None, ge=1, le=54, description="Límite máximo de hándicap de juego (WHS: 1-54)."
     )
 
     @field_validator("main_country", "adjacent_country_1", "adjacent_country_2", mode="before")
@@ -217,7 +217,7 @@ class CreateCompetitionResponseDTO(BaseModel):
     max_players: int = Field(..., description=MAX_PLAYERS_DESC)
     team_assignment: str = Field(..., description="Tipo de asignación de equipos.")
     max_playing_handicap: int | None = Field(
-        None, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+        None, description="Límite máximo de hándicap de juego (WHS: 1-54)."
     )
 
     # Campos calculados
@@ -270,7 +270,7 @@ class UpdateCompetitionRequestDTO(BaseModel):
     max_players: int | None = Field(None, ge=2, le=100, description="Nuevo máximo de jugadores.")
     team_assignment: str | None = Field(None, description="Nueva asignación de equipos.")
     max_playing_handicap: int | None = Field(
-        None, ge=1, le=54, description="Nuevo límite máximo de hándicap de juego (WHS: 1–54)."
+        None, ge=1, le=54, description="Nuevo límite máximo de hándicap de juego (WHS: 1-54)."
     )
     team_1_name: str | None = Field(
         None, min_length=3, max_length=50, description="Nuevo nombre del equipo 1."
@@ -368,7 +368,7 @@ class CompetitionResponseDTO(BaseModel):
     max_players: int = Field(..., description=MAX_PLAYERS_DESC)
     team_assignment: str = Field(..., description="Tipo de asignación de equipos.")
     max_playing_handicap: int | None = Field(
-        None, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+        None, description="Límite máximo de hándicap de juego (WHS: 1-54)."
     )
 
     # Campos calculados (NUEVO - requeridos por frontend)
@@ -381,7 +381,10 @@ class CompetitionResponseDTO(BaseModel):
     )
     pending_enrollments_count: int = Field(
         default=0,
-        description="Número de solicitudes con enrollment status PENDING (solo visible para el creador).",
+        description=(
+            "Número de solicitudes con enrollment status PENDING "
+            "(solo visible para el creador o un admin)."
+        ),
     )
     user_enrollment_status: str | None = Field(
         None,

--- a/src/modules/competition/application/dto/competition_dto.py
+++ b/src/modules/competition/application/dto/competition_dto.py
@@ -113,6 +113,11 @@ class CreateCompetitionRequestDTO(BaseModel):
         default="Team 2", min_length=3, max_length=50, description=TEAM_2_NAME_DESC
     )
 
+    # Límite de hándicap de juego
+    max_playing_handicap: int | None = Field(
+        None, ge=1, le=54, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+    )
+
     @field_validator("main_country", "adjacent_country_1", "adjacent_country_2", mode="before")
     @classmethod
     def uppercase_country_codes(cls, v):
@@ -211,6 +216,9 @@ class CreateCompetitionResponseDTO(BaseModel):
     # Config
     max_players: int = Field(..., description=MAX_PLAYERS_DESC)
     team_assignment: str = Field(..., description="Tipo de asignación de equipos.")
+    max_playing_handicap: int | None = Field(
+        None, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+    )
 
     # Campos calculados
     is_creator: bool = Field(default=True, description="Siempre True para el creador.")
@@ -261,6 +269,9 @@ class UpdateCompetitionRequestDTO(BaseModel):
     # Competition Config
     max_players: int | None = Field(None, ge=2, le=100, description="Nuevo máximo de jugadores.")
     team_assignment: str | None = Field(None, description="Nueva asignación de equipos.")
+    max_playing_handicap: int | None = Field(
+        None, ge=1, le=54, description="Nuevo límite máximo de hándicap de juego (WHS: 1–54)."
+    )
     team_1_name: str | None = Field(
         None, min_length=3, max_length=50, description="Nuevo nombre del equipo 1."
     )
@@ -356,6 +367,9 @@ class CompetitionResponseDTO(BaseModel):
     # Config
     max_players: int = Field(..., description=MAX_PLAYERS_DESC)
     team_assignment: str = Field(..., description="Tipo de asignación de equipos.")
+    max_playing_handicap: int | None = Field(
+        None, description="Límite máximo de hándicap de juego (WHS: 1–54)."
+    )
 
     # Campos calculados (NUEVO - requeridos por frontend)
     is_creator: bool = Field(

--- a/src/modules/competition/application/dto/enrollment_dto.py
+++ b/src/modules/competition/application/dto/enrollment_dto.py
@@ -234,6 +234,9 @@ class SetCustomHandicapResponseDTO(BaseModel):
     """
 
     id: UUID = Field(..., description="ID de la inscripción.")
+    competition_id: UUID = Field(..., description="ID de la competición.")
+    user_id: UUID = Field(..., description="ID del usuario.")
+    status: str = Field(..., description="Estado de la inscripción.")
     custom_handicap: Decimal = Field(..., description="Nuevo hándicap personalizado.")
     updated_at: datetime = Field(..., description="Fecha y hora de actualización.")
 

--- a/src/modules/competition/application/dto/enrollment_dto.py
+++ b/src/modules/competition/application/dto/enrollment_dto.py
@@ -244,6 +244,32 @@ class SetCustomHandicapResponseDTO(BaseModel):
 
 
 # ======================================================================================
+# DTO para el Caso de Uso: Eliminar Hándicap Personalizado (revertir al oficial)
+# ======================================================================================
+
+
+class RemoveCustomHandicapResponseDTO(BaseModel):
+    """
+    DTO de salida para eliminar el hándicap personalizado.
+
+    Tras la operación el enrollment vuelve a usar el hándicap oficial del jugador
+    (el de su perfil, actualizado vía RFEG en los flujos ya existentes de login/
+    generación de partidos).
+    """
+
+    id: UUID = Field(..., description="ID de la inscripción.")
+    competition_id: UUID = Field(..., description="ID de la competición.")
+    user_id: UUID = Field(..., description="ID del usuario.")
+    status: str = Field(..., description="Estado de la inscripción.")
+    custom_handicap: Decimal | None = Field(
+        None, description="Siempre None tras eliminar el hándicap personalizado."
+    )
+    updated_at: datetime = Field(..., description="Fecha y hora de actualización.")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ======================================================================================
 # DTO de Respuesta Genérico para Enrollment
 # ======================================================================================
 

--- a/src/modules/competition/application/dto/round_match_dto.py
+++ b/src/modules/competition/application/dto/round_match_dto.py
@@ -30,6 +30,17 @@ class MatchPlayerResponseDTO(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    @classmethod
+    def from_domain(cls, p) -> "MatchPlayerResponseDTO":
+        """Construye el DTO a partir de un MatchPlayer de dominio (VO)."""
+        return cls(
+            user_id=p.user_id.value,
+            playing_handicap=p.playing_handicap,
+            tee_category=p.tee_category.value,
+            strokes_received=list(p.strokes_received),
+            player_handicap=float(p.player_handicap) if p.player_handicap is not None else None,
+        )
+
 
 class MatchResponseDTO(BaseModel):
     """DTO de respuesta para un partido."""

--- a/src/modules/competition/application/dto/round_match_dto.py
+++ b/src/modules/competition/application/dto/round_match_dto.py
@@ -22,6 +22,11 @@ class MatchPlayerResponseDTO(BaseModel):
     strokes_received: list[int] = Field(
         default_factory=list, description="Hoyos donde recibe golpe."
     )
+    player_handicap: float | None = Field(
+        None,
+        description="HI del jugador en el momento de generar el partido (snapshot, HM-1b). "
+        "None en partidos generados antes de esta feature.",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/modules/competition/application/dto/scoring_dto.py
+++ b/src/modules/competition/application/dto/scoring_dto.py
@@ -1,5 +1,7 @@
 """DTOs para el modulo de scoring."""
 
+from uuid import UUID
+
 from pydantic import BaseModel, Field
 
 
@@ -9,6 +11,10 @@ class SubmitHoleScoreBodyDTO(BaseModel):
     own_score: int | None = Field(None, ge=1, le=15)
     marked_player_id: str
     marked_score: int | None = Field(None, ge=1, le=15)
+    acting_as: UUID | None = Field(
+        None,
+        description="Solo admin: ID del jugador al que se representa para registrar su score.",
+    )
 
 
 class RoundInfoDTO(BaseModel):

--- a/src/modules/competition/application/dto/scoring_dto.py
+++ b/src/modules/competition/application/dto/scoring_dto.py
@@ -67,8 +67,8 @@ class HoleResultDTO(BaseModel):
     winner: str | None = None
     standing: str | None = None
     standing_team: str | None = None
-    best_ball_player_a: str | None = None
-    best_ball_player_b: str | None = None
+    best_ball_player_a: list[str] = []
+    best_ball_player_b: list[str] = []
 
 
 class HoleScoreEntryDTO(BaseModel):

--- a/src/modules/competition/application/exceptions.py
+++ b/src/modules/competition/application/exceptions.py
@@ -101,3 +101,9 @@ class InvalidHoleNumberError(Exception):
     """El numero de hoyo no es valido."""
 
     pass
+
+
+class HandicapEditNotAllowedError(Exception):
+    """El hándicap personalizado no puede modificarse en el estado actual de la competición."""
+
+    pass

--- a/src/modules/competition/application/exceptions.py
+++ b/src/modules/competition/application/exceptions.py
@@ -107,3 +107,15 @@ class HandicapEditNotAllowedError(Exception):
     """El hándicap personalizado no puede modificarse en el estado actual de la competición."""
 
     pass
+
+
+class EnrollmentNotFoundError(Exception):
+    """La inscripción no existe."""
+
+    pass
+
+
+class NotCreatorError(Exception):
+    """El usuario no es el creador de la competición."""
+
+    pass

--- a/src/modules/competition/application/mappers/competition_mapper.py
+++ b/src/modules/competition/application/mappers/competition_mapper.py
@@ -123,6 +123,7 @@ class CompetitionDTOMapper:
                 if hasattr(competition.team_assignment, "value")
                 else competition.team_assignment
             ),
+            max_playing_handicap=competition.max_playing_handicap,
             # Teams
             team_1_name=competition.team_1_name,
             team_2_name=competition.team_2_name,

--- a/src/modules/competition/application/mappers/competition_mapper.py
+++ b/src/modules/competition/application/mappers/competition_mapper.py
@@ -35,6 +35,7 @@ class CompetitionDTOMapper:
         current_user_id: UserId,
         uow: CompetitionUnitOfWorkInterface,
         user_uow: UserUnitOfWorkInterface | None = None,
+        is_admin: bool = False,
     ) -> CompetitionResponseDTO:
         """
         Convierte una entidad Competition a CompetitionResponseDTO.
@@ -44,12 +45,19 @@ class CompetitionDTOMapper:
         - enrolled_count: número de enrollments APPROVED
         - location: string formateado con nombres de países
         - creator: información completa del creador (si user_uow es provisto)
+
+        pending_enrollments_count solo se calcula y expone para el creador
+        de la competición o para administradores (is_admin=True).
         """
+        is_creator = competition.creator_id == current_user_id
+
         # Calcular enrolled_count
         enrolled_count = await uow.enrollments.count_approved(competition.id)
 
-        # Calcular pending_enrollments_count (solicitudes pendientes)
-        pending_enrollments_count = await uow.enrollments.count_pending(competition.id)
+        # Calcular pending_enrollments_count (solo visible para creador/admin)
+        pending_enrollments_count = 0
+        if is_creator or is_admin:
+            pending_enrollments_count = await uow.enrollments.count_pending(competition.id)
 
         # Obtener enrollment status del usuario actual (si existe)
         user_enrollment_status = None
@@ -128,7 +136,7 @@ class CompetitionDTOMapper:
             team_1_name=competition.team_1_name,
             team_2_name=competition.team_2_name,
             # Campos calculados
-            is_creator=(competition.creator_id == current_user_id),
+            is_creator=is_creator,
             enrolled_count=enrolled_count,
             pending_enrollments_count=pending_enrollments_count,
             user_enrollment_status=user_enrollment_status,

--- a/src/modules/competition/application/use_cases/activate_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/activate_competition_use_case.py
@@ -50,7 +50,7 @@ class ActivateCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: ActivateCompetitionRequestDTO, user_id: UserId
+        self, request: ActivateCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> ActivateCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de activación de competición.
@@ -78,7 +78,7 @@ class ActivateCompetitionUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede activar la competición")
 
             # 3. Activar la competición (la entidad valida la transición)

--- a/src/modules/competition/application/use_cases/add_golf_course_use_case.py
+++ b/src/modules/competition/application/use_cases/add_golf_course_use_case.py
@@ -90,7 +90,7 @@ class AddGolfCourseToCompetitionUseCase:
         self._golf_course_repo = golf_course_repository
 
     async def execute(
-        self, request: AddGolfCourseRequestDTO, user_id: UserId
+        self, request: AddGolfCourseRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> AddGolfCourseResponseDTO:
         """
         Ejecuta el caso de uso de añadir campo de golf a competición.
@@ -121,8 +121,8 @@ class AddGolfCourseToCompetitionUseCase:
                     f"No existe competición con ID {request.competition_id}"
                 )
 
-            # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            # 2. Verificar que el usuario sea el creador (o admin)
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError(
                     "Solo el creador puede añadir campos de golf a la competición"
                 )

--- a/src/modules/competition/application/use_cases/assign_teams_use_case.py
+++ b/src/modules/competition/application/use_cases/assign_teams_use_case.py
@@ -70,7 +70,7 @@ class AssignTeamsUseCase:
         self._draft_service = snake_draft_service or SnakeDraftService()
 
     async def execute(
-        self, request: AssignTeamsRequestDTO, user_id: UserId
+        self, request: AssignTeamsRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> AssignTeamsResponseDTO:
         async with self._uow:
             # 1. Buscar la competición
@@ -83,7 +83,7 @@ class AssignTeamsUseCase:
                 )
 
             # 2. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede asignar equipos")
 
             # 3. Verificar estado CLOSED

--- a/src/modules/competition/application/use_cases/cancel_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/cancel_competition_use_case.py
@@ -56,7 +56,7 @@ class CancelCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: CancelCompetitionRequestDTO, user_id: UserId
+        self, request: CancelCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> CancelCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de cancelación de competición.
@@ -84,7 +84,7 @@ class CancelCompetitionUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede cancelar la competición")
 
             # 3. Cancelar la competición (la entidad valida la transición)

--- a/src/modules/competition/application/use_cases/cancel_enrollment_use_case.py
+++ b/src/modules/competition/application/use_cases/cancel_enrollment_use_case.py
@@ -8,17 +8,12 @@ from src.modules.competition.application.dto.enrollment_dto import (
     CancelEnrollmentRequestDTO,
     CancelEnrollmentResponseDTO,
 )
+from src.modules.competition.application.exceptions import EnrollmentNotFoundError
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class EnrollmentNotFoundError(Exception):
-    """Excepción lanzada cuando la inscripción no existe."""
-
-    pass
 
 
 class NotOwnerError(Exception):

--- a/src/modules/competition/application/use_cases/close_enrollments_use_case.py
+++ b/src/modules/competition/application/use_cases/close_enrollments_use_case.py
@@ -51,7 +51,7 @@ class CloseEnrollmentsUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: CloseEnrollmentsRequestDTO, user_id: UserId
+        self, request: CloseEnrollmentsRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> CloseEnrollmentsResponseDTO:
         """
         Ejecuta el caso de uso de cierre de inscripciones.
@@ -79,7 +79,7 @@ class CloseEnrollmentsUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede cerrar las inscripciones")
 
             # 3. Contar inscripciones aprobadas

--- a/src/modules/competition/application/use_cases/complete_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/complete_competition_use_case.py
@@ -50,7 +50,7 @@ class CompleteCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: CompleteCompetitionRequestDTO, user_id: UserId
+        self, request: CompleteCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> CompleteCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de completar competicion.
@@ -77,8 +77,8 @@ class CompleteCompetitionUseCase:
                     f"No existe competición con ID {request.competition_id}"
                 )
 
-            # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            # 2. Verificar que el usuario sea el creador (o admin)
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede completar la competicion")
 
             # 3. Completar la competicion (la entidad valida la transicion)

--- a/src/modules/competition/application/use_cases/concede_match_use_case.py
+++ b/src/modules/competition/application/use_cases/concede_match_use_case.py
@@ -33,6 +33,7 @@ class ConcedeMatchUseCase:
         user_id: UserId,
         conceding_team: str,
         reason: str | None = None,
+        is_admin: bool = False,
     ) -> dict:
         async with self._uow:
             match_id = MatchId(match_id_str)
@@ -53,9 +54,9 @@ class ConcedeMatchUseCase:
             if not competition:
                 raise CompetitionNotFoundError("La competicion asociada no existe")
 
-            # Auth: player can only concede own team; creator can concede any
+            # Auth: player can only concede own team; creator and admin can concede any
             player_team = match.get_player_team(user_id)
-            is_creator = competition.is_creator(user_id)
+            is_creator = is_admin or competition.is_creator(user_id)
 
             if player_team is None and not is_creator:
                 raise NotMatchPlayerError(

--- a/src/modules/competition/application/use_cases/configure_schedule_use_case.py
+++ b/src/modules/competition/application/use_cases/configure_schedule_use_case.py
@@ -52,7 +52,7 @@ class ConfigureScheduleUseCase:
         self._format_service = schedule_format_service or ScheduleFormatService()
 
     async def execute(
-        self, request: ConfigureScheduleRequestDTO, user_id: UserId
+        self, request: ConfigureScheduleRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> ConfigureScheduleResponseDTO:
         async with self._uow:
             # 1. Buscar la competición
@@ -65,7 +65,7 @@ class ConfigureScheduleUseCase:
                 )
 
             # 2. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede configurar el schedule")
 
             # 3. Verificar estado CLOSED

--- a/src/modules/competition/application/use_cases/create_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/create_competition_use_case.py
@@ -125,6 +125,7 @@ class CreateCompetitionUseCase:
                 play_mode=play_mode,
                 max_players=request.max_players,
                 team_assignment=team_assignment_vo,
+                max_playing_handicap=request.max_playing_handicap,
             )
 
             # 9. Persistir la competición
@@ -167,6 +168,7 @@ class CreateCompetitionUseCase:
             # Config
             max_players=competition.max_players,
             team_assignment=competition.team_assignment.value,
+            max_playing_handicap=competition.max_playing_handicap,
             # Timestamps
             created_at=competition.created_at,
             updated_at=competition.updated_at,

--- a/src/modules/competition/application/use_cases/create_round_use_case.py
+++ b/src/modules/competition/application/use_cases/create_round_use_case.py
@@ -56,7 +56,7 @@ class CreateRoundUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: CreateRoundRequestDTO, user_id: UserId
+        self, request: CreateRoundRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> CreateRoundResponseDTO:
         async with self._uow:
             # 1. Buscar la competición
@@ -69,7 +69,7 @@ class CreateRoundUseCase:
                 )
 
             # 2. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede crear rondas")
 
             # 3. Verificar estado CLOSED

--- a/src/modules/competition/application/use_cases/declare_walkover_use_case.py
+++ b/src/modules/competition/application/use_cases/declare_walkover_use_case.py
@@ -41,7 +41,7 @@ class DeclareWalkoverUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: DeclareWalkoverRequestDTO, user_id: UserId
+        self, request: DeclareWalkoverRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> DeclareWalkoverResponseDTO:
         async with self._uow:
             # 1. Buscar el partido
@@ -61,7 +61,7 @@ class DeclareWalkoverUseCase:
                 raise MatchNotFoundError("La competicion asociada no existe")
 
             # 3. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede declarar walkover")
 
             # 4. Verificar competicion IN_PROGRESS

--- a/src/modules/competition/application/use_cases/delete_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/delete_competition_use_case.py
@@ -55,7 +55,7 @@ class DeleteCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: DeleteCompetitionRequestDTO, user_id: UserId
+        self, request: DeleteCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> DeleteCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de eliminacion de competicion.
@@ -83,7 +83,7 @@ class DeleteCompetitionUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede eliminar la competicion")
 
             # 3. Verificar que este en estado DRAFT

--- a/src/modules/competition/application/use_cases/delete_round_use_case.py
+++ b/src/modules/competition/application/use_cases/delete_round_use_case.py
@@ -38,7 +38,7 @@ class DeleteRoundUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: DeleteRoundRequestDTO, user_id: UserId
+        self, request: DeleteRoundRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> DeleteRoundResponseDTO:
         async with self._uow:
             # 1. Buscar la ronda
@@ -55,7 +55,7 @@ class DeleteRoundUseCase:
                 raise CompetitionNotFoundError("La competición asociada no existe")
 
             # 3. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede eliminar rondas")
 
             # 4. Verificar competición CLOSED

--- a/src/modules/competition/application/use_cases/direct_enroll_player_use_case.py
+++ b/src/modules/competition/application/use_cases/direct_enroll_player_use_case.py
@@ -11,6 +11,7 @@ from src.modules.competition.application.dto.enrollment_dto import (
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
     InvalidTeeCategoryError,
+    NotCreatorError,
 )
 from src.modules.competition.domain.entities.enrollment import Enrollment
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
@@ -23,12 +24,6 @@ from src.modules.competition.domain.value_objects.competition_status import (
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class NotCreatorError(Exception):
-    """Excepcion lanzada cuando el usuario no es el creador de la competicion."""
-
-    pass
 
 
 class CompetitionNotActiveError(Exception):

--- a/src/modules/competition/application/use_cases/direct_enroll_player_use_case.py
+++ b/src/modules/competition/application/use_cases/direct_enroll_player_use_case.py
@@ -72,7 +72,7 @@ class DirectEnrollPlayerUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: DirectEnrollPlayerRequestDTO, creator_id: UserId
+        self, request: DirectEnrollPlayerRequestDTO, creator_id: UserId, is_admin: bool = False
     ) -> DirectEnrollPlayerResponseDTO:
         """
         Ejecuta el caso de uso de inscripcion directa.
@@ -102,7 +102,7 @@ class DirectEnrollPlayerUseCase:
                 )
 
             # 2. Verificar que es el creador
-            if competition.creator_id != creator_id:
+            if not is_admin and competition.creator_id != creator_id:
                 raise NotCreatorError(
                     "Solo el creador de la competicion puede inscribir jugadores directamente"
                 )

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -166,6 +166,8 @@ class GenerateMatchesUseCase:
             team_a_ids = list(team_assignment.team_a_player_ids)
             team_b_ids = list(team_assignment.team_b_player_ids)
 
+            max_playing_handicap = competition.max_playing_handicap
+
             if request.manual_pairings:
                 matches_created = await self._generate_manual(
                     request,
@@ -178,6 +180,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
             else:
                 matches_created = await self._generate_auto(
@@ -193,6 +196,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
 
             # 13. Transicionar ronda
@@ -260,6 +264,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ):
         """Genera partidos automáticamente emparejando por ranking."""
         # Para SINGLES: 1v1, para FOURBALL/FOURSOMES: 2v2
@@ -293,6 +298,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
                 team_a_match_players = [a_player]
                 team_b_match_players = [b_player]
@@ -308,6 +314,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
             elif match_format == MatchFormat.FOURSOMES:
                 team_a_match_players, team_b_match_players = self._build_foursomes_match_players(
@@ -321,6 +328,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
             else:
                 raise ValueError(f"Formato de partido no soportado: {match_format.value}")
@@ -352,6 +360,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ):
         """Genera partidos según emparejamientos manuales."""
         # Validar que todos los jugadores estén inscritos (APPROVED)
@@ -381,6 +390,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
             elif match_format == MatchFormat.FOURSOMES:
                 team_a_match_players, team_b_match_players = self._build_foursomes_match_players(
@@ -394,6 +404,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
             elif match_format == MatchFormat.SINGLES:
                 # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
@@ -408,6 +419,7 @@ class GenerateMatchesUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    max_playing_handicap,
                 )
                 team_a_match_players = [a_player]
                 team_b_match_players = [b_player]
@@ -482,6 +494,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ) -> MatchPlayer:
         """Construye un MatchPlayer con handicap calculado y tee auto-resuelto."""
         tee_category, tee_gender, tee_rating, handicap_index = self._resolve_player_data(
@@ -503,7 +516,7 @@ class GenerateMatchesUseCase:
                 f"(gender: {tee_gender}) en el campo de golf"
             )
 
-        playing_handicap = calculator.calculate(handicap_index, tee_rating, allowance)
+        playing_handicap = calculator.calculate(handicap_index, tee_rating, allowance, max_playing_handicap)
         strokes_received = calculator.compute_strokes_received(
             playing_handicap, holes_by_stroke_index
         )
@@ -528,6 +541,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ) -> tuple[list[MatchPlayer], list[MatchPlayer]]:
         """
         Construye MatchPlayers para FOURBALL usando el método diferencial WHS.
@@ -592,6 +606,10 @@ class GenerateMatchesUseCase:
         # 2. Método diferencial: aplica allowance% a diferencias respecto al menor CH
         differential_phs = calculator.calculate_fourball_differential(course_handicaps, allowance)
 
+        # Aplicar cap de max_playing_handicap si está definido
+        if max_playing_handicap is not None:
+            differential_phs = {k: min(v, max_playing_handicap) for k, v in differential_phs.items()}
+
         # 3. Construir MatchPlayers con PH diferencial
         def build_player(uid):
             uid_str = str(uid.value)
@@ -622,6 +640,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ) -> tuple["MatchPlayer", "MatchPlayer"]:
         """
         Construye MatchPlayers para SINGLES usando el método diferencial WHS.
@@ -664,8 +683,8 @@ class GenerateMatchesUseCase:
                 f"(gender: {tee_gen_b}) en el campo de golf"
             )
 
-        ph_a = calculator.calculate(hi_a, tee_rating_a, allowance)
-        ph_b = calculator.calculate(hi_b, tee_rating_b, allowance)
+        ph_a = calculator.calculate(hi_a, tee_rating_a, allowance, max_playing_handicap)
+        ph_b = calculator.calculate(hi_b, tee_rating_b, allowance, max_playing_handicap)
 
         diff = ph_a - ph_b
         if diff > 0:
@@ -701,6 +720,7 @@ class GenerateMatchesUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ) -> tuple[list[MatchPlayer], list[MatchPlayer]]:
         """
         Construye MatchPlayers para FOURSOMES usando el método diferencial WHS.
@@ -773,6 +793,11 @@ class GenerateMatchesUseCase:
         team_a_ph, team_b_ph = calculator.calculate_foursomes_differential(
             team_a_chs, team_b_chs, allowance
         )
+
+        # Aplicar cap de max_playing_handicap si está definido
+        if max_playing_handicap is not None:
+            team_a_ph = min(team_a_ph, max_playing_handicap)
+            team_b_ph = min(team_b_ph, max_playing_handicap)
 
         # 3. Ambos jugadores del equipo comparten los mismos strokes (una bola)
         team_a_strokes = calculator.compute_strokes_received(team_a_ph, holes_by_stroke_index)

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -1,6 +1,8 @@
 """Caso de Uso: Generar partidos para una ronda."""
 
 import asyncio
+import logging
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from src.modules.competition.application.dto.round_match_dto import (
@@ -32,8 +34,11 @@ from src.modules.competition.domain.value_objects.round_id import RoundId
 from src.modules.golf_course.domain.repositories.golf_course_repository import IGolfCourseRepository
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.repositories.user_repository_interface import UserRepositoryInterface
+from src.modules.user.domain.services.handicap_service import HandicapService
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.value_objects.gender import Gender
+
+logger = logging.getLogger(__name__)
 
 
 class RoundNotPendingMatchesError(Exception):
@@ -77,12 +82,14 @@ class GenerateMatchesUseCase:
         user_repository: UserRepositoryInterface,
         handicap_calculator: PlayingHandicapCalculator | None = None,
         scoring_service: ScoringService | None = None,
+        handicap_service: HandicapService | None = None,
     ):
         self._uow = uow
         self._gc_repo = golf_course_repository
         self._user_repo = user_repository
         self._calculator = handicap_calculator or PlayingHandicapCalculator()
         self._scoring_service = scoring_service or ScoringService()
+        self._handicap_service = handicap_service
 
     async def execute(
         self, request: GenerateMatchesRequestDTO, user_id: UserId, is_admin: bool = False
@@ -151,6 +158,7 @@ class GenerateMatchesUseCase:
                 golf_course,
                 is_scratch,
                 team_assignment,
+                enrollment_map,
             )
 
             # 11. Eliminar partidos existentes (re-generación)
@@ -209,7 +217,7 @@ class GenerateMatchesUseCase:
             round_status=round_entity.status.value,
         )
 
-    async def _build_handicap_data(self, golf_course, is_scratch, team_assignment):
+    async def _build_handicap_data(self, golf_course, is_scratch, team_assignment, enrollment_map):
         """Pre-fetch tee ratings, hole stroke order, user handicaps, and user genders."""
         tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
         holes_by_stroke_index: list[int] = []
@@ -244,11 +252,58 @@ class GenerateMatchesUseCase:
             )
             for pid, user in zip(all_player_ids, users, strict=True):
                 if user:
+                    enrollment = enrollment_map.get(str(pid.value))
+                    has_custom_handicap = enrollment is not None and enrollment.custom_handicap is not None
+                    if not has_custom_handicap:
+                        await self._maybe_refresh_rfeg_handicap(user)
                     if user.handicap is not None:
                         user_handicap_map[str(pid.value)] = Decimal(str(user.handicap.value))
                     user_gender_map[str(pid.value)] = user.gender
 
         return tee_ratings, holes_by_stroke_index, user_handicap_map, user_gender_map
+
+    async def _maybe_refresh_rfeg_handicap(self, user) -> None:
+        """
+        HM-1a: refresco best-effort del hándicap RFEG antes de generar partidos.
+
+        Solo para jugadores ES sin hándicap personalizado en la inscripción, y como
+        máximo una vez al día (mismo gate que el refresco en login, HM-2a/c). Errores
+        de red o de persistencia se registran y se ignoran: nunca deben bloquear la
+        generación de partidos.
+        """
+        if self._handicap_service is None:
+            return
+
+        country_code_value = user.country_code.value if user.country_code else None
+        if country_code_value != "ES":
+            return
+
+        now = datetime.now(UTC)
+        if user.handicap_updated_at is not None and user.handicap_updated_at.date() == now.date():
+            return
+
+        try:
+            handicap_value = await self._handicap_service.search_handicap(user.get_full_name())
+        except Exception:
+            logger.warning(
+                "RFEG lookup failed for %s during match generation",
+                user.get_full_name(),
+                exc_info=True,
+            )
+            return
+
+        if handicap_value is None:
+            return
+
+        try:
+            user.update_handicap(handicap_value)
+            await self._user_repo.save(user)
+        except Exception:
+            logger.error(
+                "Failed to persist RFEG handicap for %s during match generation",
+                user.get_full_name(),
+                exc_info=True,
+            )
 
     async def _generate_auto(
         self,
@@ -508,6 +563,7 @@ class GenerateMatchesUseCase:
                 tee_category=tee_category,
                 strokes_received=[],
                 tee_gender=tee_gender,
+                player_handicap=handicap_index,
             )
 
         if not tee_rating:
@@ -527,6 +583,7 @@ class GenerateMatchesUseCase:
             tee_category=tee_category,
             strokes_received=strokes_received,
             tee_gender=tee_gender,
+            player_handicap=handicap_index,
         )
 
     def _build_fourball_match_players(
@@ -558,7 +615,7 @@ class GenerateMatchesUseCase:
             # En modo SCRATCH, todos juegan off scratch
             team_a_players = []
             for uid in team_a_ids:
-                tee_cat, tee_gen, _, _ = self._resolve_player_data(
+                tee_cat, tee_gen, _, hi = self._resolve_player_data(
                     uid, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
                 )
                 team_a_players.append(
@@ -568,11 +625,12 @@ class GenerateMatchesUseCase:
                         tee_category=tee_cat,
                         strokes_received=[],
                         tee_gender=tee_gen,
+                        player_handicap=hi,
                     )
                 )
             team_b_players = []
             for uid in team_b_ids:
-                tee_cat, tee_gen, _, _ = self._resolve_player_data(
+                tee_cat, tee_gen, _, hi = self._resolve_player_data(
                     uid, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
                 )
                 team_b_players.append(
@@ -582,6 +640,7 @@ class GenerateMatchesUseCase:
                         tee_category=tee_cat,
                         strokes_received=[],
                         tee_gender=tee_gen,
+                        player_handicap=hi,
                     )
                 )
             return team_a_players, team_b_players
@@ -613,7 +672,7 @@ class GenerateMatchesUseCase:
         # 3. Construir MatchPlayers con PH diferencial
         def build_player(uid):
             uid_str = str(uid.value)
-            tee_cat, tee_gen, _, _ = player_data[uid_str]
+            tee_cat, tee_gen, _, hi = player_data[uid_str]
             ph = differential_phs[uid_str]
             strokes = calculator.compute_strokes_received(ph, holes_by_stroke_index)
             return MatchPlayer.create(
@@ -622,6 +681,7 @@ class GenerateMatchesUseCase:
                 tee_category=tee_cat,
                 strokes_received=strokes,
                 tee_gender=tee_gen,
+                player_handicap=hi,
             )
 
         team_a_players = [build_player(uid) for uid in team_a_ids]
@@ -664,11 +724,11 @@ class GenerateMatchesUseCase:
             return (
                 MatchPlayer.create(
                     user_id=a_player_id, playing_handicap=0, tee_category=tee_cat_a,
-                    strokes_received=[], tee_gender=tee_gen_a,
+                    strokes_received=[], tee_gender=tee_gen_a, player_handicap=hi_a,
                 ),
                 MatchPlayer.create(
                     user_id=b_player_id, playing_handicap=0, tee_category=tee_cat_b,
-                    strokes_received=[], tee_gender=tee_gen_b,
+                    strokes_received=[], tee_gender=tee_gen_b, player_handicap=hi_b,
                 ),
             )
 
@@ -700,11 +760,11 @@ class GenerateMatchesUseCase:
         return (
             MatchPlayer.create(
                 user_id=a_player_id, playing_handicap=ph_a, tee_category=tee_cat_a,
-                strokes_received=strokes_a, tee_gender=tee_gen_a,
+                strokes_received=strokes_a, tee_gender=tee_gen_a, player_handicap=hi_a,
             ),
             MatchPlayer.create(
                 user_id=b_player_id, playing_handicap=ph_b, tee_category=tee_cat_b,
-                strokes_received=strokes_b, tee_gender=tee_gen_b,
+                strokes_received=strokes_b, tee_gender=tee_gen_b, player_handicap=hi_b,
             ),
         )
 
@@ -740,7 +800,7 @@ class GenerateMatchesUseCase:
         if is_scratch:
             team_a_players = []
             for uid in team_a_ids:
-                tee_cat, tee_gen, _, _ = self._resolve_player_data(
+                tee_cat, tee_gen, _, hi = self._resolve_player_data(
                     uid, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
                 )
                 team_a_players.append(
@@ -750,11 +810,12 @@ class GenerateMatchesUseCase:
                         tee_category=tee_cat,
                         strokes_received=[],
                         tee_gender=tee_gen,
+                        player_handicap=hi,
                     )
                 )
             team_b_players = []
             for uid in team_b_ids:
-                tee_cat, tee_gen, _, _ = self._resolve_player_data(
+                tee_cat, tee_gen, _, hi = self._resolve_player_data(
                     uid, enrollment_map, tee_ratings, user_handicap_map, user_gender_map
                 )
                 team_b_players.append(
@@ -764,12 +825,13 @@ class GenerateMatchesUseCase:
                         tee_category=tee_cat,
                         strokes_received=[],
                         tee_gender=tee_gen,
+                        player_handicap=hi,
                     )
                 )
             return team_a_players, team_b_players
 
         # 1. Calcular Course Handicaps individuales (100%, sin allowance)
-        player_data: dict[str, tuple[TeeCategory, Gender | None]] = {}
+        player_data: dict[str, tuple[TeeCategory, Gender | None, Decimal]] = {}
         team_a_chs: list[int] = []
         team_b_chs: list[int] = []
 
@@ -782,7 +844,7 @@ class GenerateMatchesUseCase:
                     f"No se encontró tee rating para categoría '{tee_cat.value}' "
                     f"(gender: {tee_gen}) en el campo de golf"
                 )
-            player_data[str(uid.value)] = (tee_cat, tee_gen)
+            player_data[str(uid.value)] = (tee_cat, tee_gen, hi)
             ch = calculator.calculate_course_handicap(hi, tee_rating)
             if uid in team_a_ids:
                 team_a_chs.append(ch)
@@ -805,7 +867,7 @@ class GenerateMatchesUseCase:
 
         team_a_players = []
         for uid in team_a_ids:
-            tee_cat, tee_gen = player_data[str(uid.value)]
+            tee_cat, tee_gen, hi = player_data[str(uid.value)]
             team_a_players.append(
                 MatchPlayer.create(
                     user_id=uid,
@@ -813,12 +875,13 @@ class GenerateMatchesUseCase:
                     tee_category=tee_cat,
                     strokes_received=team_a_strokes,
                     tee_gender=tee_gen,
+                    player_handicap=hi,
                 )
             )
 
         team_b_players = []
         for uid in team_b_ids:
-            tee_cat, tee_gen = player_data[str(uid.value)]
+            tee_cat, tee_gen, hi = player_data[str(uid.value)]
             team_b_players.append(
                 MatchPlayer.create(
                     user_id=uid,
@@ -826,6 +889,7 @@ class GenerateMatchesUseCase:
                     tee_category=tee_cat,
                     strokes_received=team_b_strokes,
                     tee_gender=tee_gen,
+                    player_handicap=hi,
                 )
             )
 

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -85,7 +85,7 @@ class GenerateMatchesUseCase:
         self._scoring_service = scoring_service or ScoringService()
 
     async def execute(
-        self, request: GenerateMatchesRequestDTO, user_id: UserId
+        self, request: GenerateMatchesRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> GenerateMatchesResponseDTO:
         async with self._uow:
             # 1. Buscar la ronda
@@ -101,7 +101,7 @@ class GenerateMatchesUseCase:
                 raise CompetitionNotFoundError("La competición asociada no existe")
 
             # 3. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede generar partidos")
 
             # 4. Verificar competición CLOSED

--- a/src/modules/competition/application/use_cases/get_match_detail_use_case.py
+++ b/src/modules/competition/application/use_cases/get_match_detail_use_case.py
@@ -48,6 +48,9 @@ class GetMatchDetailUseCase:
                     playing_handicap=p.playing_handicap,
                     tee_category=p.tee_category.value,
                     strokes_received=list(p.strokes_received),
+                    player_handicap=float(p.player_handicap)
+                    if p.player_handicap is not None
+                    else None,
                 )
                 for p in match.team_a_players
             ],
@@ -57,6 +60,9 @@ class GetMatchDetailUseCase:
                     playing_handicap=p.playing_handicap,
                     tee_category=p.tee_category.value,
                     strokes_received=list(p.strokes_received),
+                    player_handicap=float(p.player_handicap)
+                    if p.player_handicap is not None
+                    else None,
                 )
                 for p in match.team_b_players
             ],

--- a/src/modules/competition/application/use_cases/get_match_detail_use_case.py
+++ b/src/modules/competition/application/use_cases/get_match_detail_use_case.py
@@ -43,28 +43,10 @@ class GetMatchDetailUseCase:
             round_id=match.round_id.value,
             match_number=match.match_number,
             team_a_players=[
-                MatchPlayerResponseDTO(
-                    user_id=p.user_id.value,
-                    playing_handicap=p.playing_handicap,
-                    tee_category=p.tee_category.value,
-                    strokes_received=list(p.strokes_received),
-                    player_handicap=float(p.player_handicap)
-                    if p.player_handicap is not None
-                    else None,
-                )
-                for p in match.team_a_players
+                MatchPlayerResponseDTO.from_domain(p) for p in match.team_a_players
             ],
             team_b_players=[
-                MatchPlayerResponseDTO(
-                    user_id=p.user_id.value,
-                    playing_handicap=p.playing_handicap,
-                    tee_category=p.tee_category.value,
-                    strokes_received=list(p.strokes_received),
-                    player_handicap=float(p.player_handicap)
-                    if p.player_handicap is not None
-                    else None,
-                )
-                for p in match.team_b_players
+                MatchPlayerResponseDTO.from_domain(p) for p in match.team_b_players
             ],
             status=match.status.value,
             handicap_strokes_given=match.handicap_strokes_given,

--- a/src/modules/competition/application/use_cases/get_schedule_use_case.py
+++ b/src/modules/competition/application/use_cases/get_schedule_use_case.py
@@ -67,28 +67,10 @@ class GetScheduleUseCase:
                     round_id=m.round_id.value,
                     match_number=m.match_number,
                     team_a_players=[
-                        MatchPlayerResponseDTO(
-                            user_id=p.user_id.value,
-                            playing_handicap=p.playing_handicap,
-                            tee_category=p.tee_category.value,
-                            strokes_received=list(p.strokes_received),
-                            player_handicap=float(p.player_handicap)
-                            if p.player_handicap is not None
-                            else None,
-                        )
-                        for p in m.team_a_players
+                        MatchPlayerResponseDTO.from_domain(p) for p in m.team_a_players
                     ],
                     team_b_players=[
-                        MatchPlayerResponseDTO(
-                            user_id=p.user_id.value,
-                            playing_handicap=p.playing_handicap,
-                            tee_category=p.tee_category.value,
-                            strokes_received=list(p.strokes_received),
-                            player_handicap=float(p.player_handicap)
-                            if p.player_handicap is not None
-                            else None,
-                        )
-                        for p in m.team_b_players
+                        MatchPlayerResponseDTO.from_domain(p) for p in m.team_b_players
                     ],
                     status=m.status.value,
                     handicap_strokes_given=m.handicap_strokes_given,

--- a/src/modules/competition/application/use_cases/get_schedule_use_case.py
+++ b/src/modules/competition/application/use_cases/get_schedule_use_case.py
@@ -72,6 +72,9 @@ class GetScheduleUseCase:
                             playing_handicap=p.playing_handicap,
                             tee_category=p.tee_category.value,
                             strokes_received=list(p.strokes_received),
+                            player_handicap=float(p.player_handicap)
+                            if p.player_handicap is not None
+                            else None,
                         )
                         for p in m.team_a_players
                     ],
@@ -81,6 +84,9 @@ class GetScheduleUseCase:
                             playing_handicap=p.playing_handicap,
                             tee_category=p.tee_category.value,
                             strokes_received=list(p.strokes_received),
+                            player_handicap=float(p.player_handicap)
+                            if p.player_handicap is not None
+                            else None,
                         )
                         for p in m.team_b_players
                     ],

--- a/src/modules/competition/application/use_cases/handle_enrollment_use_case.py
+++ b/src/modules/competition/application/use_cases/handle_enrollment_use_case.py
@@ -8,25 +8,17 @@ from src.modules.competition.application.dto.enrollment_dto import (
     HandleEnrollmentRequestDTO,
     HandleEnrollmentResponseDTO,
 )
-from src.modules.competition.application.exceptions import CompetitionNotFoundError
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    EnrollmentNotFoundError,
+    NotCreatorError,
+)
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.services.competition_policy import CompetitionPolicy
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class EnrollmentNotFoundError(Exception):
-    """Excepción lanzada cuando la inscripción no existe."""
-
-    pass
-
-
-class NotCreatorError(Exception):
-    """Excepción lanzada cuando el usuario no es el creador de la competición."""
-
-    pass
 
 
 class InvalidActionError(Exception):

--- a/src/modules/competition/application/use_cases/handle_enrollment_use_case.py
+++ b/src/modules/competition/application/use_cases/handle_enrollment_use_case.py
@@ -62,7 +62,7 @@ class HandleEnrollmentUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: HandleEnrollmentRequestDTO, creator_id: UserId
+        self, request: HandleEnrollmentRequestDTO, creator_id: UserId, is_admin: bool = False
     ) -> HandleEnrollmentResponseDTO:
         """
         Ejecuta el caso de uso de manejo de inscripción.
@@ -99,7 +99,7 @@ class HandleEnrollmentUseCase:
                 )
 
             # 3. Verificar que es el creador
-            if competition.creator_id != creator_id:
+            if not is_admin and competition.creator_id != creator_id:
                 raise NotCreatorError(
                     "Solo el creador de la competición puede aprobar o rechazar inscripciones"
                 )

--- a/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
+++ b/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
@@ -77,11 +77,11 @@ class ReassignMatchPlayersUseCase:
         self._calculator = handicap_calculator or PlayingHandicapCalculator()
 
     async def execute(
-        self, request: ReassignMatchPlayersRequestDTO, user_id: UserId
+        self, request: ReassignMatchPlayersRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> ReassignMatchPlayersResponseDTO:
         async with self._uow:
             # 1-4. Validaciones
-            match, round_entity, competition = await self._validate(request, user_id)
+            match, round_entity, competition = await self._validate(request, user_id, is_admin)
 
             # 5. Verificar que los jugadores pertenecen al equipo correcto
             team_assignment = await self._uow.team_assignments.find_by_competition(
@@ -258,7 +258,7 @@ class ReassignMatchPlayersUseCase:
             tee_gender=tee_gender,
         )
 
-    async def _validate(self, request, user_id):
+    async def _validate(self, request, user_id, is_admin: bool = False):
         """Validaciones: buscar match, ronda, competicion, verificar creador y estado."""
         match_id = MatchId(request.match_id)
         match = await self._uow.matches.find_by_id(match_id)
@@ -279,7 +279,7 @@ class ReassignMatchPlayersUseCase:
         if not competition:
             raise MatchNotFoundError("La competicion asociada no existe")
 
-        if not competition.is_creator(user_id):
+        if not is_admin and not competition.is_creator(user_id):
             raise NotCompetitionCreatorError("Solo el creador puede reasignar jugadores")
 
         return match, round_entity, competition

--- a/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
+++ b/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
@@ -121,6 +121,7 @@ class ReassignMatchPlayersUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    competition.max_playing_handicap,
                 )
                 for uid in request.team_a_player_ids
             ]
@@ -134,6 +135,7 @@ class ReassignMatchPlayersUseCase:
                     user_handicap_map,
                     holes_by_stroke_index,
                     user_gender_map,
+                    competition.max_playing_handicap,
                 )
                 for uid in request.team_b_player_ids
             ]
@@ -205,6 +207,7 @@ class ReassignMatchPlayersUseCase:
         user_handicap_map,
         holes_by_stroke_index,
         user_gender_map,
+        max_playing_handicap=None,
     ) -> MatchPlayer:
         """Construye un MatchPlayer con handicap calculado y tee auto-resuelto."""
         uid = UserId(uid_value)
@@ -246,7 +249,9 @@ class ReassignMatchPlayersUseCase:
                 f"Verifique que el campo tiene un tee configurado para "
                 f"categoría={tee_category.value}, género={tee_gender}"
             )
-        playing_handicap = self._calculator.calculate(handicap_index, tee_rating, allowance)
+        playing_handicap = self._calculator.calculate(
+            handicap_index, tee_rating, allowance, max_playing_handicap
+        )
         strokes_received = self._calculator.compute_strokes_received(
             playing_handicap, holes_by_stroke_index
         )

--- a/src/modules/competition/application/use_cases/remove_custom_handicap_use_case.py
+++ b/src/modules/competition/application/use_cases/remove_custom_handicap_use_case.py
@@ -1,12 +1,13 @@
 """
-Caso de Uso: Establecer Handicap Personalizado (Set Custom Handicap).
+Caso de Uso: Eliminar Handicap Personalizado (Remove Custom Handicap).
 
-Permite al creador establecer un handicap personalizado para un jugador inscrito.
+Permite al creador revertir el handicap personalizado de un jugador, volviendo a usar
+su handicap oficial (el del perfil, actualizado vía RFEG en los flujos ya existentes
+de login y generación de partidos).
 """
 
 from src.modules.competition.application.dto.enrollment_dto import (
-    SetCustomHandicapRequestDTO,
-    SetCustomHandicapResponseDTO,
+    RemoveCustomHandicapResponseDTO,
 )
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
@@ -32,21 +33,22 @@ class NotCreatorError(Exception):
     pass
 
 
-class SetCustomHandicapUseCase:
+class RemoveCustomHandicapUseCase:
     """
-    Caso de uso para establecer un handicap personalizado.
+    Caso de uso para eliminar el handicap personalizado de un jugador.
 
     Orquesta:
     1. Validacion de existencia del enrollment
     2. Validacion de existencia de la competicion
-    3. Validacion de que el solicitante es el creador
-    4. Establecer el handicap personalizado
-    5. Persistencia mediante UoW
+    3. Validacion de que el solicitante es el creador (o admin)
+    4. Validacion de que el enrollment esta aprobado
+    5. Validacion de que la competicion permite editar handicaps (DRAFT/ACTIVE/CLOSED)
+    6. Eliminar el handicap personalizado (vuelve a usarse el handicap oficial)
+    7. Persistencia mediante UoW
 
     Reglas de negocio:
-    - Solo el creador puede establecer handicaps personalizados
-    - El handicap debe estar en rango valido (-10.0 a 54.0)
-    - Este valor hace override del handicap oficial del jugador
+    - Solo el creador (o admin) puede eliminar handicaps personalizados
+    - Solo se permite mientras la competicion esta en DRAFT, ACTIVE o CLOSED
     """
 
     def __init__(self, uow: CompetitionUnitOfWorkInterface):
@@ -59,31 +61,33 @@ class SetCustomHandicapUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: SetCustomHandicapRequestDTO, creator_id: UserId, is_admin: bool = False
-    ) -> SetCustomHandicapResponseDTO:
+        self, enrollment_id: str, creator_id: UserId, is_admin: bool = False
+    ) -> RemoveCustomHandicapResponseDTO:
         """
-        Ejecuta el caso de uso de establecer handicap personalizado.
+        Ejecuta el caso de uso de eliminar handicap personalizado.
 
         Args:
-            request: DTO con enrollment_id y custom_handicap
+            enrollment_id: ID de la inscripcion
             creator_id: ID del usuario que ejecuta la accion (debe ser el creador)
+            is_admin: Si el usuario es admin (bypass del check de creador)
 
         Returns:
-            DTO con los datos actualizados
+            DTO con los datos actualizados (custom_handicap=None)
 
         Raises:
             EnrollmentNotFoundError: Si la inscripcion no existe
             CompetitionNotFoundError: Si la competicion no existe
-            NotCreatorError: Si el solicitante no es el creador
-            ValueError: Si el handicap no es valido
+            NotCreatorError: Si el solicitante no es el creador ni admin
+            EnrollmentStateError: Si el enrollment no esta aprobado
+            HandicapEditNotAllowedError: Si la competicion no permite editar handicaps
         """
         async with self._uow:
-            enrollment_id = EnrollmentId(request.enrollment_id)
+            eid = EnrollmentId(enrollment_id)
 
             # 1. Obtener enrollment
-            enrollment = await self._uow.enrollments.find_by_id(enrollment_id)
+            enrollment = await self._uow.enrollments.find_by_id(eid)
             if not enrollment:
-                raise EnrollmentNotFoundError(f"Inscripcion no encontrada: {request.enrollment_id}")
+                raise EnrollmentNotFoundError(f"Inscripcion no encontrada: {enrollment_id}")
 
             # 2. Obtener competicion
             competition = await self._uow.competitions.find_by_id(enrollment.competition_id)
@@ -95,30 +99,30 @@ class SetCustomHandicapUseCase:
             # 3. Verificar que es el creador
             if not is_admin and competition.creator_id != creator_id:
                 raise NotCreatorError(
-                    "Solo el creador de la competicion puede establecer handicaps personalizados"
+                    "Solo el creador de la competicion puede eliminar handicaps personalizados"
                 )
 
             # 4. Verificar que el enrollment esta aprobado
             if not enrollment.is_approved():
                 raise EnrollmentStateError(
-                    "Solo se puede establecer un handicap personalizado en inscripciones aprobadas"
+                    "Solo se puede eliminar el handicap personalizado de inscripciones aprobadas"
                 )
 
-            # 4b. Verificar que la competicion permite editar handicaps (DRAFT/ACTIVE/CLOSED)
+            # 5. Verificar que la competicion permite editar handicaps (DRAFT/ACTIVE/CLOSED)
             if not competition.status.allows_handicap_edits():
                 raise HandicapEditNotAllowedError(
                     "El hándicap personalizado solo puede modificarse mientras la competición "
                     f"está en DRAFT, ACTIVE o CLOSED. Estado actual: {competition.status.value}"
                 )
 
-            # 5. Establecer handicap (la entidad valida el rango)
-            enrollment.set_custom_handicap(request.custom_handicap)
+            # 6. Eliminar handicap personalizado
+            enrollment.remove_custom_handicap()
 
-            # 6. Persistir cambios
+            # 7. Persistir cambios
             await self._uow.enrollments.update(enrollment)
 
         # 8. Retornar DTO
-        return SetCustomHandicapResponseDTO(
+        return RemoveCustomHandicapResponseDTO(
             id=enrollment.id.value,
             competition_id=enrollment.competition_id.value,
             user_id=enrollment.user_id.value,

--- a/src/modules/competition/application/use_cases/remove_custom_handicap_use_case.py
+++ b/src/modules/competition/application/use_cases/remove_custom_handicap_use_case.py
@@ -11,7 +11,9 @@ from src.modules.competition.application.dto.enrollment_dto import (
 )
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
+    EnrollmentNotFoundError,
     HandicapEditNotAllowedError,
+    NotCreatorError,
 )
 from src.modules.competition.domain.entities.enrollment import EnrollmentStateError
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
@@ -19,18 +21,6 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
 )
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class EnrollmentNotFoundError(Exception):
-    """Excepcion lanzada cuando la inscripcion no existe."""
-
-    pass
-
-
-class NotCreatorError(Exception):
-    """Excepcion lanzada cuando el usuario no es el creador de la competicion."""
-
-    pass
 
 
 class RemoveCustomHandicapUseCase:

--- a/src/modules/competition/application/use_cases/remove_golf_course_use_case.py
+++ b/src/modules/competition/application/use_cases/remove_golf_course_use_case.py
@@ -58,7 +58,7 @@ class RemoveGolfCourseFromCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: RemoveGolfCourseRequestDTO, user_id: UserId
+        self, request: RemoveGolfCourseRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> RemoveGolfCourseResponseDTO:
         """
         Ejecuta el caso de uso de eliminar campo de golf de competicion.
@@ -87,7 +87,7 @@ class RemoveGolfCourseFromCompetitionUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError(
                     "Solo el creador puede eliminar campos de golf de la competicion"
                 )

--- a/src/modules/competition/application/use_cases/reopen_enrollments_use_case.py
+++ b/src/modules/competition/application/use_cases/reopen_enrollments_use_case.py
@@ -44,7 +44,7 @@ class ReopenEnrollmentsUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: ReopenEnrollmentsRequestDTO, user_id: UserId
+        self, request: ReopenEnrollmentsRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> ReopenEnrollmentsResponseDTO:
         """
         Ejecuta el caso de uso de reapertura de inscripciones.
@@ -71,8 +71,8 @@ class ReopenEnrollmentsUseCase:
                     f"No existe competición con ID {request.competition_id}"
                 )
 
-            # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            # 2. Verificar que el usuario sea el creador (o admin)
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede reabrir inscripciones")
 
             # 3. Reabrir inscripciones (la entidad valida la transición)

--- a/src/modules/competition/application/use_cases/reorder_golf_courses_use_case.py
+++ b/src/modules/competition/application/use_cases/reorder_golf_courses_use_case.py
@@ -47,7 +47,7 @@ class ReorderGolfCoursesUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: ReorderGolfCoursesRequestDTO, user_id: UserId
+        self, request: ReorderGolfCoursesRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> ReorderGolfCoursesResponseDTO:
         async with self._uow:
             # 1. Buscar la competición
@@ -60,7 +60,7 @@ class ReorderGolfCoursesUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError(
                     "Solo el creador puede reordenar campos de golf de la competición"
                 )

--- a/src/modules/competition/application/use_cases/revert_competition_status_use_case.py
+++ b/src/modules/competition/application/use_cases/revert_competition_status_use_case.py
@@ -44,7 +44,7 @@ class RevertCompetitionStatusUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: RevertCompetitionStatusRequestDTO, user_id: UserId
+        self, request: RevertCompetitionStatusRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> RevertCompetitionStatusResponseDTO:
         """
         Ejecuta el caso de uso de reversión de competición.
@@ -72,7 +72,7 @@ class RevertCompetitionStatusUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede revertir la competición")
 
             # 3. Revertir la competición (la entidad valida la transición)

--- a/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
@@ -58,7 +58,7 @@ class SendInvitationByEmailUseCase:
         self._user_uow = user_uow
         self._email_service = email_service
 
-    async def execute(self, request: SendInvitationByEmailRequestDTO) -> InvitationResponseDTO:
+    async def execute(self, request: SendInvitationByEmailRequestDTO, is_admin: bool = False) -> InvitationResponseDTO:
         async with self._uow:
             competition_id = CompetitionId(request.competition_id)
             inviter_id = UserId(request.inviter_id)
@@ -69,7 +69,7 @@ class SendInvitationByEmailUseCase:
                 raise CompetitionNotFoundError(f"Competition not found: {request.competition_id}")
 
             # 2. Verificar creator/admin
-            if not competition.is_creator(inviter_id):
+            if not is_admin and not competition.is_creator(inviter_id):
                 raise NotCompetitionCreatorError(
                     "Only the competition creator can send invitations."
                 )

--- a/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
@@ -58,7 +58,7 @@ class SendInvitationByUserIdUseCase:
         self._user_uow = user_uow
         self._email_service = email_service
 
-    async def execute(self, request: SendInvitationByUserIdRequestDTO) -> InvitationResponseDTO:
+    async def execute(self, request: SendInvitationByUserIdRequestDTO, is_admin: bool = False) -> InvitationResponseDTO:
         async with self._uow:
             competition_id = CompetitionId(request.competition_id)
             inviter_id = UserId(request.inviter_id)
@@ -70,7 +70,7 @@ class SendInvitationByUserIdUseCase:
                 raise CompetitionNotFoundError(f"Competition not found: {request.competition_id}")
 
             # 2. Verificar creator/admin
-            if not competition.is_creator(inviter_id):
+            if not is_admin and not competition.is_creator(inviter_id):
                 raise NotCompetitionCreatorError(
                     "Only the competition creator can send invitations."
                 )

--- a/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
+++ b/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
@@ -56,7 +56,7 @@ class SetCustomHandicapUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: SetCustomHandicapRequestDTO, creator_id: UserId
+        self, request: SetCustomHandicapRequestDTO, creator_id: UserId, is_admin: bool = False
     ) -> SetCustomHandicapResponseDTO:
         """
         Ejecuta el caso de uso de establecer handicap personalizado.
@@ -90,7 +90,7 @@ class SetCustomHandicapUseCase:
                 )
 
             # 3. Verificar que es el creador
-            if competition.creator_id != creator_id:
+            if not is_admin and competition.creator_id != creator_id:
                 raise NotCreatorError(
                     "Solo el creador de la competicion puede establecer handicaps personalizados"
                 )

--- a/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
+++ b/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
@@ -110,6 +110,9 @@ class SetCustomHandicapUseCase:
         # 8. Retornar DTO
         return SetCustomHandicapResponseDTO(
             id=enrollment.id.value,
+            competition_id=enrollment.competition_id.value,
+            user_id=enrollment.user_id.value,
+            status=enrollment.status.value,
             custom_handicap=enrollment.custom_handicap,
             updated_at=enrollment.updated_at,
         )

--- a/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
+++ b/src/modules/competition/application/use_cases/set_custom_handicap_use_case.py
@@ -10,7 +10,9 @@ from src.modules.competition.application.dto.enrollment_dto import (
 )
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
+    EnrollmentNotFoundError,
     HandicapEditNotAllowedError,
+    NotCreatorError,
 )
 from src.modules.competition.domain.entities.enrollment import EnrollmentStateError
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
@@ -18,18 +20,6 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
 )
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class EnrollmentNotFoundError(Exception):
-    """Excepcion lanzada cuando la inscripcion no existe."""
-
-    pass
-
-
-class NotCreatorError(Exception):
-    """Excepcion lanzada cuando el usuario no es el creador de la competicion."""
-
-    pass
 
 
 class SetCustomHandicapUseCase:

--- a/src/modules/competition/application/use_cases/start_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/start_competition_use_case.py
@@ -50,7 +50,7 @@ class StartCompetitionUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: StartCompetitionRequestDTO, user_id: UserId
+        self, request: StartCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> StartCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de inicio de competición.
@@ -78,7 +78,7 @@ class StartCompetitionUseCase:
                 )
 
             # 2. Verificar que el usuario sea el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede iniciar la competición")
 
             # 3. Iniciar la competición (la entidad valida la transición)

--- a/src/modules/competition/application/use_cases/update_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/update_competition_use_case.py
@@ -135,6 +135,7 @@ class UpdateCompetitionUseCase:
                 team_assignment=team_assignment,
                 team_1_name=request.team_1_name,
                 team_2_name=request.team_2_name,
+                max_playing_handicap=request.max_playing_handicap,
             )
 
             # 6. Persistir cambios

--- a/src/modules/competition/application/use_cases/update_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/update_competition_use_case.py
@@ -64,6 +64,7 @@ class UpdateCompetitionUseCase:
         competition_id: CompetitionId,
         request: UpdateCompetitionRequestDTO,
         user_id: UserId,
+        is_admin: bool = False,
     ) -> UpdateCompetitionResponseDTO:
         """
         Ejecuta el caso de uso de actualización de competición.
@@ -90,7 +91,7 @@ class UpdateCompetitionUseCase:
                 )
 
             # 2. Validar que el usuario es el creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede actualizar la competición")
 
             # 3. Validar que está en estado DRAFT (se puede modificar)

--- a/src/modules/competition/application/use_cases/update_match_status_use_case.py
+++ b/src/modules/competition/application/use_cases/update_match_status_use_case.py
@@ -46,11 +46,11 @@ class UpdateMatchStatusUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: UpdateMatchStatusRequestDTO, user_id: UserId
+        self, request: UpdateMatchStatusRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> UpdateMatchStatusResponseDTO:
         async with self._uow:
             # 1-4. Validaciones
-            match, round_entity = await self._validate(request, user_id)
+            match, round_entity = await self._validate(request, user_id, is_admin)
 
             # 5. Ejecutar accion
             if request.action == "START":
@@ -71,7 +71,7 @@ class UpdateMatchStatusUseCase:
             updated_at=match.updated_at,
         )
 
-    async def _validate(self, request, user_id):
+    async def _validate(self, request, user_id, is_admin: bool = False):
         """Validaciones: buscar match, ronda, competicion, verificar creador y estado."""
         match_id = MatchId(request.match_id)
         match = await self._uow.matches.find_by_id(match_id)
@@ -87,7 +87,7 @@ class UpdateMatchStatusUseCase:
         if not competition:
             raise CompetitionNotFoundError("La competicion asociada no existe")
 
-        if not competition.is_creator(user_id):
+        if not is_admin and not competition.is_creator(user_id):
             raise NotCompetitionCreatorError("Solo el creador puede actualizar partidos")
 
         if not competition.is_in_progress():

--- a/src/modules/competition/application/use_cases/update_round_use_case.py
+++ b/src/modules/competition/application/use_cases/update_round_use_case.py
@@ -50,7 +50,7 @@ class UpdateRoundUseCase:
         self._uow = uow
 
     async def execute(
-        self, request: UpdateRoundRequestDTO, user_id: UserId
+        self, request: UpdateRoundRequestDTO, user_id: UserId, is_admin: bool = False
     ) -> UpdateRoundResponseDTO:
         async with self._uow:
             # 1. Buscar la ronda
@@ -67,7 +67,7 @@ class UpdateRoundUseCase:
                 raise CompetitionNotFoundError("La competición asociada no existe")
 
             # 3. Verificar creador
-            if not competition.is_creator(user_id):
+            if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede actualizar rondas")
 
             # 4. Verificar competición CLOSED

--- a/src/modules/competition/application/use_cases/withdraw_enrollment_use_case.py
+++ b/src/modules/competition/application/use_cases/withdraw_enrollment_use_case.py
@@ -8,17 +8,12 @@ from src.modules.competition.application.dto.enrollment_dto import (
     WithdrawEnrollmentRequestDTO,
     WithdrawEnrollmentResponseDTO,
 )
+from src.modules.competition.application.exceptions import EnrollmentNotFoundError
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.user.domain.value_objects.user_id import UserId
-
-
-class EnrollmentNotFoundError(Exception):
-    """Excepción lanzada cuando la inscripción no existe."""
-
-    pass
 
 
 class NotOwnerError(Exception):

--- a/src/modules/competition/domain/entities/competition.py
+++ b/src/modules/competition/domain/entities/competition.py
@@ -101,10 +101,13 @@ class Competition:
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
+        max_playing_handicap: int | None = None,
     ):
         # Validaciones de invariantes
         self._validate_team_names(team_1_name, team_2_name)
         self._validate_max_players(max_players)
+        if max_playing_handicap is not None:
+            self._validate_max_playing_handicap(max_playing_handicap)
 
         # Asignación de atributos privados (encapsulación)
         self._id = id
@@ -117,6 +120,7 @@ class Competition:
         self._play_mode = play_mode
         self._max_players = max_players
         self._team_assignment = team_assignment
+        self._max_playing_handicap = max_playing_handicap
         self._status = status
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
@@ -136,6 +140,7 @@ class Competition:
         play_mode: PlayMode,
         max_players: int = 24,
         team_assignment: TeamAssignment = TeamAssignment.MANUAL,
+        max_playing_handicap: int | None = None,
     ) -> "Competition":
         """
         Factory method para crear una nueva competición.
@@ -153,6 +158,7 @@ class Competition:
             play_mode=play_mode,
             max_players=max_players,
             team_assignment=team_assignment,
+            max_playing_handicap=max_playing_handicap,
             status=CompetitionStatus.DRAFT,
         )
 
@@ -183,6 +189,12 @@ class Competition:
         """Valida que max_players esté en rango válido."""
         if not MIN_PLAYERS <= max_players <= MAX_PLAYERS:
             raise ValueError(f"max_players debe estar entre {MIN_PLAYERS} y {MAX_PLAYERS}")
+
+    @staticmethod
+    def _validate_max_playing_handicap(max_playing_handicap: int) -> None:
+        """Valida que max_playing_handicap esté en rango válido (WHS: 0–54)."""
+        if not 1 <= max_playing_handicap <= 54:
+            raise ValueError("max_playing_handicap debe estar entre 1 y 54")
 
     # ===========================================
     # PROPERTIES (Encapsulación — solo lectura)
@@ -227,6 +239,10 @@ class Competition:
     @property
     def team_assignment(self) -> TeamAssignment:
         return self._team_assignment
+
+    @property
+    def max_playing_handicap(self) -> int | None:
+        return self._max_playing_handicap
 
     @property
     def status(self) -> CompetitionStatus:
@@ -439,6 +455,7 @@ class Competition:
         play_mode: PlayMode | None = None,
         max_players: int | None = None,
         team_assignment: TeamAssignment | None = None,
+        max_playing_handicap: int | None = None,
     ) -> None:
         """
         Actualiza la información del torneo. Solo permitido en estado DRAFT.
@@ -471,6 +488,10 @@ class Competition:
 
         if team_assignment is not None:
             self._team_assignment = team_assignment
+
+        if max_playing_handicap is not None:
+            self._validate_max_playing_handicap(max_playing_handicap)
+            self._max_playing_handicap = max_playing_handicap
 
         # Validar y actualizar nombres de equipos
         updated_team_1 = team_1_name if team_1_name is not None else self._team_1_name

--- a/src/modules/competition/domain/entities/competition.py
+++ b/src/modules/competition/domain/entities/competition.py
@@ -39,6 +39,8 @@ from ..value_objects.team_assignment import TeamAssignment
 # Constantes de validación
 MIN_PLAYERS = 2
 MAX_PLAYERS = 100
+MIN_PLAYING_HANDICAP = 1
+MAX_PLAYING_HANDICAP = 54
 
 
 class CompetitionStateError(Exception):
@@ -192,9 +194,12 @@ class Competition:
 
     @staticmethod
     def _validate_max_playing_handicap(max_playing_handicap: int) -> None:
-        """Valida que max_playing_handicap esté en rango válido (WHS: 0–54)."""
-        if not 1 <= max_playing_handicap <= 54:
-            raise ValueError("max_playing_handicap debe estar entre 1 y 54")
+        """Valida que max_playing_handicap esté en rango válido (WHS: 1-54)."""
+        if not MIN_PLAYING_HANDICAP <= max_playing_handicap <= MAX_PLAYING_HANDICAP:
+            raise ValueError(
+                f"max_playing_handicap debe estar entre "
+                f"{MIN_PLAYING_HANDICAP} y {MAX_PLAYING_HANDICAP}"
+            )
 
     # ===========================================
     # PROPERTIES (Encapsulación — solo lectura)

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -85,6 +85,7 @@ class PlayingHandicapCalculator:
         handicap_index: Decimal,
         tee_rating: TeeRating,
         allowance_percentage: int,
+        max_playing_handicap: int | None = None,
     ) -> int:
         """
         Calcula el Playing Handicap (Handicap de Juego).
@@ -114,7 +115,10 @@ class PlayingHandicapCalculator:
         playing_handicap = int(playing_handicap_raw.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
         # Playing Handicap no puede ser negativo
-        return max(0, playing_handicap)
+        result = max(0, playing_handicap)
+        if max_playing_handicap is not None:
+            result = min(result, max_playing_handicap)
+        return result
 
     def calculate_for_singles(
         self,

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -97,9 +97,11 @@ class PlayingHandicapCalculator:
             handicap_index: Handicap Index del jugador (ej: 12.4)
             tee_rating: Ratings del tee (CR, SR, Par)
             allowance_percentage: Porcentaje de allowance (50-100)
+            max_playing_handicap: Límite superior opcional (cap WHS de la competición)
 
         Returns:
-            Playing Handicap redondeado al entero más cercano (>=0)
+            Playing Handicap redondeado al entero más cercano (>=0), acotado a
+            max_playing_handicap si se proporciona
         """
         # Paso 1: Calcular Course Handicap
         # CH = HI x (SR / 113) + (CR - Par)

--- a/src/modules/competition/domain/services/scoring_service.py
+++ b/src/modules/competition/domain/services/scoring_service.py
@@ -218,23 +218,24 @@ class ScoringService:
     @staticmethod
     def find_best_ball_player(
         player_net_scores: list[tuple[str, int | None]],
-    ) -> str | None:
+    ) -> list[str]:
         """
-        Encuentra el jugador con la mejor bola (menor net score) en un equipo.
+        Encuentra el/los jugador/es con la mejor bola (menor net score) en un equipo.
 
         Args:
             player_net_scores: Lista de (user_id, net_score) del equipo
 
         Returns:
-            user_id del jugador con mejor net score, o None si no hay scores
+            Lista de user_ids con el mejor net score. Vacía si no hay scores.
+            Múltiples elementos en caso de empate.
         """
-        best_uid = None
         best_score = None
-        for uid, net in player_net_scores:
+        for _, net in player_net_scores:
             if net is not None and (best_score is None or net < best_score):
                 best_score = net
-                best_uid = uid
-        return best_uid
+        if best_score is None:
+            return []
+        return [uid for uid, net in player_net_scores if net == best_score]
 
     def calculate_match_standing(
         self,

--- a/src/modules/competition/domain/value_objects/competition_status.py
+++ b/src/modules/competition/domain/value_objects/competition_status.py
@@ -89,6 +89,14 @@ class CompetitionStatus(StrEnum):
         """Verifica si el estado permite modificar la configuración."""
         return self == CompetitionStatus.DRAFT
 
+    def allows_handicap_edits(self) -> bool:
+        """Verifica si el estado permite editar el hándicap personalizado de un jugador."""
+        return self in {
+            CompetitionStatus.DRAFT,
+            CompetitionStatus.ACTIVE,
+            CompetitionStatus.CLOSED,
+        }
+
     def __composite_values__(self):
         """
         Retorna los valores para SQLAlchemy composite mapping.

--- a/src/modules/competition/domain/value_objects/match_player.py
+++ b/src/modules/competition/domain/value_objects/match_player.py
@@ -5,6 +5,7 @@ NO es una entidad (no tiene identidad propia), es un Value Object embebido en Ma
 """
 
 from dataclasses import dataclass
+from decimal import Decimal
 
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -47,6 +48,7 @@ class MatchPlayer:
     strokes_received: tuple[
         int, ...
     ]  # Hoyos donde recibe golpe (puede tener duplicados si PH > 18)
+    player_handicap: Decimal | None = None  # HM-1b: snapshot del HI usado al generar el partido
 
     def __post_init__(self):
         """Validaciones después de inicialización."""
@@ -66,6 +68,7 @@ class MatchPlayer:
         tee_category: TeeCategory,
         strokes_received: list[int] | tuple[int, ...],
         tee_gender: Gender | None = None,
+        player_handicap: Decimal | None = None,
     ) -> "MatchPlayer":
         """
         Factory method para crear un MatchPlayer.
@@ -76,6 +79,7 @@ class MatchPlayer:
             tee_category: Categoría de tee que usa
             strokes_received: Lista de hoyos donde recibe golpe
             tee_gender: Género del tee (MALE/FEMALE/None)
+            player_handicap: HI del jugador en el momento de generar el partido (snapshot)
 
         Returns:
             Nueva instancia de MatchPlayer
@@ -86,6 +90,7 @@ class MatchPlayer:
             tee_category=tee_category,
             tee_gender=tee_gender,
             strokes_received=tuple(strokes_received),
+            player_handicap=player_handicap,
         )
 
     def receives_stroke_on_hole(self, hole_number: int) -> bool:

--- a/src/modules/competition/infrastructure/api/v1/competition_crud_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_crud_routes.py
@@ -405,7 +405,7 @@ async def update_competition(
         current_user_id = UserId(str(current_user.id))
         competition_vo_id = CompetitionId(competition_id)
 
-        await use_case.execute(competition_vo_id, competition_data, current_user_id)
+        await use_case.execute(competition_vo_id, competition_data, current_user_id, is_admin=current_user.is_admin)
 
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
@@ -450,7 +450,7 @@ async def delete_competition(
 
         request_dto = DeleteCompetitionRequestDTO(competition_id=competition_id)
 
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         return
 

--- a/src/modules/competition/infrastructure/api/v1/competition_crud_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_crud_routes.py
@@ -170,7 +170,7 @@ async def _get_user_competitions(
     return created_competitions + enrolled_competitions
 
 
-async def _map_competitions_to_dtos(competitions, current_user_id, uow, user_uow):
+async def _map_competitions_to_dtos(competitions, current_user_id, uow, user_uow, is_admin=False):
     """Convierte entidades Competition a DTOs.
 
     Assumes caller manages the uow/user_uow transaction context.
@@ -178,7 +178,7 @@ async def _map_competitions_to_dtos(competitions, current_user_id, uow, user_uow
     result = []
     for competition in competitions:
         dto = await CompetitionDTOMapper.to_response_dto(
-            competition, current_user_id, uow, user_uow
+            competition, current_user_id, uow, user_uow, is_admin=is_admin
         )
         result.append(dto)
     return result
@@ -337,7 +337,9 @@ async def list_competitions(
                     search_creator,
                 )
 
-            result = await _map_competitions_to_dtos(competitions, current_user_id, uow, user_uow)
+            result = await _map_competitions_to_dtos(
+                competitions, current_user_id, uow, user_uow, is_admin=current_user.is_admin
+            )
 
         return result
     except ValueError as e:
@@ -373,7 +375,7 @@ async def get_competition(
                 )
 
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -417,7 +419,7 @@ async def update_competition(
                 )
 
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto

--- a/src/modules/competition/infrastructure/api/v1/competition_golf_course_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_golf_course_routes.py
@@ -100,7 +100,7 @@ async def add_golf_course_to_competition(
             golf_course_id=golf_course_body.golf_course_id,
         )
 
-        response = await use_case.execute(request_dto, current_user_id)
+        response = await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         return response
 
@@ -145,7 +145,7 @@ async def remove_golf_course_from_competition(
             golf_course_id=golf_course_id,
         )
 
-        response = await use_case.execute(request_dto, current_user_id)
+        response = await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         return response
 
@@ -181,7 +181,7 @@ async def reorder_golf_courses(
             golf_course_ids=reorder_body.golf_course_ids,
         )
 
-        response = await use_case.execute(request_dto, current_user_id)
+        response = await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         return response
 

--- a/src/modules/competition/infrastructure/api/v1/competition_state_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_state_routes.py
@@ -114,7 +114,7 @@ async def activate_competition(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = ActivateCompetitionRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -155,7 +155,7 @@ async def close_enrollments(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = CloseEnrollmentsRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -196,7 +196,7 @@ async def start_competition(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = StartCompetitionRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -237,7 +237,7 @@ async def complete_competition(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = CompleteCompetitionRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -278,7 +278,7 @@ async def revert_competition_status(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = RevertCompetitionStatusRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -319,7 +319,7 @@ async def reopen_enrollments(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = ReopenEnrollmentsRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:
@@ -360,7 +360,7 @@ async def cancel_competition(
         current_user_id = UserId(str(current_user.id))
 
         request_dto = CancelCompetitionRequestDTO(competition_id=competition_id)
-        await use_case.execute(request_dto, current_user_id)
+        await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
         competition_vo_id = CompetitionId(competition_id)
         async with uow, user_uow:

--- a/src/modules/competition/infrastructure/api/v1/competition_state_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_state_routes.py
@@ -120,7 +120,7 @@ async def activate_competition(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -161,7 +161,7 @@ async def close_enrollments(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -202,7 +202,7 @@ async def start_competition(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -243,7 +243,7 @@ async def complete_competition(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -284,7 +284,7 @@ async def revert_competition_status(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -325,7 +325,7 @@ async def reopen_enrollments(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto
@@ -366,7 +366,7 @@ async def cancel_competition(
         async with uow, user_uow:
             competition = await uow.competitions.find_by_id(competition_vo_id)
             dto = await CompetitionDTOMapper.to_response_dto(
-                competition, current_user_id, uow, user_uow
+                competition, current_user_id, uow, user_uow, is_admin=current_user.is_admin
             )
 
         return dto

--- a/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
@@ -255,7 +255,7 @@ async def direct_enroll_player(
             tee_category=request.tee_category,
         )
         creator_id = UserId(str(current_user.id))
-        return await use_case.execute(request_dto, creator_id)
+        return await use_case.execute(request_dto, creator_id, is_admin=current_user.is_admin)
 
     except DirectCompetitionNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
@@ -331,7 +331,7 @@ async def approve_enrollment(
     try:
         request_dto = HandleEnrollmentRequestDTO(enrollment_id=enrollment_id, action="APPROVE")
         creator_id = UserId(str(current_user.id))
-        return await use_case.execute(request_dto, creator_id)
+        return await use_case.execute(request_dto, creator_id, is_admin=current_user.is_admin)
 
     except HandleEnrollmentNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
@@ -362,7 +362,7 @@ async def reject_enrollment(
     try:
         request_dto = HandleEnrollmentRequestDTO(enrollment_id=enrollment_id, action="REJECT")
         creator_id = UserId(str(current_user.id))
-        return await use_case.execute(request_dto, creator_id)
+        return await use_case.execute(request_dto, creator_id, is_admin=current_user.is_admin)
 
     except HandleEnrollmentNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
@@ -460,7 +460,7 @@ async def set_custom_handicap(
             enrollment_id=enrollment_id, custom_handicap=request.custom_handicap
         )
         creator_id = UserId(str(current_user.id))
-        return await use_case.execute(request_dto, creator_id)
+        return await use_case.execute(request_dto, creator_id, is_admin=current_user.is_admin)
 
     except HandicapEnrollmentNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
@@ -16,6 +16,7 @@ from src.config.dependencies import (
     get_direct_enroll_player_use_case,
     get_handle_enrollment_use_case,
     get_list_enrollments_use_case,
+    get_remove_custom_handicap_use_case,
     get_request_enrollment_use_case,
     get_set_custom_handicap_use_case,
     get_uow,  # User Unit of Work para obtener datos del usuario
@@ -30,6 +31,7 @@ from src.modules.competition.application.dto.enrollment_dto import (
     EnrollmentResponseDTO,
     HandleEnrollmentRequestDTO,
     HandleEnrollmentResponseDTO,
+    RemoveCustomHandicapResponseDTO,
     RequestEnrollmentRequestDTO,
     RequestEnrollmentResponseDTO,
     SetCustomHandicapRequestDTO,
@@ -42,6 +44,7 @@ from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError as HandicapCompetitionNotFoundError,
     CompetitionNotFoundError as ListCompetitionNotFoundError,
     CompetitionNotFoundError as RequestCompetitionNotFoundError,
+    HandicapEditNotAllowedError,
     InvalidTeeCategoryError,
 )
 from src.modules.competition.application.use_cases.cancel_enrollment_use_case import (
@@ -63,6 +66,11 @@ from src.modules.competition.application.use_cases.handle_enrollment_use_case im
 )
 from src.modules.competition.application.use_cases.list_enrollments_use_case import (
     ListEnrollmentsUseCase,
+)
+from src.modules.competition.application.use_cases.remove_custom_handicap_use_case import (
+    EnrollmentNotFoundError as RemoveHandicapEnrollmentNotFoundError,
+    NotCreatorError as RemoveHandicapNotCreatorError,
+    RemoveCustomHandicapUseCase,
 )
 from src.modules.competition.application.use_cases.request_enrollment_use_case import (
     AlreadyEnrolledError as RequestAlreadyEnrolledError,
@@ -468,5 +476,47 @@ async def set_custom_handicap(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except HandicapNotCreatorError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except EnrollmentStateError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except HandicapEditNotAllowedError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+@router.delete(
+    "/enrollments/{enrollment_id}/handicap",
+    response_model=RemoveCustomHandicapResponseDTO,
+    summary="Eliminar hándicap personalizado",
+    description=(
+        "El creador elimina el hándicap personalizado de un jugador, que vuelve a usar "
+        "su hándicap oficial."
+    ),
+)
+async def remove_custom_handicap(
+    enrollment_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: RemoveCustomHandicapUseCase = Depends(get_remove_custom_handicap_use_case),
+):
+    """
+    Elimina el hándicap personalizado de un jugador.
+
+    Solo el creador de la competición (o un admin) puede eliminarlo. Solo se permite
+    mientras la competición está en DRAFT, ACTIVE o CLOSED.
+    """
+    try:
+        creator_id = UserId(str(current_user.id))
+        return await use_case.execute(
+            str(enrollment_id), creator_id, is_admin=current_user.is_admin
+        )
+
+    except RemoveHandicapEnrollmentNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except HandicapCompetitionNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except RemoveHandicapNotCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except EnrollmentStateError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except HandicapEditNotAllowedError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e

--- a/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/enrollment_routes.py
@@ -42,34 +42,37 @@ from src.modules.competition.application.dto.enrollment_dto import (
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError as DirectCompetitionNotFoundError,
     CompetitionNotFoundError as HandicapCompetitionNotFoundError,
+    CompetitionNotFoundError as HandleCompetitionNotFoundError,
     CompetitionNotFoundError as ListCompetitionNotFoundError,
     CompetitionNotFoundError as RequestCompetitionNotFoundError,
+    EnrollmentNotFoundError as CancelEnrollmentNotFoundError,
+    EnrollmentNotFoundError as HandicapEnrollmentNotFoundError,
+    EnrollmentNotFoundError as HandleEnrollmentNotFoundError,
+    EnrollmentNotFoundError as RemoveHandicapEnrollmentNotFoundError,
+    EnrollmentNotFoundError as WithdrawEnrollmentNotFoundError,
     HandicapEditNotAllowedError,
     InvalidTeeCategoryError,
+    NotCreatorError as DirectNotCreatorError,
+    NotCreatorError as HandicapNotCreatorError,
+    NotCreatorError as HandleNotCreatorError,
+    NotCreatorError as RemoveHandicapNotCreatorError,
 )
 from src.modules.competition.application.use_cases.cancel_enrollment_use_case import (
     CancelEnrollmentUseCase,
-    EnrollmentNotFoundError as CancelEnrollmentNotFoundError,
     NotOwnerError as CancelNotOwnerError,
 )
 from src.modules.competition.application.use_cases.direct_enroll_player_use_case import (
     AlreadyEnrolledError as DirectAlreadyEnrolledError,
     CompetitionNotActiveError as DirectCompetitionNotActiveError,
     DirectEnrollPlayerUseCase,
-    NotCreatorError as DirectNotCreatorError,
 )
 from src.modules.competition.application.use_cases.handle_enrollment_use_case import (
-    CompetitionNotFoundError as HandleCompetitionNotFoundError,
-    EnrollmentNotFoundError as HandleEnrollmentNotFoundError,
     HandleEnrollmentUseCase,
-    NotCreatorError as HandleNotCreatorError,
 )
 from src.modules.competition.application.use_cases.list_enrollments_use_case import (
     ListEnrollmentsUseCase,
 )
 from src.modules.competition.application.use_cases.remove_custom_handicap_use_case import (
-    EnrollmentNotFoundError as RemoveHandicapEnrollmentNotFoundError,
-    NotCreatorError as RemoveHandicapNotCreatorError,
     RemoveCustomHandicapUseCase,
 )
 from src.modules.competition.application.use_cases.request_enrollment_use_case import (
@@ -78,12 +81,9 @@ from src.modules.competition.application.use_cases.request_enrollment_use_case i
     RequestEnrollmentUseCase,
 )
 from src.modules.competition.application.use_cases.set_custom_handicap_use_case import (
-    EnrollmentNotFoundError as HandicapEnrollmentNotFoundError,
-    NotCreatorError as HandicapNotCreatorError,
     SetCustomHandicapUseCase,
 )
 from src.modules.competition.application.use_cases.withdraw_enrollment_use_case import (
-    EnrollmentNotFoundError as WithdrawEnrollmentNotFoundError,
     NotOwnerError as WithdrawNotOwnerError,
     WithdrawEnrollmentUseCase,
 )

--- a/src/modules/competition/infrastructure/api/v1/invitation_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/invitation_routes.py
@@ -131,7 +131,7 @@ async def send_invitation_by_user_id(
             invitee_user_id=body.invitee_user_id,
             personal_message=body.personal_message,
         )
-        return await use_case.execute(request_dto)
+        return await use_case.execute(request_dto, is_admin=current_user.is_admin)
 
     except CompetitionNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
@@ -170,7 +170,7 @@ async def send_invitation_by_email(
             invitee_email=body.invitee_email,
             personal_message=body.personal_message,
         )
-        return await use_case.execute(request_dto)
+        return await use_case.execute(request_dto, is_admin=current_user.is_admin)
 
     except CompetitionNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/src/modules/competition/infrastructure/api/v1/round_match_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/round_match_routes.py
@@ -197,7 +197,7 @@ async def create_round(
             handicap_mode=body.handicap_mode,
             allowance_percentage=body.allowance_percentage,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except CreateRoundNotFoundError as e:
         raise HTTPException(
@@ -262,7 +262,7 @@ async def update_round(
             allowance_percentage=body.allowance_percentage,
             clear_allowance=body.clear_allowance,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except UpdateRoundNotFoundError as e:
         raise HTTPException(
@@ -317,7 +317,7 @@ async def delete_round(
     try:
         current_user_id = UserId(current_user.id)
         request_dto = DeleteRoundRequestDTO(round_id=round_id)
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except DeleteRoundNotFoundError as e:
         raise HTTPException(
@@ -444,7 +444,7 @@ async def update_match_status(
             action=body.action,
             result=body.result,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except (
         StatusMatchNotFoundError,
@@ -506,7 +506,7 @@ async def declare_walkover(
             winning_team=body.winning_team,
             reason=body.reason,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except WalkoverMatchNotFoundError as e:
         raise HTTPException(
@@ -564,7 +564,7 @@ async def reassign_match_players(
             team_a_player_ids=body.team_a_player_ids,
             team_b_player_ids=body.team_b_player_ids,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except ReassignMatchNotFoundError as e:
         raise HTTPException(
@@ -637,7 +637,7 @@ async def assign_teams(
             team_a_player_ids=body.team_a_player_ids,
             team_b_player_ids=body.team_b_player_ids,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except AssignTeamsNotFoundError as e:
         raise HTTPException(
@@ -696,7 +696,7 @@ async def generate_matches(
             round_id=round_id,
             manual_pairings=body.manual_pairings,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except GenMatchesRoundNotFoundError as e:
         raise HTTPException(
@@ -758,7 +758,7 @@ async def configure_schedule(
             total_sessions=body.total_sessions,
             sessions_per_day=body.sessions_per_day,
         )
-        return await use_case.execute(request_dto, current_user_id)
+        return await use_case.execute(request_dto, current_user_id, is_admin=current_user.is_admin)
 
     except ConfigSchedNotFoundError as e:
         raise HTTPException(

--- a/src/modules/competition/infrastructure/api/v1/round_match_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/round_match_routes.py
@@ -175,7 +175,7 @@ async def create_round(
     Crea una nueva ronda/sesión de competición.
 
     **Restricciones:**
-    - Solo el creador puede crear rondas
+    - El creador o admin puede crear rondas
     - La competición debe estar en estado CLOSED
     - El campo de golf debe estar asociado a la competición
     - No puede haber sesión duplicada (misma fecha + tipo de sesión)
@@ -183,7 +183,7 @@ async def create_round(
     **Returns:**
     - 201: Ronda creada exitosamente
     - 400: Estado inválido, sesión duplicada, fecha fuera de rango, o campo no asociado
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Competición no encontrada
     """
     try:
@@ -240,14 +240,14 @@ async def update_round(
     Actualiza una ronda existente (campos opcionales).
 
     **Restricciones:**
-    - Solo el creador puede modificar rondas
+    - El creador o admin puede modificar rondas
     - La ronda debe estar en estado modificable (PENDING_TEAMS o PENDING_MATCHES)
     - La competición debe estar en estado CLOSED
 
     **Returns:**
     - 200: Ronda actualizada
     - 400: Estado no modificable, sesión duplicada, o campo no asociado
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Ronda no encontrada
     """
     try:
@@ -304,14 +304,14 @@ async def delete_round(
     Elimina una ronda y sus partidos asociados.
 
     **Restricciones:**
-    - Solo el creador puede eliminar rondas
+    - El creador o admin puede eliminar rondas
     - La ronda debe estar en estado modificable (PENDING_TEAMS o PENDING_MATCHES)
     - La competición debe estar en estado CLOSED
 
     **Returns:**
     - 200: Ronda eliminada
     - 400: Estado no modificable
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Ronda no encontrada
     """
     try:
@@ -427,14 +427,14 @@ async def update_match_status(
     Actualiza el estado de un partido (START o COMPLETE).
 
     **Restricciones:**
-    - Solo el creador puede cambiar estados
+    - El creador o admin puede cambiar estados
     - La competición debe estar IN_PROGRESS
     - Acciones válidas: START (SCHEDULED→IN_PROGRESS), COMPLETE (IN_PROGRESS→COMPLETED)
 
     **Returns:**
     - 200: Estado actualizado
     - 400: Acción inválida o competición no en progreso
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Partido no encontrado
     """
     try:
@@ -489,14 +489,14 @@ async def declare_walkover(
     Declara un walkover (victoria por incomparecencia) en un partido.
 
     **Restricciones:**
-    - Solo el creador puede declarar walkovers
+    - El creador o admin puede declarar walkovers
     - La competición debe estar IN_PROGRESS
     - El partido debe estar en estado válido para walkover
 
     **Returns:**
     - 200: Walkover declarado
     - 400: Walkover inválido o competición no en progreso
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Partido no encontrado
     """
     try:
@@ -547,14 +547,14 @@ async def reassign_match_players(
     Reasigna los jugadores de un partido (recalcula handicaps).
 
     **Restricciones:**
-    - Solo el creador puede reasignar jugadores
+    - El creador o admin puede reasignar jugadores
     - El partido debe estar en estado SCHEDULED
     - Los jugadores deben pertenecer a los equipos asignados
 
     **Returns:**
     - 200: Jugadores reasignados con handicaps recalculados
     - 400: Partido no scheduled o jugadores no válidos
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Partido no encontrado
     """
     try:
@@ -618,7 +618,7 @@ async def assign_teams(
     Asigna equipos para la competición (automático con snake draft o manual).
 
     **Restricciones:**
-    - Solo el creador puede asignar equipos
+    - El creador o admin puede asignar equipos
     - La competición debe estar en estado CLOSED
     - Debe haber suficientes jugadores inscritos (mínimo 2)
     - En modo MANUAL, los equipos deben estar balanceados
@@ -626,7 +626,7 @@ async def assign_teams(
     **Returns:**
     - 201: Equipos asignados
     - 400: Estado inválido, jugadores insuficientes, o equipos desequilibrados
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Competición no encontrada
     """
     try:
@@ -680,7 +680,7 @@ async def generate_matches(
     Genera partidos para una ronda basándose en los equipos asignados.
 
     **Restricciones:**
-    - Solo el creador puede generar partidos
+    - El creador o admin puede generar partidos
     - La ronda debe estar en estado PENDING_MATCHES
     - Debe existir asignación de equipos
     - La competición debe estar en estado CLOSED
@@ -740,14 +740,14 @@ async def configure_schedule(
     Configura el schedule de la competición (automático o manual).
 
     **Restricciones:**
-    - Solo el creador puede configurar el schedule
+    - El creador o admin puede configurar el schedule
     - La competición debe estar en estado CLOSED
     - Debe tener al menos un campo de golf asociado (modo AUTO)
 
     **Returns:**
     - 200: Schedule configurado
     - 400: Estado inválido o sin campos de golf
-    - 403: Usuario no es el creador
+    - 403: Usuario no es el creador ni admin
     - 404: Competición no encontrada
     """
     try:

--- a/src/modules/competition/infrastructure/api/v1/scoring_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/scoring_routes.py
@@ -315,7 +315,8 @@ async def concede_match(
     try:
         current_user_id = UserId(current_user.id)
         return await use_case.execute(
-            str(match_id), current_user_id, body.conceding_team, body.reason
+            str(match_id), current_user_id, body.conceding_team, body.reason,
+            is_admin=current_user.is_admin,
         )
 
     except MatchNotFoundError as e:

--- a/src/modules/competition/infrastructure/api/v1/scoring_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/scoring_routes.py
@@ -8,7 +8,7 @@ Endpoints FastAPI para scoring en vivo del modulo Competition.
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from src.config.dependencies import (
     get_concede_match_use_case,
@@ -137,9 +137,17 @@ async def submit_hole_score(
     - 404: Partido no encontrado
     - 409: Partido no en estado de scoring
     """
+    if body.acting_as is not None and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Solo admins pueden usar acting_as",
+        )
+    effective_user_id = (
+        UserId(body.acting_as) if body.acting_as is not None else UserId(current_user.id)
+    )
+
     try:
-        current_user_id = UserId(current_user.id)
-        return await use_case.execute(str(match_id), hole_number, body, current_user_id)
+        return await use_case.execute(str(match_id), hole_number, body, effective_user_id)
 
     except MatchNotFoundError as e:
         raise HTTPException(
@@ -176,6 +184,10 @@ async def submit_scorecard(
     match_id: UUID,
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: SubmitScorecardUseCase = Depends(get_submit_scorecard_use_case),
+    acting_as: UUID | None = Query(
+        None,
+        description="Solo admin: ID del jugador cuya tarjeta se entrega en su nombre.",
+    ),
 ):
     """
     Entrega la tarjeta de scores de un jugador.
@@ -184,7 +196,7 @@ async def submit_scorecard(
     Si todos los jugadores entregan su tarjeta, el partido se completa automaticamente.
 
     **Restricciones:**
-    - Solo jugadores del partido
+    - Solo jugadores del partido (o admin con acting_as)
     - El partido debe estar IN_PROGRESS
     - Todos los hoyos jugados deben tener validation_status MATCH
     - No se puede entregar dos veces
@@ -196,9 +208,15 @@ async def submit_scorecard(
     - 404: Partido no encontrado
     - 409: Partido no en estado de scoring
     """
+    if acting_as is not None and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Solo admins pueden usar acting_as",
+        )
+    effective_user_id = UserId(acting_as) if acting_as is not None else UserId(current_user.id)
+
     try:
-        current_user_id = UserId(current_user.id)
-        return await use_case.execute(str(match_id), current_user_id)
+        return await use_case.execute(str(match_id), effective_user_id)
 
     except MatchNotFoundError as e:
         raise HTTPException(

--- a/src/modules/competition/infrastructure/api/v1/scoring_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/scoring_routes.py
@@ -125,7 +125,7 @@ async def submit_hole_score(
     Retorna la vista completa de scoring actualizada.
 
     **Restricciones:**
-    - Solo jugadores del partido pueden registrar scores
+    - Solo jugadores del partido pueden registrar scores (o admin con acting_as)
     - El partido debe estar IN_PROGRESS
     - Hoyo debe estar entre 1-18
     - Los campos bloqueados tras la entrega se omiten silenciosamente
@@ -301,6 +301,7 @@ async def concede_match(
     **Auth:**
     - Jugadores del partido: solo pueden conceder SU propio equipo
     - Creator de la competicion: puede conceder cualquier equipo
+    - Admin: puede conceder cualquier equipo
 
     **Body:**
     - conceding_team: "A" o "B"
@@ -309,7 +310,7 @@ async def concede_match(
     **Returns:**
     - 200: Partido concedido
     - 409: Partido no en estado de scoring
-    - 403: No es jugador ni creador
+    - 403: No es jugador, creador ni admin
     - 404: Partido no encontrado
     """
     try:

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
@@ -29,7 +29,7 @@ class SQLAlchemyHoleScoreRepository(HoleScoreRepositoryInterface):
         statement = (
             select(HoleScore)
             .where(HoleScore._match_id == match_id)
-            .order_by(HoleScore._hole_number.asc())
+            .order_by(HoleScore._hole_number.asc(), HoleScore._player_user_id.asc())
         )
         result = await self._session.execute(statement)
         return list(result.scalars().all())

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
@@ -7,6 +7,7 @@ Sigue el patron Imperative Mapping establecido en el modulo User.
 
 import uuid
 from datetime import date
+from decimal import Decimal
 
 from sqlalchemy import (
     Boolean,
@@ -375,8 +376,12 @@ class MatchPlayersJsonType(TypeDecorator):
         "playing_handicap": 12,
         "tee_category": "AMATEUR",
         "tee_gender": "MALE",
-        "strokes_received": [1, 3, 5, 7]
+        "strokes_received": [1, 3, 5, 7],
+        "player_handicap": "14.2"
     }
+
+    player_handicap (HM-1b) es opcional: partidos generados antes de esta feature
+    no lo tienen en su JSON y se deserializan con player_handicap=None.
     """
 
     impl = JSONB
@@ -392,6 +397,7 @@ class MatchPlayersJsonType(TypeDecorator):
                 "tee_category": p.tee_category.value,
                 "tee_gender": p.tee_gender.value if p.tee_gender else None,
                 "strokes_received": list(p.strokes_received),
+                "player_handicap": str(p.player_handicap) if p.player_handicap is not None else None,
             }
             for p in value
         ]
@@ -401,12 +407,14 @@ class MatchPlayersJsonType(TypeDecorator):
             return None
         players = []
         for p in value:
+            player_handicap = p.get("player_handicap")
             player = MatchPlayer(
                 user_id=UserId(uuid.UUID(p["user_id"])),
                 playing_handicap=p["playing_handicap"],
                 tee_category=TeeCategory(p["tee_category"]),
                 tee_gender=Gender(p["tee_gender"]) if p.get("tee_gender") else None,
                 strokes_received=tuple(p["strokes_received"]),
+                player_handicap=Decimal(player_handicap) if player_handicap is not None else None,
             )
             players.append(player)
         return tuple(players)

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
@@ -693,6 +693,7 @@ competitions_table = Table(
     Column("max_players", Integer, nullable=False, default=24),
     Column("team_assignment", TeamAssignmentModeDecorator, nullable=False, default="MANUAL"),
     Column("status", String(20), nullable=False, default="DRAFT"),
+    Column("max_playing_handicap", Integer, nullable=True),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
 )
@@ -938,6 +939,7 @@ def start_competition_mappers():
                 "_team_2_name": competitions_table.c.team_2_name,
                 "_play_mode": competitions_table.c.play_mode,
                 "_max_players": competitions_table.c.max_players,
+                "_max_playing_handicap": competitions_table.c.max_playing_handicap,
                 "_created_at": competitions_table.c.created_at,
                 "_updated_at": competitions_table.c.updated_at,
                 # Composite VOs → private attrs

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -286,6 +286,11 @@ class LoginResponseDTO(BaseModel):
         default=False,
         description="True si el caller debe setear la cookie device_id (v2.0.4). False si la cookie ya existe.",
     )
+    # HM-2: Handicap request flow
+    needs_handicap: bool = Field(
+        default=False,
+        description="True si el usuario es español (ES) y no tiene hándicap registrado. El FE debe mostrar HandicapRequestModal.",
+    )
 
 
 # ======================================================================================

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -289,7 +289,12 @@ class LoginResponseDTO(BaseModel):
     # HM-2: Handicap request flow
     needs_handicap: bool = Field(
         default=False,
-        description="True si el usuario es español (ES) y no tiene hándicap registrado. El FE debe mostrar HandicapRequestModal.",
+        description=(
+            "True si el hándicap del usuario no se ha actualizado hoy y no pudo "
+            "refrescarse automáticamente: usuarios no españoles, sin país registrado, "
+            "o españoles cuya búsqueda RFEG falló o no devolvió resultado. "
+            "El FE debe mostrar HandicapRequestModal."
+        ),
     )
 
 

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -22,6 +22,7 @@ from src.modules.user.application.use_cases.register_device_use_case import (
     RegisterDeviceUseCase,
 )
 from src.modules.user.domain.entities.refresh_token import RefreshToken
+from src.modules.user.domain.entities.user import User
 from src.modules.user.domain.exceptions import AccountLockedException
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
@@ -240,25 +241,8 @@ class LoginUserUseCase:
         # Generar token CSRF (256 bits, 15 minutos de duración)
         csrf_token = generate_csrf_token()
 
-        # HM-2a: Fetch RFEG en login para usuarios españoles sin hándicap
-        needs_handicap = False
-        country_code_value = user.country_code.value if user.country_code else None
-        if country_code_value == "ES" and user.handicap is None:
-            if self._handicap_service is not None:
-                try:
-                    handicap_value = await self._handicap_service.search_handicap(
-                        user.get_full_name()
-                    )
-                    if handicap_value is not None:
-                        user.update_handicap(handicap_value)
-                        async with self._uow:
-                            await self._uow.users.save(user)
-                    else:
-                        needs_handicap = True
-                except Exception:  # noqa: BLE001
-                    needs_handicap = True
-            else:
-                needs_handicap = True
+        # HM-2a: Refresco de hándicap en login (best-effort, 1 vez al día).
+        needs_handicap = await self._refresh_handicap(user, login_time)
 
         # Crear respuesta con tokens y datos de usuario
         user_dto = UserResponseDTO.model_validate(user)
@@ -276,3 +260,41 @@ class LoginUserUseCase:
             # HM-2a: Indica si el FE debe mostrar HandicapRequestModal
             needs_handicap=needs_handicap,
         )
+
+    async def _refresh_handicap(self, user: User, login_time: datetime) -> bool:
+        """
+        Refresca el hándicap del usuario en login (best-effort, 1 vez al día).
+
+        ES: intenta fetch automático y silencioso vía RFEG.
+        No-ES, o RFEG sin resultado/con error: no se actualiza, hay que pedirlo al usuario.
+
+        Args:
+            user: Usuario autenticado.
+            login_time: Instante del login, usado para el gate "una vez al día".
+
+        Returns:
+            True si el FE debe mostrar el HandicapRequestModal.
+        """
+        handicap_updated_today = (
+            user.handicap_updated_at is not None
+            and user.handicap_updated_at.date() == login_time.date()
+        )
+        if handicap_updated_today:
+            return False
+
+        country_code_value = user.country_code.value if user.country_code else None
+        if country_code_value != "ES" or self._handicap_service is None:
+            return True
+
+        try:
+            handicap_value = await self._handicap_service.search_handicap(user.get_full_name())
+        except Exception:
+            return True
+
+        if handicap_value is None:
+            return True
+
+        user.update_handicap(handicap_value)
+        async with self._uow:
+            await self._uow.users.save(user)
+        return False

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -26,6 +26,7 @@ from src.modules.user.domain.exceptions import AccountLockedException
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
+from src.modules.user.domain.services.handicap_service import HandicapService
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.shared.infrastructure.logging.security_logger import get_security_logger
@@ -54,6 +55,7 @@ class LoginUserUseCase:
         uow: UserUnitOfWorkInterface,
         token_service: ITokenService,
         register_device_use_case: RegisterDeviceUseCase,
+        handicap_service: HandicapService | None = None,
     ):
         """
         Inicializa el caso de uso.
@@ -62,10 +64,12 @@ class LoginUserUseCase:
             uow: Unit of Work para acceso a repositorios (users + refresh_tokens + user_devices)
             token_service: Servicio para generación de tokens de autenticación
             register_device_use_case: Caso de uso para registrar/actualizar dispositivos (v1.13.0)
+            handicap_service: Servicio RFEG para fetch de hándicap en login (HM-2a). Opcional.
         """
         self._uow = uow
         self._token_service = token_service
         self._register_device_use_case = register_device_use_case
+        self._handicap_service = handicap_service
 
     async def execute(self, request: LoginRequestDTO) -> LoginResponseDTO | None:
         """
@@ -236,6 +240,26 @@ class LoginUserUseCase:
         # Generar token CSRF (256 bits, 15 minutos de duración)
         csrf_token = generate_csrf_token()
 
+        # HM-2a: Fetch RFEG en login para usuarios españoles sin hándicap
+        needs_handicap = False
+        country_code_value = user.country_code.value if user.country_code else None
+        if country_code_value == "ES" and user.handicap is None:
+            if self._handicap_service is not None:
+                try:
+                    handicap_value = await self._handicap_service.search_handicap(
+                        user.get_full_name()
+                    )
+                    if handicap_value is not None:
+                        user.update_handicap(handicap_value)
+                        async with self._uow:
+                            await self._uow.users.save(user)
+                    else:
+                        needs_handicap = True
+                except Exception:  # noqa: BLE001
+                    needs_handicap = True
+            else:
+                needs_handicap = True
+
         # Crear respuesta con tokens y datos de usuario
         user_dto = UserResponseDTO.model_validate(user)
 
@@ -249,4 +273,6 @@ class LoginUserUseCase:
             # Device Fingerprinting (v2.0.4): Cookie-based identification
             device_id=device_id_str,
             should_set_device_cookie=should_set_device_cookie,
+            # HM-2a: Indica si el FE debe mostrar HandicapRequestModal
+            needs_handicap=needs_handicap,
         )

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -8,6 +8,7 @@ Account Lockout (v1.13.0): Bloquea cuenta tras 10 intentos fallidos por 30 minut
 CSRF Protection (v1.13.0): Genera token CSRF de 256 bits para validación double-submit.
 """
 
+import logging
 from datetime import UTC, datetime
 
 from src.config.csrf_config import generate_csrf_token
@@ -31,6 +32,8 @@ from src.modules.user.domain.services.handicap_service import HandicapService
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.shared.infrastructure.logging.security_logger import get_security_logger
+
+logger = logging.getLogger(__name__)
 
 
 class LoginUserUseCase:
@@ -291,12 +294,25 @@ class LoginUserUseCase:
         try:
             handicap_value = await self._handicap_service.search_handicap(user.get_full_name())
         except Exception:
+            logger.warning(
+                "RFEG lookup failed for %s during login handicap refresh",
+                user.get_full_name(),
+                exc_info=True,
+            )
             return True
 
         if handicap_value is None:
             return True
 
-        user.update_handicap(handicap_value)
-        async with self._uow:
-            await self._uow.users.save(user)
+        try:
+            user.update_handicap(handicap_value)
+            async with self._uow:
+                await self._uow.users.save(user)
+        except Exception:
+            logger.error(
+                "Failed to persist RFEG handicap for %s during login",
+                user.get_full_name(),
+                exc_info=True,
+            )
+            return True
         return False

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -8,7 +8,7 @@ Account Lockout (v1.13.0): Bloquea cuenta tras 10 intentos fallidos por 30 minut
 CSRF Protection (v1.13.0): Genera token CSRF de 256 bits para validación double-submit.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from src.config.csrf_config import generate_csrf_token
 from src.modules.user.application.dto.device_dto import RegisterDeviceRequestDTO
@@ -180,7 +180,9 @@ class LoginUserUseCase:
         user.reset_failed_attempts()
 
         # Registrar evento de login exitoso (Clean Architecture)
-        login_time = datetime.now()
+        # UTC-aware: handicap_updated_at ahora es timezone-aware, y la comparación
+        # de fechas en _refresh_handicap() necesita el mismo huso horario.
+        login_time = datetime.now(UTC)
         user.record_login(
             logged_in_at=login_time,
             # ip_address y user_agent se pueden agregar cuando el controlador los pase

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from src.shared.domain.events.domain_event import DomainEvent
 from src.shared.domain.value_objects.country_code import CountryCode
@@ -168,8 +168,10 @@ class User:
             self.handicap = None
 
         # Actualizar timestamps
+        # handicap_updated_at se guarda en UTC (columna timezone-aware) para que el
+        # frontend pueda convertirlo correctamente a la hora local del usuario.
         now = datetime.now()
-        self.handicap_updated_at = now
+        self.handicap_updated_at = datetime.now(UTC)
         self.updated_at = now
 
         # Emitir evento solo si cambió

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -110,7 +110,7 @@ users_table = Table(
     Column("email", String(255), nullable=False, unique=True),
     Column("password", String(255), nullable=True),  # Nullable for OAuth-only users
     Column("handicap", HandicapDecorator, nullable=True),
-    Column("handicap_updated_at", DateTime, nullable=True),
+    Column("handicap_updated_at", DateTime(timezone=True), nullable=True),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
     Column("email_verified", Boolean, nullable=False, default=False),

--- a/tests/integration/api/v1/test_enrollment_endpoints.py
+++ b/tests/integration/api/v1/test_enrollment_endpoints.py
@@ -408,6 +408,160 @@ class TestSetCustomHandicap:
         assert float(response.json()["custom_handicap"]) == pytest.approx(12.0)
 
 
+class TestRemoveCustomHandicap:
+    """Tests para DELETE /api/v1/enrollments/{id}/handicap"""
+
+    @pytest.mark.asyncio
+    async def test_remove_custom_handicap_success(self, client: AsyncClient):
+        """Creador elimina el handicap personalizado y vuelve a None."""
+        creator = await create_authenticated_user(
+            client, "creator14@test.com", "P@ssw0rd123!", "Creator", "Fourteen"
+        )
+        player = await create_authenticated_user(
+            client, "player14@test.com", "P@ssw0rd123!", "Player", "Fourteen"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        enroll_response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=creator["cookies"],
+        )
+        enrollment_id = enroll_response.json()["id"]
+
+        await client.put(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            json={"enrollment_id": enrollment_id, "custom_handicap": 15.5},
+            cookies=creator["cookies"],
+        )
+
+        response = await client.delete(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            cookies=creator["cookies"],
+        )
+
+        assert response.status_code == 200
+        assert response.json()["custom_handicap"] is None
+
+    @pytest.mark.asyncio
+    async def test_remove_custom_handicap_by_admin_not_creator_succeeds(
+        self, client: AsyncClient
+    ):
+        """Admin (no creador) puede eliminar el handicap personalizado."""
+        creator = await create_authenticated_user(
+            client, "creator14b@test.com", "P@ssw0rd123!", "Creator", "FourteenB"
+        )
+        admin = await create_admin_user(
+            client, "admin14b@test.com", "AdminPass123!", "Admin", "FourteenB"
+        )
+        player = await create_authenticated_user(
+            client, "player14b@test.com", "P@ssw0rd123!", "Player", "FourteenB"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        enroll_response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=creator["cookies"],
+        )
+        enrollment_id = enroll_response.json()["id"]
+
+        await client.put(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            json={"enrollment_id": enrollment_id, "custom_handicap": 12.0},
+            cookies=creator["cookies"],
+        )
+
+        response = await client.delete(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            cookies=admin["cookies"],
+        )
+
+        assert response.status_code == 200
+        assert response.json()["custom_handicap"] is None
+
+    @pytest.mark.asyncio
+    async def test_remove_custom_handicap_not_creator_returns_403(self, client: AsyncClient):
+        """Un jugador que no es el creador no puede eliminar el handicap."""
+        creator = await create_authenticated_user(
+            client, "creator14c@test.com", "P@ssw0rd123!", "Creator", "FourteenC"
+        )
+        player = await create_authenticated_user(
+            client, "player14c@test.com", "P@ssw0rd123!", "Player", "FourteenC"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        enroll_response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=creator["cookies"],
+        )
+        enrollment_id = enroll_response.json()["id"]
+
+        response = await client.delete(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            cookies=player["cookies"],
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_set_and_remove_custom_handicap_return_400_once_in_progress(
+        self, client: AsyncClient
+    ):
+        """Ni establecer ni eliminar el handicap personalizado funcionan una vez IN_PROGRESS."""
+        creator = await create_authenticated_user(
+            client, "creator14d@test.com", "P@ssw0rd123!", "Creator", "FourteenD"
+        )
+        player = await create_authenticated_user(
+            client, "player14d@test.com", "P@ssw0rd123!", "Player", "FourteenD"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        enroll_response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=creator["cookies"],
+        )
+        enrollment_id = enroll_response.json()["id"]
+
+        await client.put(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            json={"enrollment_id": enrollment_id, "custom_handicap": 15.5},
+            cookies=creator["cookies"],
+        )
+
+        await client.post(
+            f"/api/v1/competitions/{comp['id']}/close-enrollments",
+            cookies=creator["cookies"],
+        )
+        await client.post(
+            f"/api/v1/competitions/{comp['id']}/start",
+            cookies=creator["cookies"],
+        )
+
+        set_response = await client.put(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            json={"enrollment_id": enrollment_id, "custom_handicap": 20.0},
+            cookies=creator["cookies"],
+        )
+        remove_response = await client.delete(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            cookies=creator["cookies"],
+        )
+
+        assert set_response.status_code == 400
+        assert remove_response.status_code == 400
+
+
 class TestEnrollmentEdgeCases:
     """Tests de edge cases para Enrollment"""
 

--- a/tests/integration/api/v1/test_enrollment_endpoints.py
+++ b/tests/integration/api/v1/test_enrollment_endpoints.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 
 from tests.conftest import (
     activate_competition,
+    create_admin_user,
     create_authenticated_user,
     create_competition,
     set_auth_cookies,
@@ -133,6 +134,31 @@ class TestDirectEnrollPlayer:
         )
 
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_direct_enroll_by_admin_not_creator_succeeds(self, client: AsyncClient):
+        """Admin (no creador) puede inscribir directamente y retorna 201."""
+        creator = await create_authenticated_user(
+            client, "creator5b@test.com", "P@ssw0rd123!", "Creator", "FiveB"
+        )
+        admin = await create_admin_user(
+            client, "admin5b@test.com", "AdminPass123!", "Admin", "FiveB"
+        )
+        player = await create_authenticated_user(
+            client, "player5b@test.com", "P@ssw0rd123!", "Player", "FiveB"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=admin["cookies"],
+        )
+
+        assert response.status_code == 201
+        assert response.json()["status"] == "APPROVED"
 
 
 class TestListEnrollments:
@@ -348,6 +374,38 @@ class TestSetCustomHandicap:
 
         assert response.status_code == 200
         assert float(response.json()["custom_handicap"]) == pytest.approx(15.5)
+
+    @pytest.mark.asyncio
+    async def test_set_custom_handicap_by_admin_not_creator_succeeds(self, client: AsyncClient):
+        """Admin (no creador) puede establecer handicap personalizado."""
+        creator = await create_authenticated_user(
+            client, "creator13b@test.com", "P@ssw0rd123!", "Creator", "ThirteenB"
+        )
+        admin = await create_admin_user(
+            client, "admin13b@test.com", "AdminPass123!", "Admin", "ThirteenB"
+        )
+        player = await create_authenticated_user(
+            client, "player13b@test.com", "P@ssw0rd123!", "Player", "ThirteenB"
+        )
+
+        comp = await create_competition(client, creator["cookies"])
+        await activate_competition(client, creator["cookies"], comp["id"])
+
+        enroll_response = await client.post(
+            f"/api/v1/competitions/{comp['id']}/enrollments/direct",
+            json={"competition_id": comp["id"], "user_id": player["user"]["id"]},
+            cookies=creator["cookies"],
+        )
+        enrollment_id = enroll_response.json()["id"]
+
+        response = await client.put(
+            f"/api/v1/enrollments/{enrollment_id}/handicap",
+            json={"enrollment_id": enrollment_id, "custom_handicap": 12.0},
+            cookies=admin["cookies"],
+        )
+
+        assert response.status_code == 200
+        assert float(response.json()["custom_handicap"]) == pytest.approx(12.0)
 
 
 class TestEnrollmentEdgeCases:

--- a/tests/unit/modules/competition/application/use_cases/helpers.py
+++ b/tests/unit/modules/competition/application/use_cases/helpers.py
@@ -1,0 +1,69 @@
+"""Helper factories para tests de use cases de Enrollment/Handicap."""
+
+from datetime import date
+from decimal import Decimal
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+async def create_competition(uow: InMemoryUnitOfWork, creator_id: UserId):
+    """Crea una competición en DRAFT."""
+    create_uc = CreateCompetitionUseCase(uow)
+    request = CreateCompetitionRequestDTO(
+        name="Test Cup",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 3),
+        main_country="ES",
+        play_mode="SCRATCH",
+        max_players=24,
+    )
+    return await create_uc.execute(request, creator_id)
+
+
+async def set_competition_status(uow: InMemoryUnitOfWork, competition_id, status: str):
+    """Mueve una competición a través de sus transiciones hasta `status`."""
+    async with uow:
+        competition = await uow.competitions.find_by_id(CompetitionId(competition_id))
+        if status in ("ACTIVE", "CLOSED", "IN_PROGRESS", "COMPLETED", "CANCELLED"):
+            competition.activate()
+        if status in ("CLOSED", "IN_PROGRESS", "COMPLETED"):
+            competition.close_enrollments()
+        if status in ("IN_PROGRESS", "COMPLETED"):
+            competition.start()
+        if status == "COMPLETED":
+            competition.complete()
+        if status == "CANCELLED":
+            competition.cancel()
+        await uow.competitions.update(competition)
+        await uow.commit()
+
+
+async def create_approved_enrollment(
+    uow: InMemoryUnitOfWork,
+    competition_id,
+    user_id: UserId,
+    custom_handicap: Decimal | None = None,
+) -> Enrollment:
+    """Crea un enrollment ya aprobado, opcionalmente con hándicap personalizado."""
+    enrollment = Enrollment.direct_enroll(
+        id=EnrollmentId.generate(),
+        competition_id=CompetitionId(competition_id),
+        user_id=user_id,
+        custom_handicap=custom_handicap,
+    )
+    async with uow:
+        await uow.enrollments.add(enrollment)
+        await uow.commit()
+    return enrollment

--- a/tests/unit/modules/competition/application/use_cases/test_create_round_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_create_round_use_case.py
@@ -200,6 +200,40 @@ class TestCreateRoundUseCase:
         with pytest.raises(NotCompetitionCreatorError):
             await use_case.execute(request, other_user_id)
 
+    async def test_should_succeed_when_admin_not_creator(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        other_user_id: UserId,
+    ):
+        """
+        Verifica que un admin puede crear rondas aunque no sea el creador.
+
+        Given: Una competicion CLOSED creada por un usuario
+        When: Un admin (no creador) crea una ronda con is_admin=True
+        Then: La ronda se crea correctamente sin lanzar NotCompetitionCreatorError
+        """
+        # Arrange
+        competition = await self._create_closed_competition_with_course(
+            uow, creator_id, golf_course_id
+        )
+        use_case = CreateRoundUseCase(uow=uow)
+        request = CreateRoundRequestDTO(
+            competition_id=competition.id.value,
+            golf_course_id=golf_course_id.value,
+            round_date=date(2026, 6, 1),
+            session_type="MORNING",
+            match_format="SINGLES",
+        )
+
+        # Act
+        response = await use_case.execute(request, other_user_id, is_admin=True)
+
+        # Assert
+        assert response.id is not None
+        assert response.status == "PENDING_TEAMS"
+
     async def test_should_fail_when_not_closed(
         self,
         uow: InMemoryUnitOfWork,

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -1,6 +1,6 @@
 """Tests para GenerateMatchesUseCase."""
 
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -626,7 +626,12 @@ class TestGenerateMatchesUseCase:
         return golf_course
 
     def _build_mock_user(
-        self, user_id: UserId, handicap_value: float, gender: Gender | None = Gender.MALE
+        self,
+        user_id: UserId,
+        handicap_value: float,
+        gender: Gender | None = Gender.MALE,
+        country_code: str | None = None,
+        handicap_updated_at=None,
     ) -> MagicMock:
         """
         Helper que construye un mock de User con un handicap y genero.
@@ -635,6 +640,8 @@ class TestGenerateMatchesUseCase:
             user_id: ID del usuario.
             handicap_value: Valor del handicap.
             gender: Genero del usuario (default: MALE).
+            country_code: Codigo de pais ISO (default: None -> country_code=None).
+            handicap_updated_at: Fecha de ultima actualizacion del handicap (HM-1a).
 
         Returns:
             Mock de User con handicap y gender configurados.
@@ -643,6 +650,9 @@ class TestGenerateMatchesUseCase:
         user.id = user_id
         user.handicap = Handicap(handicap_value)
         user.gender = gender
+        user.country_code = CountryCode(country_code) if country_code else None
+        user.handicap_updated_at = handicap_updated_at
+        user.get_full_name.return_value = "Test Player"
         return user
 
     async def _create_teams_and_enrollments_with_tees(
@@ -1199,3 +1209,352 @@ class TestGenerateMatchesUseCase:
         assert len(matches) == 1
         for p in (*matches[0].team_a_players, *matches[0].team_b_players):
             assert p.playing_handicap <= 3
+
+    # =========================================================================
+    # HM-1b: PLAYER_HANDICAP SNAPSHOT TESTS
+    # =========================================================================
+
+    async def test_player_handicap_snapshot_is_stored_in_generated_match(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1b: el HI usado para calcular el playing_handicap se guarda como snapshot.
+
+        Given: Jugadores con HI=15.0 (sin RFEG, sin custom_handicap)
+        When: Se generan partidos en modo HANDICAP
+        Then: Cada MatchPlayer.player_handicap == Decimal("15.0")
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 15.0)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        matches = await uow.matches.find_by_round(round_entity.id)
+        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+            assert p.player_handicap == Decimal("15.0")
+
+    # =========================================================================
+    # HM-1a: RFEG AUTO-REFRESH TESTS
+    # =========================================================================
+
+    async def test_rfeg_refresh_updates_handicap_and_flows_into_player_handicap(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: refresca el HI vía RFEG para jugadores ES sin hándicap personalizado.
+
+        Given: Jugador ES sin custom_handicap, RFEG devuelve un HI nuevo (12.3)
+        When: Se generan partidos
+        Then: user.update_handicap() se invoca con el valor de RFEG, se persiste vía
+              save(), y el nuevo valor queda reflejado en player_handicap del partido.
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        mock_user = self._build_mock_user(UserId.generate(), 15.0, country_code="ES")
+        mock_user.update_handicap.side_effect = lambda v: setattr(
+            mock_user, "handicap", Handicap(v)
+        )
+        user_repo.find_by_id = AsyncMock(return_value=mock_user)
+
+        handicap_service = AsyncMock()
+        handicap_service.search_handicap = AsyncMock(return_value=12.3)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+            handicap_service=handicap_service,
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        handicap_service.search_handicap.assert_called_with("Test Player")
+        mock_user.update_handicap.assert_called_with(12.3)
+        assert user_repo.save.await_count >= 1
+
+        matches = await uow.matches.find_by_round(round_entity.id)
+        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+            assert p.player_handicap == Decimal("12.3")
+
+    async def test_rfeg_refresh_skipped_for_player_with_custom_handicap(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: no se refresca vía RFEG si el jugador tiene custom_handicap en su enrollment.
+
+        Given: Jugador ES con custom_handicap definido en su enrollment
+        When: Se generan partidos
+        Then: handicap_service.search_handicap no se invoca para ese jugador
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+
+        player_a = UserId(uuid4())
+        player_b = UserId(uuid4())
+        team_assignment = TeamAssignmentEntity.create(
+            competition_id=competition.id,
+            mode=TeamAssignmentMode.MANUAL,
+            team_a_player_ids=[player_a],
+            team_b_player_ids=[player_b],
+        )
+        async with uow:
+            await uow.team_assignments.add(team_assignment)
+
+        enrollment_a = Enrollment(
+            id=EnrollmentId.generate(),
+            competition_id=competition.id,
+            user_id=player_a,
+            status=EnrollmentStatus.APPROVED,
+            tee_category=TeeCategory.AMATEUR,
+        )
+        enrollment_a.set_custom_handicap(Decimal("10.0"))
+        enrollment_b = Enrollment(
+            id=EnrollmentId.generate(),
+            competition_id=competition.id,
+            user_id=player_b,
+            status=EnrollmentStatus.APPROVED,
+            tee_category=TeeCategory.AMATEUR,
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment_a)
+            await uow.enrollments.add(enrollment_b)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 15.0, country_code="ES")
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        handicap_service = AsyncMock()
+        handicap_service.search_handicap = AsyncMock(return_value=5.0)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+            handicap_service=handicap_service,
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        # Solo player_b (sin custom_handicap) dispara el refresco RFEG
+        handicap_service.search_handicap.assert_called_once_with("Test Player")
+
+    async def test_rfeg_refresh_skipped_for_non_es_player(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: no se refresca vía RFEG si el jugador no es de España.
+
+        Given: Jugador con country_code=FR (no ES), sin custom_handicap
+        When: Se generan partidos
+        Then: handicap_service.search_handicap no se invoca
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 15.0, country_code="FR")
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        handicap_service = AsyncMock()
+        handicap_service.search_handicap = AsyncMock(return_value=5.0)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+            handicap_service=handicap_service,
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        handicap_service.search_handicap.assert_not_called()
+
+    async def test_rfeg_refresh_skipped_if_already_updated_today(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: no se refresca más de una vez al día (mismo gate que login HM-2c).
+
+        Given: Jugador ES cuyo handicap_updated_at ya es de hoy
+        When: Se generan partidos
+        Then: handicap_service.search_handicap no se invoca
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(
+                uid, 15.0, country_code="ES", handicap_updated_at=datetime.now(UTC)
+            )
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        handicap_service = AsyncMock()
+        handicap_service.search_handicap = AsyncMock(return_value=5.0)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+            handicap_service=handicap_service,
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        handicap_service.search_handicap.assert_not_called()
+
+    async def test_rfeg_refresh_error_is_silently_ignored(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: un error del servicio RFEG no debe bloquear la generación de partidos.
+
+        Given: handicap_service.search_handicap lanza una excepción
+        When: Se generan partidos
+        Then: Los partidos se generan igualmente, usando el HI existente del usuario
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 15.0, country_code="ES")
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        handicap_service = AsyncMock()
+        handicap_service.search_handicap = AsyncMock(side_effect=RuntimeError("RFEG down"))
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+            handicap_service=handicap_service,
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        response = await use_case.execute(request, creator_id)
+
+        assert response.matches_generated == 1
+        matches = await uow.matches.find_by_round(round_entity.id)
+        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+            assert p.player_handicap == Decimal("15.0")
+
+    async def test_generate_matches_without_handicap_service_does_not_crash(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        HM-1a: handicap_service es opcional (compat con instanciaciones sin este parámetro).
+
+        Given: GenerateMatchesUseCase construido sin handicap_service (default None)
+        When: Se generan partidos con un jugador ES sin custom_handicap
+        Then: No se lanza ninguna excepción y los partidos se generan normalmente
+        """
+        competition = await self._create_handicap_competition(uow, creator_id)
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 15.0, country_code="ES")
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        response = await use_case.execute(request, creator_id)
+
+        assert response.matches_generated == 1

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -1163,9 +1163,13 @@ class TestGenerateMatchesUseCase:
         """
         Verifica que max_playing_handicap se aplica al generar partidos FOURBALL.
 
-        Given: Competicion HANDICAP con max_playing_handicap=3, jugadores HI=36
+        Given: Competicion HANDICAP con max_playing_handicap=3, HI dispares entre los 4
+               jugadores (36 vs 0), de forma que el metodo diferencial WHS produzca un
+               PH > 3 para el jugador de mayor HI antes de aplicar el cap
         When: Se generan partidos FOURBALL
-        Then: playing_handicap de todos los jugadores <= 3
+        Then: playing_handicap de todos los jugadores <= 3, y el jugador de mayor HI
+              queda exactamente en 3 (confirma que el cap realmente actuo, no que el
+              diferencial ya diera <=3 por si solo)
         """
         competition = Competition.create(
             id=CompetitionId(uuid4()),
@@ -1188,13 +1192,17 @@ class TestGenerateMatchesUseCase:
         round_entity = await self._create_round_pending_matches(
             uow, competition, golf_course_id, MatchFormat.FOURBALL
         )
-        await self._create_teams_and_enrollments_with_tees(uow, competition, 2, 2)
+        team_a_ids, _team_b_ids = await self._create_teams_and_enrollments_with_tees(
+            uow, competition, 2, 2
+        )
+        high_hi_uid = team_a_ids[0]
 
         mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
         gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
 
         async def mock_find_user(uid):
-            return self._build_mock_user(uid, 36.0, Gender.MALE)
+            hi = 36.0 if uid == high_hi_uid else 0.0
+            return self._build_mock_user(uid, hi, Gender.MALE)
 
         user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
 
@@ -1207,8 +1215,12 @@ class TestGenerateMatchesUseCase:
 
         matches = await uow.matches.find_by_round(round_entity.id)
         assert len(matches) == 1
-        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+        all_players = (*matches[0].team_a_players, *matches[0].team_b_players)
+        for p in all_players:
             assert p.playing_handicap <= 3
+
+        high_hi_player = next(p for p in all_players if p.user_id == high_hi_uid)
+        assert high_hi_player.playing_handicap == 3
 
     # =========================================================================
     # HM-1b: PLAYER_HANDICAP SNAPSHOT TESTS

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -1079,3 +1079,123 @@ class TestGenerateMatchesUseCase:
         # Act & Assert
         with pytest.raises(ValueError, match="campo de golf"):
             await use_case.execute(request, creator_id)
+
+    async def test_max_playing_handicap_is_applied_in_singles(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica que max_playing_handicap se aplica al generar partidos SINGLES.
+
+        Given: Competicion HANDICAP con max_playing_handicap=5, jugadores HI=36
+        When: Se generan partidos SINGLES
+        Then: playing_handicap de todos los jugadores <= 5
+        """
+        # Arrange: competition con max_playing_handicap=5
+        competition = Competition.create(
+            id=CompetitionId(uuid4()),
+            creator_id=creator_id,
+            name=CompetitionName("Cap Competition"),
+            dates=DateRange(start_date=date(2026, 6, 1), end_date=date(2026, 6, 3)),
+            location=Location(main_country=CountryCode("ES")),
+            play_mode=PlayMode.HANDICAP,
+            max_players=24,
+            team_assignment=TeamAssignment.MANUAL,
+            team_1_name="Team A",
+            team_2_name="Team B",
+            max_playing_handicap=5,
+        )
+        competition.activate()
+        competition.close_enrollments()
+        async with uow:
+            await uow.competitions.add(competition)
+
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.SINGLES
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 1, 1)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        # HI=36 → PH sin cap sería ~36, con cap=5 debe quedar en 5
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 36.0, Gender.MALE)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        # Act
+        await use_case.execute(request, creator_id)
+
+        # Assert: playing_handicap individual no supera el cap
+        matches = await uow.matches.find_by_round(round_entity.id)
+        assert len(matches) == 1
+        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+            assert p.playing_handicap <= 5
+
+    async def test_max_playing_handicap_is_applied_in_fourball(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica que max_playing_handicap se aplica al generar partidos FOURBALL.
+
+        Given: Competicion HANDICAP con max_playing_handicap=3, jugadores HI=36
+        When: Se generan partidos FOURBALL
+        Then: playing_handicap de todos los jugadores <= 3
+        """
+        competition = Competition.create(
+            id=CompetitionId(uuid4()),
+            creator_id=creator_id,
+            name=CompetitionName("Cap Fourball"),
+            dates=DateRange(start_date=date(2026, 6, 1), end_date=date(2026, 6, 3)),
+            location=Location(main_country=CountryCode("ES")),
+            play_mode=PlayMode.HANDICAP,
+            max_players=24,
+            team_assignment=TeamAssignment.MANUAL,
+            team_1_name="Team A",
+            team_2_name="Team B",
+            max_playing_handicap=3,
+        )
+        competition.activate()
+        competition.close_enrollments()
+        async with uow:
+            await uow.competitions.add(competition)
+
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.FOURBALL
+        )
+        await self._create_teams_and_enrollments_with_tees(uow, competition, 2, 2)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            return self._build_mock_user(uid, 36.0, Gender.MALE)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        matches = await uow.matches.find_by_round(round_entity.id)
+        assert len(matches) == 1
+        for p in (*matches[0].team_a_players, *matches[0].team_b_players):
+            assert p.playing_handicap <= 3

--- a/tests/unit/modules/competition/application/use_cases/test_handle_enrollment_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_handle_enrollment_use_case.py
@@ -49,6 +49,10 @@ class TestHandleEnrollmentUseCase:
     def other_user_id(self) -> UserId:
         return UserId(uuid4())
 
+    @pytest.fixture
+    def admin_user_id(self) -> UserId:
+        return UserId(uuid4())
+
     async def _create_active_competition(
         self, uow: InMemoryUnitOfWork, creator_id: UserId, max_players: int = 24
     ):
@@ -164,6 +168,31 @@ class TestHandleEnrollmentUseCase:
 
         with pytest.raises(NotCreatorError):
             await use_case.execute(request, other_user_id)
+
+    async def test_should_succeed_when_admin_not_creator(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        other_user_id: UserId,
+        admin_user_id: UserId,
+    ):
+        """
+        Given: Un enrollment válido en una competición ajena
+        When: Un admin (no creador) lo aprueba con is_admin=True
+        Then: El enrollment pasa a APPROVED sin lanzar NotCreatorError
+        """
+        created = await self._create_active_competition(uow, creator_id)
+        enrollment = await self._create_requested_enrollment(uow, created.id, other_user_id)
+
+        use_case = HandleEnrollmentUseCase(uow)
+        request = HandleEnrollmentRequestDTO(
+            enrollment_id=enrollment.id.value,
+            action="APPROVE",
+        )
+
+        response = await use_case.execute(request, admin_user_id, is_admin=True)
+
+        assert response.status == "APPROVED"
 
     async def test_should_raise_validation_error_for_invalid_action(
         self, uow: InMemoryUnitOfWork, creator_id: UserId, other_user_id: UserId

--- a/tests/unit/modules/competition/application/use_cases/test_reassign_match_players_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_reassign_match_players_use_case.py
@@ -1,6 +1,7 @@
 """Tests para ReassignMatchPlayersUseCase."""
 
 from datetime import date
+from decimal import Decimal
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -29,6 +30,7 @@ from src.modules.competition.domain.value_objects.date_range import DateRange
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.competition.domain.value_objects.location import Location
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.match_id import MatchId
 from src.modules.competition.domain.value_objects.match_player import MatchPlayer
 from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.competition.domain.value_objects.session_type import SessionType
@@ -39,9 +41,13 @@ from src.modules.competition.domain.value_objects.team_assignment_mode import (
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
 from src.modules.golf_course.domain.repositories.golf_course_repository import (
     IGolfCourseRepository,
 )
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.repositories.user_repository_interface import (
@@ -454,3 +460,148 @@ class TestReassignMatchPlayersUseCase:
         assert response.handicap_strokes_given == 0
         assert response.strokes_given_to_team == ""
         assert response.new_status == "SCHEDULED"
+
+    async def test_should_apply_competition_max_playing_handicap_cap(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica que la reasignacion respeta el cap max_playing_handicap de la competicion.
+
+        Given: Una competicion HANDICAP con max_playing_handicap=10 y un jugador
+               con custom_handicap=30 (muy por encima del cap)
+        When: El creador reasigna ese jugador a un partido
+        Then: El playing_handicap resultante queda acotado a 10, no a 30
+        """
+        # Arrange - Competicion en modo HANDICAP con cap de 10
+        competition = Competition.create(
+            id=CompetitionId(uuid4()),
+            creator_id=creator_id,
+            name=CompetitionName("Capped Handicap Cup"),
+            dates=DateRange(start_date=date(2026, 6, 1), end_date=date(2026, 6, 3)),
+            location=Location(main_country=CountryCode("ES")),
+            play_mode=PlayMode.HANDICAP,
+            max_players=24,
+            team_assignment=TeamAssignment.MANUAL,
+            team_1_name="Team A",
+            team_2_name="Team B",
+            max_playing_handicap=10,
+        )
+        competition.activate()
+        competition.close_enrollments()
+
+        async with uow:
+            await uow.competitions.add(competition)
+
+        player1 = UserId(uuid4())
+        player2 = UserId(uuid4())
+        player3 = UserId(uuid4())
+        player4 = UserId(uuid4())
+
+        # Enrollments con custom_handicap muy por encima del cap de la competicion
+        for player_id in [player1, player2, player3, player4]:
+            enrollment = Enrollment.direct_enroll(
+                id=EnrollmentId.generate(),
+                competition_id=competition.id,
+                user_id=player_id,
+                custom_handicap=Decimal("30"),
+                tee_category=TeeCategory.AMATEUR,
+            )
+            async with uow:
+                await uow.enrollments.add(enrollment)
+
+        team_assignment = TeamAssignmentEntity.create(
+            competition_id=competition.id,
+            mode=TeamAssignmentMode.MANUAL,
+            team_a_player_ids=[player1, player2],
+            team_b_player_ids=[player3, player4],
+        )
+        async with uow:
+            await uow.team_assignments.add(team_assignment)
+
+        # Campo de golf con tee neutro (slope 113, course_rating == par total)
+        # para que el Course Handicap resultante sea igual al handicap_index (30)
+        holes = [Hole(number=i, par=4, stroke_index=i) for i in range(1, 19)]
+        tees = [
+            Tee(
+                category=TeeCategory.AMATEUR,
+                gender=None,
+                identifier="White",
+                course_rating=72.0,
+                slope_rating=113,
+            ),
+            Tee(
+                category=TeeCategory.CHAMPIONSHIP,
+                gender=None,
+                identifier="Black",
+                course_rating=74.0,
+                slope_rating=125,
+            ),
+        ]
+        golf_course = GolfCourse.create(
+            name="Test Course",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.STANDARD_18,
+            creator_id=creator_id,
+            tees=tees,
+            holes=holes,
+        )
+        gc_repo.find_by_id = AsyncMock(return_value=golf_course)
+
+        round_entity = Round.create(
+            competition_id=competition.id,
+            golf_course_id=golf_course_id,
+            round_date=date(2026, 6, 1),
+            session_type=SessionType.MORNING,
+            match_format=MatchFormat.SINGLES,
+        )
+        round_entity.mark_teams_assigned()
+        round_entity.mark_matches_generated()
+
+        original_player_a = MatchPlayer.create(
+            user_id=player1,
+            playing_handicap=0,
+            tee_category=TeeCategory.AMATEUR,
+            strokes_received=[],
+        )
+        original_player_b = MatchPlayer.create(
+            user_id=player3,
+            playing_handicap=0,
+            tee_category=TeeCategory.AMATEUR,
+            strokes_received=[],
+        )
+        match = Match.create(
+            round_id=round_entity.id,
+            match_number=1,
+            team_a_players=[original_player_a],
+            team_b_players=[original_player_b],
+        )
+
+        async with uow:
+            await uow.rounds.add(round_entity)
+            await uow.matches.add(match)
+
+        use_case = ReassignMatchPlayersUseCase(
+            uow=uow,
+            golf_course_repository=gc_repo,
+            user_repository=user_repo,
+        )
+
+        request = ReassignMatchPlayersRequestDTO(
+            match_id=match.id.value,
+            team_a_player_ids=[player2.value],
+            team_b_player_ids=[player4.value],
+        )
+
+        # Act
+        response = await use_case.execute(request, creator_id)
+
+        # Assert - El playing handicap resultante debe quedar acotado a 10
+        async with uow:
+            new_match = await uow.matches.find_by_id(MatchId(response.match_id))
+        assert new_match.team_a_players[0].playing_handicap == 10
+        assert new_match.team_b_players[0].playing_handicap == 10

--- a/tests/unit/modules/competition/application/use_cases/test_remove_custom_handicap_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_remove_custom_handicap_use_case.py
@@ -1,0 +1,264 @@
+"""Tests para RemoveCustomHandicapUseCase."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    HandicapEditNotAllowedError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.remove_custom_handicap_use_case import (
+    EnrollmentNotFoundError,
+    NotCreatorError,
+    RemoveCustomHandicapUseCase,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment, EnrollmentStateError
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestRemoveCustomHandicapUseCase:
+    """Suite de tests para el caso de uso RemoveCustomHandicapUseCase."""
+
+    @pytest.fixture
+    def uow(self) -> InMemoryUnitOfWork:
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    def creator_id(self) -> UserId:
+        return UserId(uuid4())
+
+    @pytest.fixture
+    def player_id(self) -> UserId:
+        return UserId(uuid4())
+
+    @pytest.fixture
+    def admin_user_id(self) -> UserId:
+        return UserId(uuid4())
+
+    async def _create_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
+        """Helper: crea una competición en DRAFT."""
+        create_uc = CreateCompetitionUseCase(uow)
+        request = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        return await create_uc.execute(request, creator_id)
+
+    async def _set_competition_status(
+        self, uow: InMemoryUnitOfWork, competition_id, status: str
+    ):
+        """Helper: mueve una competición a través de sus transiciones hasta `status`."""
+        async with uow:
+            competition = await uow.competitions.find_by_id(CompetitionId(competition_id))
+            if status in ("ACTIVE", "CLOSED", "IN_PROGRESS", "COMPLETED", "CANCELLED"):
+                competition.activate()
+            if status in ("CLOSED", "IN_PROGRESS", "COMPLETED"):
+                competition.close_enrollments()
+            if status in ("IN_PROGRESS", "COMPLETED"):
+                competition.start()
+            if status == "COMPLETED":
+                competition.complete()
+            if status == "CANCELLED":
+                competition.cancel()
+            await uow.competitions.update(competition)
+            await uow.commit()
+
+    async def _create_enrollment_with_custom_handicap(
+        self, uow: InMemoryUnitOfWork, competition_id, user_id: UserId
+    ) -> Enrollment:
+        """Helper: crea un enrollment aprobado con hándicap personalizado ya establecido."""
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(competition_id),
+            user_id=user_id,
+            custom_handicap=Decimal("20.0"),
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+        return enrollment
+
+    async def test_should_remove_custom_handicap_successfully(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment aprobado con hándicap personalizado
+        When: El creador lo elimina
+        Then: El enrollment vuelve a tener custom_handicap=None
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_enrollment_with_custom_handicap(
+            uow, created.id, player_id
+        )
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+        response = await use_case.execute(str(enrollment.id.value), creator_id)
+
+        assert response.custom_handicap is None
+
+    async def test_should_allow_admin_not_creator(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        player_id: UserId,
+        admin_user_id: UserId,
+    ):
+        """
+        Given: Un enrollment con hándicap personalizado en una competición ajena
+        When: Un admin (no creador) lo elimina con is_admin=True
+        Then: Se aplica sin lanzar NotCreatorError
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_enrollment_with_custom_handicap(
+            uow, created.id, player_id
+        )
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+        response = await use_case.execute(
+            str(enrollment.id.value), admin_user_id, is_admin=True
+        )
+
+        assert response.custom_handicap is None
+
+    async def test_should_raise_not_creator_error(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment con hándicap personalizado
+        When: Un usuario que no es el creador ni admin intenta eliminarlo
+        Then: Se lanza NotCreatorError
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_enrollment_with_custom_handicap(
+            uow, created.id, player_id
+        )
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+
+        with pytest.raises(NotCreatorError):
+            await use_case.execute(str(enrollment.id.value), player_id)
+
+    async def test_should_raise_enrollment_not_found(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId
+    ):
+        """
+        Given: Un enrollment_id que no existe
+        When: Se intenta eliminar el hándicap
+        Then: Se lanza EnrollmentNotFoundError
+        """
+        use_case = RemoveCustomHandicapUseCase(uow)
+
+        with pytest.raises(EnrollmentNotFoundError):
+            await use_case.execute(str(uuid4()), creator_id)
+
+    async def test_should_raise_competition_not_found(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId
+    ):
+        """
+        Given: Un enrollment cuya competición no existe
+        When: Se intenta eliminar el hándicap
+        Then: Se lanza CompetitionNotFoundError
+        """
+        fake_comp_id = CompetitionId(uuid4())
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=fake_comp_id,
+            user_id=creator_id,
+            custom_handicap=Decimal("20.0"),
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+
+        with pytest.raises(CompetitionNotFoundError):
+            await use_case.execute(str(enrollment.id.value), creator_id)
+
+    async def test_should_raise_enrollment_state_error_when_not_approved(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment en estado REQUESTED (no aprobado)
+        When: El creador intenta eliminar el hándicap
+        Then: Se lanza EnrollmentStateError
+        """
+        created = await self._create_competition(uow, creator_id)
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = Enrollment.request(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(created.id),
+            user_id=player_id,
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+
+        with pytest.raises(EnrollmentStateError):
+            await use_case.execute(str(enrollment.id.value), creator_id)
+
+    @pytest.mark.parametrize("status", ["IN_PROGRESS", "COMPLETED", "CANCELLED"])
+    async def test_should_raise_handicap_edit_not_allowed_once_competition_left_closed(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId, status: str
+    ):
+        """
+        Given: Un enrollment con hándicap personalizado en una competición
+               IN_PROGRESS/COMPLETED/CANCELLED
+        When: El creador intenta eliminar el hándicap
+        Then: Se lanza HandicapEditNotAllowedError
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_enrollment_with_custom_handicap(
+            uow, created.id, player_id
+        )
+        await self._set_competition_status(uow, created.id, status)
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+
+        with pytest.raises(HandicapEditNotAllowedError):
+            await use_case.execute(str(enrollment.id.value), creator_id)
+
+    @pytest.mark.parametrize("status", ["DRAFT", "ACTIVE", "CLOSED"])
+    async def test_should_allow_handicap_removal_while_draft_active_or_closed(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId, status: str
+    ):
+        """
+        Given: Un enrollment con hándicap personalizado
+        When: La competición está en DRAFT, ACTIVE o CLOSED
+        Then: Se puede eliminar el hándicap personalizado sin errores
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_enrollment_with_custom_handicap(
+            uow, created.id, player_id
+        )
+        await self._set_competition_status(uow, created.id, status)
+
+        use_case = RemoveCustomHandicapUseCase(uow)
+        response = await use_case.execute(str(enrollment.id.value), creator_id)
+
+        assert response.custom_handicap is None

--- a/tests/unit/modules/competition/application/use_cases/test_remove_custom_handicap_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_remove_custom_handicap_use_case.py
@@ -1,20 +1,13 @@
 """Tests para RemoveCustomHandicapUseCase."""
 
-from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 
-from src.modules.competition.application.dto.competition_dto import (
-    CreateCompetitionRequestDTO,
-)
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
     HandicapEditNotAllowedError,
-)
-from src.modules.competition.application.use_cases.create_competition_use_case import (
-    CreateCompetitionUseCase,
 )
 from src.modules.competition.application.use_cases.remove_custom_handicap_use_case import (
     EnrollmentNotFoundError,
@@ -28,6 +21,11 @@ from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit
     InMemoryUnitOfWork,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from tests.unit.modules.competition.application.use_cases.helpers import (
+    create_approved_enrollment,
+    create_competition,
+    set_competition_status,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,53 +49,6 @@ class TestRemoveCustomHandicapUseCase:
     def admin_user_id(self) -> UserId:
         return UserId(uuid4())
 
-    async def _create_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
-        """Helper: crea una competición en DRAFT."""
-        create_uc = CreateCompetitionUseCase(uow)
-        request = CreateCompetitionRequestDTO(
-            name="Test Cup",
-            start_date=date(2026, 6, 1),
-            end_date=date(2026, 6, 3),
-            main_country="ES",
-            play_mode="SCRATCH",
-            max_players=24,
-        )
-        return await create_uc.execute(request, creator_id)
-
-    async def _set_competition_status(
-        self, uow: InMemoryUnitOfWork, competition_id, status: str
-    ):
-        """Helper: mueve una competición a través de sus transiciones hasta `status`."""
-        async with uow:
-            competition = await uow.competitions.find_by_id(CompetitionId(competition_id))
-            if status in ("ACTIVE", "CLOSED", "IN_PROGRESS", "COMPLETED", "CANCELLED"):
-                competition.activate()
-            if status in ("CLOSED", "IN_PROGRESS", "COMPLETED"):
-                competition.close_enrollments()
-            if status in ("IN_PROGRESS", "COMPLETED"):
-                competition.start()
-            if status == "COMPLETED":
-                competition.complete()
-            if status == "CANCELLED":
-                competition.cancel()
-            await uow.competitions.update(competition)
-            await uow.commit()
-
-    async def _create_enrollment_with_custom_handicap(
-        self, uow: InMemoryUnitOfWork, competition_id, user_id: UserId
-    ) -> Enrollment:
-        """Helper: crea un enrollment aprobado con hándicap personalizado ya establecido."""
-        enrollment = Enrollment.direct_enroll(
-            id=EnrollmentId.generate(),
-            competition_id=CompetitionId(competition_id),
-            user_id=user_id,
-            custom_handicap=Decimal("20.0"),
-        )
-        async with uow:
-            await uow.enrollments.add(enrollment)
-            await uow.commit()
-        return enrollment
-
     async def test_should_remove_custom_handicap_successfully(
         self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
     ):
@@ -106,11 +57,11 @@ class TestRemoveCustomHandicapUseCase:
         When: El creador lo elimina
         Then: El enrollment vuelve a tener custom_handicap=None
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_enrollment_with_custom_handicap(
-            uow, created.id, player_id
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(
+            uow, created.id, player_id, custom_handicap=Decimal("20.0")
         )
-        await self._set_competition_status(uow, created.id, "ACTIVE")
+        await set_competition_status(uow, created.id, "ACTIVE")
 
         use_case = RemoveCustomHandicapUseCase(uow)
         response = await use_case.execute(str(enrollment.id.value), creator_id)
@@ -129,11 +80,11 @@ class TestRemoveCustomHandicapUseCase:
         When: Un admin (no creador) lo elimina con is_admin=True
         Then: Se aplica sin lanzar NotCreatorError
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_enrollment_with_custom_handicap(
-            uow, created.id, player_id
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(
+            uow, created.id, player_id, custom_handicap=Decimal("20.0")
         )
-        await self._set_competition_status(uow, created.id, "ACTIVE")
+        await set_competition_status(uow, created.id, "ACTIVE")
 
         use_case = RemoveCustomHandicapUseCase(uow)
         response = await use_case.execute(
@@ -150,11 +101,11 @@ class TestRemoveCustomHandicapUseCase:
         When: Un usuario que no es el creador ni admin intenta eliminarlo
         Then: Se lanza NotCreatorError
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_enrollment_with_custom_handicap(
-            uow, created.id, player_id
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(
+            uow, created.id, player_id, custom_handicap=Decimal("20.0")
         )
-        await self._set_competition_status(uow, created.id, "ACTIVE")
+        await set_competition_status(uow, created.id, "ACTIVE")
 
         use_case = RemoveCustomHandicapUseCase(uow)
 
@@ -206,8 +157,8 @@ class TestRemoveCustomHandicapUseCase:
         When: El creador intenta eliminar el hándicap
         Then: Se lanza EnrollmentStateError
         """
-        created = await self._create_competition(uow, creator_id)
-        await self._set_competition_status(uow, created.id, "ACTIVE")
+        created = await create_competition(uow, creator_id)
+        await set_competition_status(uow, created.id, "ACTIVE")
         enrollment = Enrollment.request(
             id=EnrollmentId.generate(),
             competition_id=CompetitionId(created.id),
@@ -232,11 +183,11 @@ class TestRemoveCustomHandicapUseCase:
         When: El creador intenta eliminar el hándicap
         Then: Se lanza HandicapEditNotAllowedError
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_enrollment_with_custom_handicap(
-            uow, created.id, player_id
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(
+            uow, created.id, player_id, custom_handicap=Decimal("20.0")
         )
-        await self._set_competition_status(uow, created.id, status)
+        await set_competition_status(uow, created.id, status)
 
         use_case = RemoveCustomHandicapUseCase(uow)
 
@@ -252,11 +203,11 @@ class TestRemoveCustomHandicapUseCase:
         When: La competición está en DRAFT, ACTIVE o CLOSED
         Then: Se puede eliminar el hándicap personalizado sin errores
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_enrollment_with_custom_handicap(
-            uow, created.id, player_id
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(
+            uow, created.id, player_id, custom_handicap=Decimal("20.0")
         )
-        await self._set_competition_status(uow, created.id, status)
+        await set_competition_status(uow, created.id, status)
 
         use_case = RemoveCustomHandicapUseCase(uow)
         response = await use_case.execute(str(enrollment.id.value), creator_id)

--- a/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
@@ -150,6 +150,24 @@ class TestSendInvitationByUserIdUseCase:
         with pytest.raises(NotCompetitionCreatorError):
             await uc.execute(request)
 
+    async def test_should_succeed_when_admin_not_creator(self, comp_uow, user_uow):
+        """Admin (no creador) puede enviar invitacion con is_admin=True."""
+        creator = await self._create_user(user_uow, email="creator@test.com")
+        admin = await self._create_user(user_uow, email="admin@test.com")
+        invitee = await self._create_user(user_uow, email="invitee@test.com")
+        created = await self._create_active_competition(comp_uow, creator.id)
+
+        uc = SendInvitationByUserIdUseCase(comp_uow, user_uow)
+        request = SendInvitationByUserIdRequestDTO(
+            competition_id=created.id,
+            inviter_id=admin.id.value,
+            invitee_user_id=invitee.id.value,
+        )
+
+        result = await uc.execute(request, is_admin=True)
+
+        assert result.status == "PENDING"
+
     async def test_should_raise_invitee_not_found(self, comp_uow, user_uow):
         """Invitee inexistente lanza InviteeNotFoundError."""
         creator = await self._create_user(user_uow, email="creator@test.com")

--- a/tests/unit/modules/competition/application/use_cases/test_set_custom_handicap_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_set_custom_handicap_use_case.py
@@ -1,0 +1,274 @@
+"""Tests para SetCustomHandicapUseCase."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.application.dto.competition_dto import (
+    CreateCompetitionRequestDTO,
+)
+from src.modules.competition.application.dto.enrollment_dto import (
+    SetCustomHandicapRequestDTO,
+)
+from src.modules.competition.application.exceptions import (
+    CompetitionNotFoundError,
+    HandicapEditNotAllowedError,
+)
+from src.modules.competition.application.use_cases.create_competition_use_case import (
+    CreateCompetitionUseCase,
+)
+from src.modules.competition.application.use_cases.set_custom_handicap_use_case import (
+    EnrollmentNotFoundError,
+    NotCreatorError,
+    SetCustomHandicapUseCase,
+)
+from src.modules.competition.domain.entities.enrollment import Enrollment, EnrollmentStateError
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSetCustomHandicapUseCase:
+    """Suite de tests para el caso de uso SetCustomHandicapUseCase."""
+
+    @pytest.fixture
+    def uow(self) -> InMemoryUnitOfWork:
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    def creator_id(self) -> UserId:
+        return UserId(uuid4())
+
+    @pytest.fixture
+    def player_id(self) -> UserId:
+        return UserId(uuid4())
+
+    @pytest.fixture
+    def admin_user_id(self) -> UserId:
+        return UserId(uuid4())
+
+    async def _create_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
+        """Helper: crea una competición en DRAFT."""
+        create_uc = CreateCompetitionUseCase(uow)
+        request = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 3),
+            main_country="ES",
+            play_mode="SCRATCH",
+            max_players=24,
+        )
+        return await create_uc.execute(request, creator_id)
+
+    async def _set_competition_status(
+        self, uow: InMemoryUnitOfWork, competition_id, status: str
+    ):
+        """Helper: mueve una competición a través de sus transiciones hasta `status`."""
+        async with uow:
+            competition = await uow.competitions.find_by_id(CompetitionId(competition_id))
+            if status in ("ACTIVE", "CLOSED", "IN_PROGRESS", "COMPLETED", "CANCELLED"):
+                competition.activate()
+            if status in ("CLOSED", "IN_PROGRESS", "COMPLETED"):
+                competition.close_enrollments()
+            if status in ("IN_PROGRESS", "COMPLETED"):
+                competition.start()
+            if status == "COMPLETED":
+                competition.complete()
+            if status == "CANCELLED":
+                competition.cancel()
+            await uow.competitions.update(competition)
+            await uow.commit()
+
+    async def _create_approved_enrollment(
+        self, uow: InMemoryUnitOfWork, competition_id, user_id: UserId
+    ) -> Enrollment:
+        """Helper: crea un enrollment ya aprobado."""
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(competition_id),
+            user_id=user_id,
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+        return enrollment
+
+    async def test_should_set_custom_handicap_successfully(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment aprobado en una competición ACTIVE
+        When: El creador establece un hándicap personalizado
+        Then: El enrollment refleja el nuevo hándicap
+        """
+        created = await self._create_competition(uow, creator_id)
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("15.5")
+        )
+        response = await use_case.execute(request, creator_id)
+
+        assert response.custom_handicap == Decimal("15.5")
+
+    async def test_should_allow_admin_not_creator(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        player_id: UserId,
+        admin_user_id: UserId,
+    ):
+        """
+        Given: Un enrollment aprobado en una competición ajena
+        When: Un admin (no creador) establece el hándicap con is_admin=True
+        Then: Se aplica sin lanzar NotCreatorError
+        """
+        created = await self._create_competition(uow, creator_id)
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("10.0")
+        )
+        response = await use_case.execute(request, admin_user_id, is_admin=True)
+
+        assert response.custom_handicap == Decimal("10.0")
+
+    async def test_should_raise_not_creator_error(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment aprobado
+        When: Un usuario que no es el creador ni admin intenta establecer el hándicap
+        Then: Se lanza NotCreatorError
+        """
+        created = await self._create_competition(uow, creator_id)
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("10.0")
+        )
+
+        with pytest.raises(NotCreatorError):
+            await use_case.execute(request, player_id)
+
+    async def test_should_raise_enrollment_not_found(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId
+    ):
+        """
+        Given: Un enrollment_id que no existe
+        When: Se intenta establecer el hándicap
+        Then: Se lanza EnrollmentNotFoundError
+        """
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=uuid4(), custom_handicap=Decimal("10.0")
+        )
+
+        with pytest.raises(EnrollmentNotFoundError):
+            await use_case.execute(request, creator_id)
+
+    async def test_should_raise_competition_not_found(self, uow: InMemoryUnitOfWork, creator_id: UserId):
+        """
+        Given: Un enrollment cuya competición no existe
+        When: Se intenta establecer el hándicap
+        Then: Se lanza CompetitionNotFoundError
+        """
+        fake_comp_id = CompetitionId(uuid4())
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=fake_comp_id,
+            user_id=creator_id,
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("10.0")
+        )
+
+        with pytest.raises(CompetitionNotFoundError):
+            await use_case.execute(request, creator_id)
+
+    async def test_should_raise_enrollment_state_error_when_not_approved(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
+    ):
+        """
+        Given: Un enrollment en estado REQUESTED (no aprobado)
+        When: El creador intenta establecer el hándicap
+        Then: Se lanza EnrollmentStateError
+        """
+        created = await self._create_competition(uow, creator_id)
+        await self._set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = Enrollment.request(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId(created.id),
+            user_id=player_id,
+        )
+        async with uow:
+            await uow.enrollments.add(enrollment)
+            await uow.commit()
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("10.0")
+        )
+
+        with pytest.raises(EnrollmentStateError):
+            await use_case.execute(request, creator_id)
+
+    @pytest.mark.parametrize("status", ["IN_PROGRESS", "COMPLETED", "CANCELLED"])
+    async def test_should_raise_handicap_edit_not_allowed_once_competition_left_closed(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId, status: str
+    ):
+        """
+        Given: Un enrollment aprobado en una competición IN_PROGRESS/COMPLETED/CANCELLED
+        When: El creador intenta establecer el hándicap
+        Then: Se lanza HandicapEditNotAllowedError
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+        await self._set_competition_status(uow, created.id, status)
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("10.0")
+        )
+
+        with pytest.raises(HandicapEditNotAllowedError):
+            await use_case.execute(request, creator_id)
+
+    @pytest.mark.parametrize("status", ["DRAFT", "ACTIVE", "CLOSED"])
+    async def test_should_allow_handicap_edit_while_draft_active_or_closed(
+        self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId, status: str
+    ):
+        """
+        Given: Un enrollment aprobado
+        When: La competición está en DRAFT, ACTIVE o CLOSED
+        Then: Se puede establecer el hándicap personalizado sin errores
+        """
+        created = await self._create_competition(uow, creator_id)
+        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+        await self._set_competition_status(uow, created.id, status)
+
+        use_case = SetCustomHandicapUseCase(uow)
+        request = SetCustomHandicapRequestDTO(
+            enrollment_id=enrollment.id.value, custom_handicap=Decimal("11.0")
+        )
+
+        response = await use_case.execute(request, creator_id)
+        assert response.custom_handicap == Decimal("11.0")

--- a/tests/unit/modules/competition/application/use_cases/test_set_custom_handicap_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_set_custom_handicap_use_case.py
@@ -1,23 +1,16 @@
 """Tests para SetCustomHandicapUseCase."""
 
-from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 
-from src.modules.competition.application.dto.competition_dto import (
-    CreateCompetitionRequestDTO,
-)
 from src.modules.competition.application.dto.enrollment_dto import (
     SetCustomHandicapRequestDTO,
 )
 from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
     HandicapEditNotAllowedError,
-)
-from src.modules.competition.application.use_cases.create_competition_use_case import (
-    CreateCompetitionUseCase,
 )
 from src.modules.competition.application.use_cases.set_custom_handicap_use_case import (
     EnrollmentNotFoundError,
@@ -31,6 +24,11 @@ from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit
     InMemoryUnitOfWork,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from tests.unit.modules.competition.application.use_cases.helpers import (
+    create_approved_enrollment,
+    create_competition,
+    set_competition_status,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -54,52 +52,6 @@ class TestSetCustomHandicapUseCase:
     def admin_user_id(self) -> UserId:
         return UserId(uuid4())
 
-    async def _create_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
-        """Helper: crea una competición en DRAFT."""
-        create_uc = CreateCompetitionUseCase(uow)
-        request = CreateCompetitionRequestDTO(
-            name="Test Cup",
-            start_date=date(2026, 6, 1),
-            end_date=date(2026, 6, 3),
-            main_country="ES",
-            play_mode="SCRATCH",
-            max_players=24,
-        )
-        return await create_uc.execute(request, creator_id)
-
-    async def _set_competition_status(
-        self, uow: InMemoryUnitOfWork, competition_id, status: str
-    ):
-        """Helper: mueve una competición a través de sus transiciones hasta `status`."""
-        async with uow:
-            competition = await uow.competitions.find_by_id(CompetitionId(competition_id))
-            if status in ("ACTIVE", "CLOSED", "IN_PROGRESS", "COMPLETED", "CANCELLED"):
-                competition.activate()
-            if status in ("CLOSED", "IN_PROGRESS", "COMPLETED"):
-                competition.close_enrollments()
-            if status in ("IN_PROGRESS", "COMPLETED"):
-                competition.start()
-            if status == "COMPLETED":
-                competition.complete()
-            if status == "CANCELLED":
-                competition.cancel()
-            await uow.competitions.update(competition)
-            await uow.commit()
-
-    async def _create_approved_enrollment(
-        self, uow: InMemoryUnitOfWork, competition_id, user_id: UserId
-    ) -> Enrollment:
-        """Helper: crea un enrollment ya aprobado."""
-        enrollment = Enrollment.direct_enroll(
-            id=EnrollmentId.generate(),
-            competition_id=CompetitionId(competition_id),
-            user_id=user_id,
-        )
-        async with uow:
-            await uow.enrollments.add(enrollment)
-            await uow.commit()
-        return enrollment
-
     async def test_should_set_custom_handicap_successfully(
         self, uow: InMemoryUnitOfWork, creator_id: UserId, player_id: UserId
     ):
@@ -108,9 +60,9 @@ class TestSetCustomHandicapUseCase:
         When: El creador establece un hándicap personalizado
         Then: El enrollment refleja el nuevo hándicap
         """
-        created = await self._create_competition(uow, creator_id)
-        await self._set_competition_status(uow, created.id, "ACTIVE")
-        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+        created = await create_competition(uow, creator_id)
+        await set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await create_approved_enrollment(uow, created.id, player_id)
 
         use_case = SetCustomHandicapUseCase(uow)
         request = SetCustomHandicapRequestDTO(
@@ -132,9 +84,9 @@ class TestSetCustomHandicapUseCase:
         When: Un admin (no creador) establece el hándicap con is_admin=True
         Then: Se aplica sin lanzar NotCreatorError
         """
-        created = await self._create_competition(uow, creator_id)
-        await self._set_competition_status(uow, created.id, "ACTIVE")
-        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+        created = await create_competition(uow, creator_id)
+        await set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await create_approved_enrollment(uow, created.id, player_id)
 
         use_case = SetCustomHandicapUseCase(uow)
         request = SetCustomHandicapRequestDTO(
@@ -152,9 +104,9 @@ class TestSetCustomHandicapUseCase:
         When: Un usuario que no es el creador ni admin intenta establecer el hándicap
         Then: Se lanza NotCreatorError
         """
-        created = await self._create_competition(uow, creator_id)
-        await self._set_competition_status(uow, created.id, "ACTIVE")
-        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
+        created = await create_competition(uow, creator_id)
+        await set_competition_status(uow, created.id, "ACTIVE")
+        enrollment = await create_approved_enrollment(uow, created.id, player_id)
 
         use_case = SetCustomHandicapUseCase(uow)
         request = SetCustomHandicapRequestDTO(
@@ -212,8 +164,8 @@ class TestSetCustomHandicapUseCase:
         When: El creador intenta establecer el hándicap
         Then: Se lanza EnrollmentStateError
         """
-        created = await self._create_competition(uow, creator_id)
-        await self._set_competition_status(uow, created.id, "ACTIVE")
+        created = await create_competition(uow, creator_id)
+        await set_competition_status(uow, created.id, "ACTIVE")
         enrollment = Enrollment.request(
             id=EnrollmentId.generate(),
             competition_id=CompetitionId(created.id),
@@ -240,9 +192,9 @@ class TestSetCustomHandicapUseCase:
         When: El creador intenta establecer el hándicap
         Then: Se lanza HandicapEditNotAllowedError
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
-        await self._set_competition_status(uow, created.id, status)
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(uow, created.id, player_id)
+        await set_competition_status(uow, created.id, status)
 
         use_case = SetCustomHandicapUseCase(uow)
         request = SetCustomHandicapRequestDTO(
@@ -261,9 +213,9 @@ class TestSetCustomHandicapUseCase:
         When: La competición está en DRAFT, ACTIVE o CLOSED
         Then: Se puede establecer el hándicap personalizado sin errores
         """
-        created = await self._create_competition(uow, creator_id)
-        enrollment = await self._create_approved_enrollment(uow, created.id, player_id)
-        await self._set_competition_status(uow, created.id, status)
+        created = await create_competition(uow, creator_id)
+        enrollment = await create_approved_enrollment(uow, created.id, player_id)
+        await set_competition_status(uow, created.id, status)
 
         use_case = SetCustomHandicapUseCase(uow)
         request = SetCustomHandicapRequestDTO(

--- a/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
@@ -391,3 +391,95 @@ class TestPlayingHandicapCalculatorRealScenarios:
         # Mujer: 18 × (115/113) + (69.5-72) = 18.31 - 2.5 = 15.81 → 16
         assert ph_man == 13
         assert ph_woman == 16
+
+
+class TestPlayingHandicapCalculatorMaxHandicap:
+    """Tests para el límite máximo de hándicap de juego (max_playing_handicap)."""
+
+    def test_calculate_caps_result_when_above_limit(self):
+        """El resultado queda limitado al cap cuando supera max_playing_handicap."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        # HI=36.0 con slope neutro y 100% → PH = 36
+        # Cap de 18 → resultado debe ser 18
+        result = calculator.calculate(
+            handicap_index=Decimal("36.0"),
+            tee_rating=tee,
+            allowance_percentage=100,
+            max_playing_handicap=18,
+        )
+
+        assert result == 18
+
+    def test_calculate_no_cap_applied_when_below_limit(self):
+        """El resultado no se altera cuando el PH calculado está por debajo del límite."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        result = calculator.calculate(
+            handicap_index=Decimal("10.0"),
+            tee_rating=tee,
+            allowance_percentage=100,
+            max_playing_handicap=18,
+        )
+
+        assert result == 10
+
+    def test_calculate_no_cap_when_none(self):
+        """Sin cap (None), el resultado puede superar cualquier límite."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        result = calculator.calculate(
+            handicap_index=Decimal("54.0"),
+            tee_rating=tee,
+            allowance_percentage=100,
+            max_playing_handicap=None,
+        )
+
+        assert result == 54
+
+    def test_calculate_cap_exactly_at_limit(self):
+        """El resultado es igual al cap cuando el PH calculado coincide exactamente."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        result = calculator.calculate(
+            handicap_index=Decimal("20.0"),
+            tee_rating=tee,
+            allowance_percentage=100,
+            max_playing_handicap=20,
+        )
+
+        assert result == 20
+
+    def test_calculate_cap_applied_with_allowance(self):
+        """El cap se aplica DESPUÉS del allowance, no antes."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        # HI=36.0, 50% allowance → PH = 18, cap=10 → resultado=10
+        result = calculator.calculate(
+            handicap_index=Decimal("36.0"),
+            tee_rating=tee,
+            allowance_percentage=50,
+            max_playing_handicap=10,
+        )
+
+        assert result == 10
+
+    def test_calculate_cap_not_needed_with_allowance(self):
+        """Con allowance bajo, el PH puede quedar ya por debajo del cap."""
+        calculator = PlayingHandicapCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        # HI=36.0, 50% allowance → PH = 18, cap=20 → resultado=18 (no se aplica)
+        result = calculator.calculate(
+            handicap_index=Decimal("36.0"),
+            tee_rating=tee,
+            allowance_percentage=50,
+            max_playing_handicap=20,
+        )
+
+        assert result == 18

--- a/tests/unit/modules/competition/domain/value_objects/test_match_player.py
+++ b/tests/unit/modules/competition/domain/value_objects/test_match_player.py
@@ -1,5 +1,7 @@
 """Tests para MatchPlayer value object."""
 
+from decimal import Decimal
+
 import pytest
 
 from src.modules.competition.domain.value_objects.match_player import MatchPlayer
@@ -76,6 +78,35 @@ class TestMatchPlayerCreate:
         assert player.strokes_on_hole(3) == 2
         assert player.strokes_on_hole(1) == 1
         assert player.strokes_on_hole(4) == 0
+
+
+class TestMatchPlayerPlayerHandicap:
+    """Tests para el snapshot player_handicap (HM-1b)."""
+
+    def test_defaults_to_none_when_not_provided(self):
+        """Si no se pasa player_handicap, queda en None (compat con partidos previos a HM-1b)."""
+        player = MatchPlayer.create(
+            user_id=UserId.generate(),
+            playing_handicap=12,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=[1, 2, 3],
+        )
+
+        assert player.player_handicap is None
+
+    def test_stores_snapshot_value(self):
+        """Guarda el HI del jugador en el momento de generar el partido."""
+        player = MatchPlayer.create(
+            user_id=UserId.generate(),
+            playing_handicap=12,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=[1, 2, 3],
+            player_handicap=Decimal("14.2"),
+        )
+
+        assert player.player_handicap == Decimal("14.2")
 
 
 class TestMatchPlayerImmutability:

--- a/tests/unit/modules/competition/infrastructure/persistence/test_mappers_block5.py
+++ b/tests/unit/modules/competition/infrastructure/persistence/test_mappers_block5.py
@@ -1,6 +1,7 @@
 """Tests para TypeDecorators y JSONB serialization del Block 5."""
 
 import uuid
+from decimal import Decimal
 
 from src.modules.competition.domain.value_objects.handicap_mode import HandicapMode
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
@@ -265,6 +266,67 @@ class TestMatchPlayersJsonType:
         assert result == []
         deserialized = self.decorator.process_result_value(result, None)
         assert deserialized == ()
+
+    def test_serialize_player_handicap(self):
+        """HM-1b: serializa player_handicap como string decimal."""
+        player = MatchPlayer(
+            user_id=self.user_id_1,
+            playing_handicap=12,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=(1, 3),
+            player_handicap=Decimal("14.2"),
+        )
+        result = self.decorator.process_bind_param((player,), None)
+        assert result[0]["player_handicap"] == "14.2"
+
+    def test_serialize_player_handicap_none(self):
+        """HM-1b: player_handicap None se serializa como None."""
+        result = self.decorator.process_bind_param((self.player_1,), None)
+        assert result[0]["player_handicap"] is None
+
+    def test_deserialize_player_handicap(self):
+        """HM-1b: deserializa player_handicap de string a Decimal."""
+        json_data = [
+            {
+                "user_id": str(self.user_id_1.value),
+                "playing_handicap": 12,
+                "tee_category": "AMATEUR",
+                "tee_gender": "MALE",
+                "strokes_received": [1, 3],
+                "player_handicap": "14.2",
+            },
+        ]
+        result = self.decorator.process_result_value(json_data, None)
+        assert result[0].player_handicap == Decimal("14.2")
+
+    def test_deserialize_missing_player_handicap_defaults_none(self):
+        """HM-1b: partidos generados antes de esta feature no tienen la clave en el JSON."""
+        json_data = [
+            {
+                "user_id": str(self.user_id_1.value),
+                "playing_handicap": 12,
+                "tee_category": "AMATEUR",
+                "tee_gender": "MALE",
+                "strokes_received": [1, 3],
+            },
+        ]
+        result = self.decorator.process_result_value(json_data, None)
+        assert result[0].player_handicap is None
+
+    def test_roundtrip_with_player_handicap(self):
+        """Serializa y deserializa player_handicap sin pérdida de datos."""
+        player = MatchPlayer(
+            user_id=self.user_id_1,
+            playing_handicap=12,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=(1, 3),
+            player_handicap=Decimal("14.2"),
+        )
+        serialized = self.decorator.process_bind_param((player,), None)
+        deserialized = self.decorator.process_result_value(serialized, None)
+        assert deserialized == (player,)
 
 
 class TestUserIdsJsonType:

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -4,13 +4,14 @@ Tests para LoginUserUseCase
 Tests unitarios para el caso de uso de login de usuario.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.modules.user.application.dto.user_dto import LoginRequestDTO
 from src.modules.user.application.use_cases.login_user_use_case import LoginUserUseCase
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.handicap_errors import HandicapServiceUnavailableError
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -150,3 +151,189 @@ class TestLoginUserUseCase:
         assert "sub" in payload
         assert payload["sub"] == str(existing_user.id.value)
         assert "exp" in payload  # Debe tener tiempo de expiración
+
+
+@pytest.mark.asyncio
+class TestLoginUserUseCaseHandicapRFEG:
+    """Tests para el fetch de hándicap RFEG en login (HM-2a)."""
+
+    def _make_use_case(self, uow, token_service, register_device_use_case, handicap_service=None):
+        return LoginUserUseCase(uow, token_service, register_device_use_case, handicap_service)
+
+    def _make_handicap_service(self, return_value=None, raise_exc=None):
+        svc = MagicMock()
+        if raise_exc:
+            svc.search_handicap = AsyncMock(side_effect=raise_exc)
+        else:
+            svc.search_handicap = AsyncMock(return_value=return_value)
+        return svc
+
+    async def _create_es_user(self, uow, email="es@example.com"):
+        user = User.create(
+            first_name="Juan",
+            last_name="Garcia",
+            email_str=email,
+            plain_password="V@l1dP@ss123!",
+            country_code_str="ES",
+        )
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+        return user
+
+    async def test_es_user_no_handicap_rfeg_returns_value_updates_and_needs_handicap_false(
+        self, token_service, register_device_use_case
+    ):
+        """ES sin hándicap + RFEG devuelve valor → actualiza handicap, needs_handicap=False."""
+        uow = InMemoryUnitOfWork()
+        await self._create_es_user(uow)
+        handicap_svc = self._make_handicap_service(return_value=18.4)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="es@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False
+        assert response.user.handicap == 18.4
+        handicap_svc.search_handicap.assert_awaited_once_with("Juan Garcia")
+
+    async def test_es_user_no_handicap_rfeg_returns_none_needs_handicap_true(
+        self, token_service, register_device_use_case
+    ):
+        """ES sin hándicap + RFEG devuelve None → needs_handicap=True."""
+        uow = InMemoryUnitOfWork()
+        await self._create_es_user(uow)
+        handicap_svc = self._make_handicap_service(return_value=None)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="es@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is True
+
+    async def test_es_user_no_handicap_rfeg_fails_needs_handicap_true(
+        self, token_service, register_device_use_case
+    ):
+        """ES sin hándicap + RFEG lanza excepción → login OK, needs_handicap=True (soft fail)."""
+        uow = InMemoryUnitOfWork()
+        await self._create_es_user(uow)
+        handicap_svc = self._make_handicap_service(
+            raise_exc=HandicapServiceUnavailableError("RFEG down")
+        )
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="es@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is True
+
+    async def test_es_user_with_existing_handicap_no_rfeg_call(
+        self, token_service, register_device_use_case
+    ):
+        """ES con hándicap ya registrado → no llama RFEG, needs_handicap=False."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="Juan",
+            last_name="Garcia",
+            email_str="es2@example.com",
+            plain_password="V@l1dP@ss123!",
+            country_code_str="ES",
+        )
+        user.update_handicap(12.5)
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        handicap_svc = self._make_handicap_service(return_value=15.0)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="es2@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False
+        handicap_svc.search_handicap.assert_not_awaited()
+
+    async def test_non_es_user_no_rfeg_call_needs_handicap_false(
+        self, token_service, register_device_use_case
+    ):
+        """Usuario no-ES → no llama RFEG, needs_handicap=False."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="Pierre",
+            last_name="Dupont",
+            email_str="fr@example.com",
+            plain_password="V@l1dP@ss123!",
+            country_code_str="FR",
+        )
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        handicap_svc = self._make_handicap_service(return_value=10.0)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="fr@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False
+        handicap_svc.search_handicap.assert_not_awaited()
+
+    async def test_no_country_user_needs_handicap_false(
+        self, token_service, register_device_use_case
+    ):
+        """Usuario sin country_code → needs_handicap=False."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="Anonymous",
+            last_name="User",
+            email_str="anon@example.com",
+            plain_password="V@l1dP@ss123!",
+        )
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        handicap_svc = self._make_handicap_service()
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="anon@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False
+        handicap_svc.search_handicap.assert_not_awaited()
+
+    async def test_existing_tests_unaffected_no_handicap_service(
+        self, token_service, register_device_use_case
+    ):
+        """Sin handicap_service (tests existentes) → needs_handicap=False para usuarios no-ES."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="John",
+            last_name="Doe",
+            email_str="john@example.com",
+            plain_password="V@l1dP@ss123!",
+        )
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, None)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="john@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -4,6 +4,7 @@ Tests para LoginUserUseCase
 Tests unitarios para el caso de uso de login de usuario.
 """
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -261,10 +262,10 @@ class TestLoginUserUseCaseHandicapRFEG:
         assert response.needs_handicap is False
         handicap_svc.search_handicap.assert_not_awaited()
 
-    async def test_non_es_user_no_rfeg_call_needs_handicap_false(
+    async def test_non_es_user_no_rfeg_call_needs_handicap_true(
         self, token_service, register_device_use_case
     ):
-        """Usuario no-ES → no llama RFEG, needs_handicap=False."""
+        """Usuario no-ES → no llama RFEG (no aplica), pero se solicita con modal."""
         uow = InMemoryUnitOfWork()
         user = User.create(
             first_name="Pierre",
@@ -285,13 +286,13 @@ class TestLoginUserUseCaseHandicapRFEG:
         )
 
         assert response is not None
-        assert response.needs_handicap is False
+        assert response.needs_handicap is True
         handicap_svc.search_handicap.assert_not_awaited()
 
-    async def test_no_country_user_needs_handicap_false(
+    async def test_no_country_user_needs_handicap_true(
         self, token_service, register_device_use_case
     ):
-        """Usuario sin country_code → needs_handicap=False."""
+        """Usuario sin country_code → RFEG no aplica, pero se solicita con modal."""
         uow = InMemoryUnitOfWork()
         user = User.create(
             first_name="Anonymous",
@@ -311,13 +312,13 @@ class TestLoginUserUseCaseHandicapRFEG:
         )
 
         assert response is not None
-        assert response.needs_handicap is False
+        assert response.needs_handicap is True
         handicap_svc.search_handicap.assert_not_awaited()
 
     async def test_existing_tests_unaffected_no_handicap_service(
         self, token_service, register_device_use_case
     ):
-        """Sin handicap_service (tests existentes) → needs_handicap=False para usuarios no-ES."""
+        """Sin handicap_service inyectado → needs_handicap=True para usuario no-ES sin hándicap (se pide manual)."""
         uow = InMemoryUnitOfWork()
         user = User.create(
             first_name="John",
@@ -336,4 +337,62 @@ class TestLoginUserUseCaseHandicapRFEG:
         )
 
         assert response is not None
+        assert response.needs_handicap is True
+
+    async def test_non_es_user_handicap_updated_today_no_prompt(
+        self, token_service, register_device_use_case
+    ):
+        """Usuario no-ES con hándicap ya actualizado hoy → no se solicita de nuevo."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="Pierre",
+            last_name="Dupont",
+            email_str="fr2@example.com",
+            plain_password="V@l1dP@ss123!",
+            country_code_str="FR",
+        )
+        user.update_handicap(20.0)
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        handicap_svc = self._make_handicap_service(return_value=10.0)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="fr2@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
         assert response.needs_handicap is False
+        handicap_svc.search_handicap.assert_not_awaited()
+
+    async def test_es_user_handicap_updated_yesterday_refetches_rfeg(
+        self, token_service, register_device_use_case
+    ):
+        """ES con hándicap desactualizado (no es de hoy) → reintenta RFEG automáticamente."""
+        uow = InMemoryUnitOfWork()
+        user = User.create(
+            first_name="Juan",
+            last_name="Garcia",
+            email_str="es3@example.com",
+            plain_password="V@l1dP@ss123!",
+            country_code_str="ES",
+        )
+        user.update_handicap(12.5)
+        user.handicap_updated_at = user.handicap_updated_at - timedelta(days=1)
+        async with uow:
+            await uow.users.save(user)
+            await uow.commit()
+
+        handicap_svc = self._make_handicap_service(return_value=15.0)
+        use_case = self._make_use_case(uow, token_service, register_device_use_case, handicap_svc)
+
+        response = await use_case.execute(
+            LoginRequestDTO(email="es3@example.com", password="V@l1dP@ss123!")
+        )
+
+        assert response is not None
+        assert response.needs_handicap is False
+        assert response.user.handicap == 15.0
+        handicap_svc.search_handicap.assert_awaited_once_with("Juan Garcia")


### PR DESCRIPTION
## Summary
- Add `max_playing_handicap` WHS cap field to competitions, applied in playing handicap calculation
- Fix fourball scoring to return all tied players as best ball instead of a single winner
- Add admin `acting_as` bypass across scoring and remaining competition use cases, granting admins full creator privileges
- Fetch RFEG handicap on login for Spanish users and expose `needs_handicap` flag; prompt non-Spanish users to update their handicap on login

## Test plan
- [x] Unit tests for `max_playing_handicap` cap (`test_playing_handicap_calculator.py`)
- [x] Unit tests for fourball tie handling (`test_generate_matches_use_case.py`)
- [x] Unit tests for login handicap flow (`test_login_user_use_case.py`)
- [x] Alembic merge migration validated (heads for scoring + max handicap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `max_playing_handicap` to competitions (with WHS range validation) and applied it during handicap-based match generation and match player reassignment.
  * Expanded admin authorization across competition, scoring, and match/enrollment actions; admin scoring now supports an `acting_as` override.
  * Login now returns `needs_handicap` and can refresh handicap once per day when applicable.
  * Added a custom-handicap revert flow via a new removal endpoint.
* **Bug Fixes**
  * Improved FOURBALL best-ball tie handling (including deterministic results and consistent hole-score ordering).
  * Fixed halved matches being translated/announced incorrectly.
  * Strengthened daily handicap refresh prompting behavior for login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->