### PR TITLE
chore(release): PREPARE RELEASE V2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.0.18] - 2026-07-07
+
+### Fixed
+
+**Competition — Same-Day Start and End Dates**
+
+- `DateRange`: Single-day tournaments were rejected because date range validation required `start_date` to be strictly before `end_date` instead of allowing equality.
+
+**Scoring — Match Result Not Shown Before Every Player Submits**
+
+- The scorecard summary only computed a result once every player had formally submitted their scorecard, so a player who submitted first saw an empty result box even though all 18 holes were already played and validated. The result is now derived from whichever holes are already validated, so it reflects the real outcome immediately; Ryder Cup points are still only awarded once every player submits.
+
+---
+
 ## [2.0.17] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Version](https://img.shields.io/badge/version-2.0.17-blue?style=for-the-badge&logo=semver)](.)
+[![Version](https://img.shields.io/badge/version-2.0.18-blue?style=for-the-badge&logo=semver)](.)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12-3776AB?style=for-the-badge&logo=python&logoColor=white)](.)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.125.0-009688?style=for-the-badge&logo=fastapi&logoColor=white)](.)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791?style=for-the-badge&logo=postgresql&logoColor=white)](.)
@@ -212,6 +212,10 @@ SENTRY_DSN=<your-sentry-dsn>  # Optional but recommended
 - ✅ **Sentry Integration** - Error tracking + APM + profiling
 
 ### What's New
+
+**v2.0.18 (Jul 7, 2026) — Hotfix**
+- ✅ **Same-Day Competition Dates**: Single-day tournaments (`start_date == end_date`) are now accepted
+- ✅ **Live Match Result Visibility**: Scorecard summary now derives the result from validated holes instead of waiting for every player to submit
 
 **v2.0.17 (Jul 2026) — Scoring Improvements**
 - ✅ **Handicap Revert to RFEG**: New `DELETE /enrollments/{id}/handicap` lets creator/admin clear a custom handicap, reverting to the official RFEG value
@@ -635,9 +639,13 @@ See [CLAUDE.md](CLAUDE.md) for complete development guidelines.
 
 ## 📊 Project Roadmap
 
-### Current Version: v2.0.17 (Production)
+### Current Version: v2.0.18 (Production)
 
-**Latest Features** (v2.0.17 - Jul 6, 2026):
+**Latest Features** (v2.0.18 - Jul 7, 2026):
+- **Same-Day Competition Dates**: Single-day tournaments are now accepted instead of rejected
+- **Live Match Result Visibility**: Match summary shows the result as soon as holes are validated, without waiting for every player's formal submission
+
+**Previous Features** (v2.0.17 - Jul 6, 2026):
 - **Handicap Revert to RFEG**: Creator/admin can clear a custom handicap, reverting to the official RFEG value
 - **Auto Handicap Refresh on Login**: Daily silent RFEG lookup for Spanish players
 - **Admin Full Access**: Admins bypass creator-only checks across scoring and match management

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,15 @@
 # Roadmap - RyderCupFriends Backend
 
-> **Versión:** 2.0.17 | **Tests:** 1,966 unit | **Endpoints:** 83 | **OWASP:** 9.4/10
+> **Versión:** 2.0.18 | **Tests:** 1,966 unit | **Endpoints:** 83 | **OWASP:** 9.4/10
 >
-> **Last Updated:** Jul 6, 2026
+> **Last Updated:** Jul 7, 2026
+
+---
+
+## Completado: Hotfix ⭐ v2.0.18
+
+- Same-day competition dates (`start_date == end_date`) now accepted
+- Match summary result derived from validated holes instead of waiting for every player's formal submission
 
 ---
 


### PR DESCRIPTION
## Summary
- Bump version 2.0.17 → 2.0.18 (README badge + roadmap references)
- Move [Unreleased] hotfix changes (PR #83) into CHANGELOG [2.0.18] - 2026-07-07

## Included fixes (from #83)
- Competition: allow same-day start and end dates
- Scoring: show match result before every player submits

## Test plan
- [ ] CI checks pass