### PR TITLE
fix(security): Disable Sentry local variable capture

### DIFF
--- a/src/config/sentry_config.py
+++ b/src/config/sentry_config.py
@@ -122,6 +122,12 @@ def init_sentry() -> None:
         release="rydercup-backend@1.8.0",  # Versión actual del backend
         # Request data (incluir en eventos)
         send_default_pii=False,  # NO enviar PII automáticamente (GDPR compliance)
+        # SECURITY: send_default_pii=False NO cubre las variables locales de cada frame
+        # del stack trace -- el SDK las adjunta por defecto. Cualquier logger.error()
+        # dentro de un except que tenga en scope un secreto (p.ej. self.api_key en
+        # EmailService, o `token` en GitHubIssueService) lo habría mandado a Sentry
+        # íntegro. Causa raíz del incidente de fuga de la API key de Mailgun (Jul 2026).
+        include_local_variables=False,
         max_breadcrumbs=50,  # Máximo de breadcrumbs por evento
         # Debug mode (solo para desarrollo)
         debug=(settings.SENTRY_ENVIRONMENT == "development"),


### PR DESCRIPTION
## Summary
Root-cause fix for a credential-leak class of bug in the Sentry configuration: `send_default_pii=False` only scrubs request IP/cookies/user context — it does **not** cover stack-trace local variables, which the Python SDK attaches to every captured event by default.

Any service that keeps a secret in `self.<attr>` (or any local variable) and logs at `ERROR` level on failure — which several do — would have that secret's real value shipped to Sentry as part of the stack frame, since `event_level=logging.ERROR` sends every `logger.error()` call as an event.

## Fix
Set `include_local_variables=False` in `sentry_sdk.init()`. This is a config-level fix rather than patching individual call sites, since it protects every secret currently loaded via `os.getenv()` against this same class of leak going forward.

## Test plan
- [x] `ruff check` / `mypy` clean
- [x] Relevant unit tests pass (123 passed)
- [x] Reviewed git history of both repos end-to-end for the leaked credential — not found in source, `.env` was never committed, no CI logs reference it

🤖 Generated with [Claude Code](https://claude.com/claude-code)