### PR TITLE
chore(merge): Sync develop with main after gender profile hotfix

### DIFF
--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -358,6 +358,11 @@ class UpdateProfileRequestDTO(BaseModel):
         pattern="^[A-Z]{2}$",
         description="Nuevo código ISO del país (2 letras mayúsculas, ej: 'ES', 'FR').",
     )
+    gender: str | None = Field(
+        None,
+        pattern="^(MALE|FEMALE)$",
+        description="Nuevo género del usuario (MALE/FEMALE). Opcional.",
+    )
 
     @field_validator("first_name", "last_name")
     @classmethod
@@ -376,9 +381,9 @@ class UpdateProfileRequestDTO(BaseModel):
 
     def model_post_init(self, __context) -> None:
         """Valida que se proporcione al menos un campo."""
-        if not self.first_name and not self.last_name and not self.country_code:
+        if not self.first_name and not self.last_name and not self.country_code and not self.gender:
             raise ValueError(
-                "Debe proporcionar al menos 'first_name', 'last_name' o 'country_code'."
+                "Debe proporcionar al menos 'first_name', 'last_name', 'country_code' o 'gender'."
             )
 
 

--- a/src/modules/user/application/use_cases/update_profile_use_case.py
+++ b/src/modules/user/application/use_cases/update_profile_use_case.py
@@ -80,6 +80,7 @@ class UpdateProfileUseCase:
                 first_name=request.first_name,
                 last_name=request.last_name,
                 country_code_str=request.country_code,
+                gender=request.gender,
             )
 
             # Guardar cambios

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -36,20 +36,21 @@ class User:
     y participar en torneos Ryder Cup.
     """
 
-    def _validate_profile_update(self, first_name, last_name, country_code_str):
-        if first_name is None and last_name is None and country_code_str is None:
+    def _validate_profile_update(self, first_name, last_name, country_code_str, gender_str=None):
+        if first_name is None and last_name is None and country_code_str is None and gender_str is None:
             raise ValueError(
-                "At least one field (first_name, last_name, or country_code) must be provided"
+                "At least one field (first_name, last_name, country_code, or gender) must be provided"
             )
         if first_name is not None and first_name.strip() == "":
             raise ValueError("first_name cannot be empty")
         if last_name is not None and last_name.strip() == "":
             raise ValueError("last_name cannot be empty")
 
-    def _detect_profile_changes(self, first_name, last_name, country_code_str):
+    def _detect_profile_changes(self, first_name, last_name, country_code_str, gender_str=None):
         old_first_name = self.first_name
         old_last_name = self.last_name
         old_country_code = self.country_code
+        old_gender = self.gender
         first_name_changed = first_name is not None and first_name != old_first_name
         last_name_changed = last_name is not None and last_name != old_last_name
         new_country_code = old_country_code
@@ -57,11 +58,18 @@ class User:
         if country_code_str is not None:
             new_country_code = CountryCode(country_code_str) if country_code_str else None
             country_code_changed = new_country_code != old_country_code
+        new_gender = old_gender
+        gender_changed = False
+        if gender_str is not None:
+            new_gender = Gender(gender_str) if gender_str else None
+            gender_changed = new_gender != old_gender
         return (
             first_name_changed,
             last_name_changed,
             country_code_changed,
+            gender_changed,
             new_country_code,
+            new_gender,
             old_first_name,
             old_last_name,
             old_country_code,
@@ -408,24 +416,27 @@ class User:
         first_name: str | None = None,
         last_name: str | None = None,
         country_code_str: str | None = None,
+        gender: str | None = None,
     ) -> None:
         """
-        Actualiza la información personal del usuario (nombre, apellidos y país).
+        Actualiza la información personal del usuario (nombre, apellidos, país y género).
         Solo emite evento si al menos uno de los campos cambió.
         El evento ahora incluye el cambio de country_code (old/new) si aplica.
         """
-        self._validate_profile_update(first_name, last_name, country_code_str)
+        self._validate_profile_update(first_name, last_name, country_code_str, gender)
         (
             first_name_changed,
             last_name_changed,
             country_code_changed,
+            gender_changed,
             new_country_code,
+            new_gender,
             old_first_name,
             old_last_name,
             _old_country_code,
-        ) = self._detect_profile_changes(first_name, last_name, country_code_str)
+        ) = self._detect_profile_changes(first_name, last_name, country_code_str, gender)
 
-        if not first_name_changed and not last_name_changed and not country_code_changed:
+        if not first_name_changed and not last_name_changed and not country_code_changed and not gender_changed:
             return
 
         if first_name_changed:
@@ -434,6 +445,8 @@ class User:
             self.last_name = last_name
         if country_code_changed:
             self.country_code = new_country_code
+        if gender_changed:
+            self.gender = new_gender
 
         self.updated_at = datetime.now()
 


### PR DESCRIPTION
## Summary
- Syncs `develop` with `main` after merging hotfix #88 (missing `gender` field in `UpdateProfileRequestDTO`).
- No conflicts; clean merge.

## Test plan
- [x] `pytest tests/unit/modules/user/` — 620 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating a user’s gender as part of profile changes.
  * Gender updates accept the values `MALE` or `FEMALE`.
  * Profile updates now recognize gender changes and save them accordingly.

* **Bug Fixes**
  * Improved profile update validation to allow gender-only updates and provide clearer guidance when no fields are supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->