### PR TITLE
fix(deps): resolve Snyk High severity vulnerabilities (starlette, click, msgpack)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -16,6 +16,15 @@ ignore:
   SNYK-PYTHON-SETUPTOOLS-9964606:
     - '*':
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2025-47273)'
+  SNYK-PYTHON-NLTK-17356385:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-PYTHON-NLTK-17817780:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-PYTHON-NLTK-17821336:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
 
 # Patch settings - none needed as all vulnerabilities are resolved via upgrades
 patch: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,6 +154,14 @@ mako==1.3.12
 # - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
 nltk==3.9.4
 
+# click - Command line interface creation kit (dependencia transitiva de nltk/safety/typer/uvicorn)
+# Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)
+click==8.3.3
+
+# msgpack - Serialización binaria (dependencia transitiva de pip-audit > cachecontrol)
+# Fijada explícitamente para resolver SNYK-PYTHON-MSGPACK-17391445 (Use After Free)
+msgpack==1.2.1
+
 # pygments - Syntax highlighter (dependencia transitiva de varios dev tools)
 # Fijada explícitamente para resolver CVE-2026-4539
 pygments==2.20.0


### PR DESCRIPTION
## Summary
- Sync installed `starlette` with the existing `1.3.1` pin in `requirements.txt` (venv was stale at `1.2.1`), resolving 2 High severity issues (resource exhaustion, incorrect name resolution)
- Pin `click==8.3.3` (was `8.3.0`, transitive via nltk/safety/typer/uvicorn) — resolves High severity Command Injection (SNYK-PYTHON-CLICK-16347201)
- Pin `msgpack==1.2.1` (was `1.1.2`, transitive via pip-audit > cachecontrol) — resolves High severity Use After Free (SNYK-PYTHON-MSGPACK-17391445)
- Document 3 remaining unpatched `nltk` vulnerabilities in `.snyk` as accepted risk (transitive dev-only dependency of `safety`, not used in `src/`, matches existing Dependabot alert #29 assessment)

## Test plan
- [x] `pytest tests/unit/ -q` — 1968 passed
- [x] `ruff check .` — all checks passed
- [x] `snyk test --file=requirements.txt` — down from 7 issues to 3 (all unpatched/accepted, documented in `.snyk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)