### PR TITLE
chore(merge): Sync develop with main after Snyk hotfix (#86)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -16,6 +16,15 @@ ignore:
   SNYK-PYTHON-SETUPTOOLS-9964606:
     - '*':
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2025-47273)'
+  SNYK-PYTHON-NLTK-17356385:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-PYTHON-NLTK-17817780:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-PYTHON-NLTK-17821336:
+    - '*':
+        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
 
 # Patch settings - none needed as all vulnerabilities are resolved via upgrades
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -18,13 +18,17 @@ ignore:
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2025-47273)'
   SNYK-PYTHON-NLTK-17356385:
     - '*':
+        expires: '2027-01-08T00:00:00.000Z'
         reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
   SNYK-PYTHON-NLTK-17817780:
     - '*':
+        expires: '2027-01-08T00:00:00.000Z'
         reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
   SNYK-PYTHON-NLTK-17821336:
     - '*':
+        expires: '2027-01-08T00:00:00.000Z'
         reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
 
-# Patch settings - none needed as all vulnerabilities are resolved via upgrades
+# Patch settings - none needed; vulnerabilities are either resolved via upgrades
+# (setuptools) or accepted as dev-only risk with no available fix (NLTK, see above)
 patch: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,6 +154,14 @@ mako==1.3.12
 # - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
 nltk==3.9.4
 
+# click - Command line interface creation kit (dependencia transitiva de nltk/safety/typer/uvicorn)
+# Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)
+click==8.3.3
+
+# msgpack - Serialización binaria (dependencia transitiva de pip-audit > cachecontrol)
+# Fijada explícitamente para resolver SNYK-PYTHON-MSGPACK-17391445 (Use After Free)
+msgpack==1.2.1
+
 # pygments - Syntax highlighter (dependencia transitiva de varios dev tools)
 # Fijada explícitamente para resolver CVE-2026-4539
 pygments==2.20.0


### PR DESCRIPTION
## Summary
- GitFlow sync: merge `main` back into `develop` after PR #86 (Snyk High severity fixes) was merged directly into `main`
- Brings `click==8.3.3` / `msgpack==1.2.1` pins and the `nltk` accepted-risk entries in `.snyk` into `develop`
- No conflicts; clean merge

## Test plan
- [x] `pytest tests/unit/` — 1968 passed locally after merge
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency versions to address known security vulnerabilities.
  * Added additional vulnerability ignore rules for issues that are not currently actionable.
  * Included mitigation notes for specific package risks to improve security tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->