### PR TITLE
Hotfix: same-day competition dates and always-visible scorecard result

### DIFF
--- a/src/modules/competition/application/dto/competition_dto.py
+++ b/src/modules/competition/application/dto/competition_dto.py
@@ -166,8 +166,8 @@ class CreateCompetitionRequestDTO(BaseModel):
     def validate_config(self) -> "CreateCompetitionRequestDTO":
         """Validaciones post-inicialización."""
         # Validar fechas
-        if self.start_date >= self.end_date:
-            raise ValueError("start_date debe ser anterior a end_date")
+        if self.start_date > self.end_date:
+            raise ValueError("start_date debe ser anterior o igual a end_date")
 
         # Validar play_mode
         if self.play_mode not in ["SCRATCH", "HANDICAP"]:

--- a/src/modules/competition/application/use_cases/submit_scorecard_use_case.py
+++ b/src/modules/competition/application/use_cases/submit_scorecard_use_case.py
@@ -75,7 +75,6 @@ class SubmitScorecardUseCase:
             match.submit_scorecard(user_id)
 
             match_complete = False
-            result_data = {"winner": None, "score": None}
             points = {"team_a": 0.0, "team_b": 0.0}
 
             # Load all match scores and round for hole results calculation
@@ -86,15 +85,21 @@ class SubmitScorecardUseCase:
             match_format = round_entity.match_format
             hole_results = self._compute_hole_results(all_scores, match_format)
 
+            # Result is derived from whichever holes are already validated, so the
+            # submitting player sees the real outcome even before every other player
+            # has formally submitted their own scorecard.
+            # Preserve a decided result (e.g. "5&4") instead of recalculating from
+            # all 18 holes, which would give "5UP" (holes_remaining=0).
+            if match.is_decided and match.decided_result:
+                result_data = match.decided_result
+            elif hole_results:
+                result_data = self._scoring_service.format_decided_result(hole_results)
+            else:
+                result_data = {"winner": None, "score": None}
+
             # Check if all scorecards submitted
             if match.all_scorecards_submitted():
                 match_complete = True
-                # Preserve decided result (e.g. "5&4") instead of recalculating
-                # from all 18 holes which would give "5UP" (holes_remaining=0)
-                if match.is_decided and match.decided_result:
-                    result_data = match.decided_result
-                else:
-                    result_data = self._scoring_service.format_decided_result(hole_results)
                 match.complete(result_data)
                 points = self._scoring_service.calculate_ryder_cup_points(
                     result_data, match.status.value

--- a/src/modules/competition/domain/services/competition_policy.py
+++ b/src/modules/competition/domain/services/competition_policy.py
@@ -259,10 +259,10 @@ class CompetitionPolicy:
             ... )  # OK
         """
         # 1. Validar orden lógico
-        if start_date >= end_date:
+        if start_date > end_date:
             raise InvalidDateRangeViolation(
                 f"Competition '{competition_name}': Start date ({start_date}) "
-                f"must be before end date ({end_date})."
+                f"must be before or equal to end date ({end_date})."
             )
 
         # 2. Validar duración razonable

--- a/tests/unit/modules/competition/application/dto/test_competition_dto.py
+++ b/tests/unit/modules/competition/application/dto/test_competition_dto.py
@@ -75,9 +75,9 @@ class TestCreateCompetitionRequestDTO:
 
         assert dto.play_mode == "HANDICAP"
 
-    def test_start_date_must_be_before_end_date(self):
-        """start_date debe ser anterior a end_date."""
-        with pytest.raises(ValueError, match="start_date debe ser anterior a end_date"):
+    def test_start_date_must_be_before_or_equal_to_end_date(self):
+        """start_date debe ser anterior o igual a end_date."""
+        with pytest.raises(ValueError, match="start_date debe ser anterior o igual a end_date"):
             CreateCompetitionRequestDTO(
                 name="Test Cup",
                 start_date=date(2025, 6, 3),
@@ -85,6 +85,18 @@ class TestCreateCompetitionRequestDTO:
                 main_country="ES",
                 play_mode="SCRATCH",
             )
+
+    def test_start_date_equal_to_end_date_is_allowed(self):
+        """Una competición de un solo día (start_date == end_date) es válida."""
+        dto = CreateCompetitionRequestDTO(
+            name="Test Cup",
+            start_date=date(2025, 6, 1),
+            end_date=date(2025, 6, 1),
+            main_country="ES",
+            play_mode="SCRATCH",
+        )
+
+        assert dto.start_date == dto.end_date
 
     def test_invalid_play_mode(self):
         """Debe rechazar play_mode inválido."""

--- a/tests/unit/modules/competition/application/use_cases/test_submit_scorecard_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_submit_scorecard_use_case.py
@@ -137,6 +137,59 @@ class TestSubmitScorecardHappyPath:
         assert result.submitted_by == str(a.user_id)
 
     @pytest.mark.asyncio
+    async def test_result_shown_before_all_submit(self, uow, scoring_service):
+        """The submitting player sees the real result even before the opponent submits."""
+        a, b = _make_player(), _make_player()
+        round_id = RoundId.generate()
+        mock_round = MagicMock()
+        mock_round.id = round_id
+        mock_round.match_format = MatchFormat.SINGLES
+        mock_round.status = RoundStatus.IN_PROGRESS
+        mock_round.competition_id = MagicMock()
+        uow._rounds._rounds[mock_round.id] = mock_round
+
+        match = Match.create(
+            round_id=round_id, match_number=1, team_a_players=[a], team_b_players=[b]
+        )
+        match.start()
+
+        # A wins every hole (score 4 vs 5), all 18 holes validated for both players
+        for hole in range(1, 19):
+            hs_a = HoleScore.create(
+                match_id=match.id,
+                hole_number=hole,
+                player_user_id=a.user_id,
+                team="A",
+                strokes_received=0,
+            )
+            hs_a.set_own_score(4)
+            hs_a.set_marker_score(4)
+            hs_a.recalculate_validation()
+            await uow.hole_scores.add(hs_a)
+
+            hs_b = HoleScore.create(
+                match_id=match.id,
+                hole_number=hole,
+                player_user_id=b.user_id,
+                team="B",
+                strokes_received=0,
+            )
+            hs_b.set_own_score(5)
+            hs_b.set_marker_score(5)
+            hs_b.recalculate_validation()
+            await uow.hole_scores.add(hs_b)
+
+        await uow.matches.add(match)
+
+        uc = SubmitScorecardUseCase(uow, scoring_service)
+        result = await uc.execute(str(match.id), a.user_id)
+
+        # Match isn't complete yet (b hasn't submitted), but the result is already known
+        assert result.match_complete is False
+        assert result.result.winner == "A"
+        assert result.result.score == "18UP"
+
+    @pytest.mark.asyncio
     async def test_all_submit_completes_match(self, uow, scoring_service):
         """All players submitting completes the match."""
         a, b = _make_player(), _make_player()

--- a/tests/unit/modules/competition/domain/services/test_competition_policy.py
+++ b/tests/unit/modules/competition/domain/services/test_competition_policy.py
@@ -346,19 +346,19 @@ def test_validate_date_range_rejects_when_start_after_end():
     with pytest.raises(InvalidDateRangeViolation) as exc_info:
         CompetitionPolicy.validate_date_range(start_date, end_date, "Test")
 
-    assert "must be before end date" in str(exc_info.value).lower()
+    assert "must be before or equal to end date" in str(exc_info.value).lower()
 
 
-def test_validate_date_range_rejects_when_start_equals_end():
+def test_validate_date_range_allows_when_start_equals_end():
     """
-    Given: Start date equals end date (zero duration)
+    Given: Start date equals end date (single-day competition)
     When: Validating date range
-    Then: InvalidDateRangeViolation raised
+    Then: No exception raised
     """
     same_date = date(2026, 6, 10)
 
-    with pytest.raises(InvalidDateRangeViolation):
-        CompetitionPolicy.validate_date_range(same_date, same_date, "Test")
+    # Should not raise
+    CompetitionPolicy.validate_date_range(same_date, same_date, "Test")
 
 
 def test_validate_date_range_rejects_when_duration_exceeds_limit():


### PR DESCRIPTION
## Summary
- Allow `start_date == end_date` when creating a competition, so single-day tournaments are no longer rejected (DTO validation + `CompetitionPolicy`).
- Show the match result in the scorecard submission response as soon as it's derivable from validated holes, instead of only after every player has formally submitted their scorecard. Ryder Cup points are still only awarded once all scorecards are submitted.

## Test plan
- [x] `pytest tests/unit/modules/competition/application/dto/test_competition_dto.py tests/unit/modules/competition/domain/services/test_competition_policy.py` — passing
- [x] `pytest tests/unit/modules/competition/application/use_cases/test_submit_scorecard_use_case.py` — passing (new test covers result visible before all submit)
- [x] Full backend suite (`python dev_tests.py`) — 2276 tests, 0 failures
- [x] `ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)