### PR TITLE
fix(security): Upgrade setuptools to 83.0.0 and document Docker base image risk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -25,6 +25,24 @@ ignore:
   SNYK-PYTHON-NLTK-17821336:
     - '*':
         reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-DEBIAN13-ATTR-17678182:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libattr1, Link Following) pulled in transitively via coreutils/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-ACL-17677866:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libacl1, Link Following) pulled in transitively via coreutils/sed/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-ACL-17677882:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libacl1, TOCTOU) pulled in transitively via coreutils/sed/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-UTILLINUX-17690419:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libblkid1, Use After Free) pulled in transitively via util-linux/mount in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
 
-# Patch settings - none needed as all vulnerabilities are resolved via upgrades
+# Patch settings - none needed; vulnerabilities are either resolved via upgrades
+# (setuptools) or accepted as dev-only/base-image risk with no available fix
+# (NLTK, Debian base image packages — see above)
 patch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+**Dependencies — setuptools Medium CVE (SNYK-PYTHON-SETUPTOOLS-17895075)**
+
+- Upgraded `setuptools` from `78.1.1` to `83.0.0` to resolve CVE-2026-59890 (Improper Handling of Unicode Encoding).
+
+**Docker base image — accepted risk documented**
+
+- Added `.snyk` ignore entries (90-day expiry) for 4 vulnerabilities (2 High "Link Following" in `libattr1`/`libacl1`, 2 Medium "TOCTOU"/"Use After Free" in `libacl1`/`libblkid1`) inherited from the `python:3.12-slim` base image's Debian packages. Not used by application code; no patched image available yet.
+
 ---
 
 ## [2.0.18] - 2026-07-07

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,8 @@ cryptography==48.0.1
 # - CVE-2024-6345 (Code Injection via package_index - CVSS 7.5 HIGH)
 # - CVE-2022-40897 (Regular Expression DoS - CVSS 5.9 MEDIUM)
 # - CVE-2025-47273 (Directory Traversal en _download_url - CVSS 6.8 MEDIUM)
-setuptools==78.1.1
+# - CVE-2026-59890 (Improper Handling of Unicode Encoding - MEDIUM)
+setuptools==83.0.0
 
 # zipp - Pathlib-compatible Zipfile object wrapper (dependencia transitiva de importlib-metadata)
 # Fijada explícitamente para resolver CVE-2024-5569 (Infinite loop DoS via Path module)


### PR DESCRIPTION
## Summary
- Fixes the Snyk weekly report findings for `agustinEDev/RyderCupAM`
- `setuptools` 78.1.1 → 83.0.0 resolves CVE-2026-59890 (SNYK-PYTHON-SETUPTOOLS-17895075, Medium, Improper Handling of Unicode Encoding)
- Documents 4 Docker base image vulnerabilities (`python:3.12-slim` Debian packages: `libattr1`, `libacl1` x2, `libblkid1`) as accepted risk in `.snyk` with a 90-day expiry — they're OS-level packages pulled in transitively via `coreutils`/`util-linux`, not used by application code, and no patched base image is available yet (Snyk's only alternative suggestion is a release-candidate Alpine image, too risky to adopt without dedicated testing)

## Test plan
- [x] `pytest tests/unit/ -q` → 1968 passed
- [x] `ruff check .` → clean
- [x] `mypy src/ --ignore-missing-imports` → no new issues
- [x] `.snyk` YAML validated