### PR TITLE
fix(sentry): Remove temporary debug endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,13 +369,6 @@ async def root() -> HealthResponse:
     )
 
 
-# TEMPORAL: endpoint para verificar la conexion de Sentry tras configurar SENTRY_DSN.
-# Se elimina en cuanto se confirme la recepcion del evento en sentry.io.
-@app.get("/api/v1/debug/sentry-test", include_in_schema=False)
-async def sentry_test(username: str = Depends(verify_docs_credentials)) -> dict:  # noqa: ARG001
-    raise RuntimeError("Sentry backend verification test - safe to ignore")
-
-
 if __name__ == "__main__":
     # Para reload=True necesitamos pasar la app como string
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- Removes the temporary `GET /api/v1/debug/sentry-test` endpoint added in #92
- Purpose already fulfilled: confirmed a real error event reaches Sentry in production (event `ca3b3714`, project `rydercup-backend`)

## Test plan
- [x] Endpoint removed, no other references left
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved error reporting privacy by preventing local variables from being included in diagnostic stack frames.
  * Reduced the risk of sensitive information, such as API keys, being exposed in error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->