### PR TITLE
test(sentry): Add temporary debug endpoint to verify DSN connectivity

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,6 +369,13 @@ async def root() -> HealthResponse:
     )
 
 
+# TEMPORAL: endpoint para verificar la conexion de Sentry tras configurar SENTRY_DSN.
+# Se elimina en cuanto se confirme la recepcion del evento en sentry.io.
+@app.get("/api/v1/debug/sentry-test", include_in_schema=False)
+async def sentry_test(username: str = Depends(verify_docs_credentials)) -> dict:  # noqa: ARG001
+    raise RuntimeError("Sentry backend verification test - safe to ignore")
+
+
 if __name__ == "__main__":
     # Para reload=True necesitamos pasar la app como string
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- Adds a temporary, credential-protected `/api/v1/debug/sentry-test` endpoint that raises a `RuntimeError` on demand, used to confirm that the newly configured `SENTRY_DSN` in Render is correctly wired up end-to-end.
- Will be reverted in a follow-up commit right after confirming the event arrives in Sentry (project `rydercup-backend`).

## Test plan
- [ ] CI green
- [ ] Merge, hit the endpoint once with docs credentials
- [ ] Confirm error event appears in Sentry
- [ ] Revert this change immediately after confirmation