### PR TITLE
chore(merge): Sync develop with main after Sentry and Snyk hotfixes

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -25,6 +25,24 @@ ignore:
   SNYK-PYTHON-NLTK-17821336:
     - '*':
         reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+  SNYK-DEBIAN13-ATTR-17678182:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libattr1, Link Following) pulled in transitively via coreutils/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-ACL-17677866:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libacl1, Link Following) pulled in transitively via coreutils/sed/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-ACL-17677882:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libacl1, TOCTOU) pulled in transitively via coreutils/sed/adduser in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
+  SNYK-DEBIAN13-UTILLINUX-17690419:
+    - '*':
+        expires: '2026-10-22T00:00:00.000Z'
+        reason: 'Base image OS package (libblkid1, Use After Free) pulled in transitively via util-linux/mount in python:3.12-slim. Not used by app code, no fix available yet from Debian. Re-check on expiry for an updated base image build.'
 
-# Patch settings - none needed as all vulnerabilities are resolved via upgrades
+# Patch settings - none needed; vulnerabilities are either resolved via upgrades
+# (setuptools) or accepted as dev-only/base-image risk with no available fix
+# (NLTK, Debian base image packages — see above)
 patch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+**Dependencies — setuptools Medium CVE (SNYK-PYTHON-SETUPTOOLS-17895075)**
+
+- Upgraded `setuptools` from `78.1.1` to `83.0.0` to resolve CVE-2026-59890 (Improper Handling of Unicode Encoding).
+
+**Docker base image — accepted risk documented**
+
+- Added `.snyk` ignore entries (90-day expiry) for 4 vulnerabilities (2 High "Link Following" in `libattr1`/`libacl1`, 2 Medium "TOCTOU"/"Use After Free" in `libacl1`/`libblkid1`) inherited from the `python:3.12-slim` base image's Debian packages. Not used by application code; no patched image available yet.
+
 ---
 
 ## [2.0.18] - 2026-07-07

--- a/main.py
+++ b/main.py
@@ -369,6 +369,13 @@ async def root() -> HealthResponse:
     )
 
 
+# TEMPORAL: endpoint para verificar la conexion de Sentry tras configurar SENTRY_DSN.
+# Se elimina en cuanto se confirme la recepcion del evento en sentry.io.
+@app.get("/api/v1/debug/sentry-test", include_in_schema=False)
+async def sentry_test(username: str = Depends(verify_docs_credentials)) -> dict:  # noqa: ARG001
+    raise RuntimeError("Sentry backend verification test - safe to ignore")
+
+
 if __name__ == "__main__":
     # Para reload=True necesitamos pasar la app como string
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/main.py
+++ b/main.py
@@ -369,13 +369,6 @@ async def root() -> HealthResponse:
     )
 
 
-# TEMPORAL: endpoint para verificar la conexion de Sentry tras configurar SENTRY_DSN.
-# Se elimina en cuanto se confirme la recepcion del evento en sentry.io.
-@app.get("/api/v1/debug/sentry-test", include_in_schema=False)
-async def sentry_test(username: str = Depends(verify_docs_credentials)) -> dict:  # noqa: ARG001
-    raise RuntimeError("Sentry backend verification test - safe to ignore")
-
-
 if __name__ == "__main__":
     # Para reload=True necesitamos pasar la app como string
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,8 @@ cryptography==48.0.1
 # - CVE-2024-6345 (Code Injection via package_index - CVSS 7.5 HIGH)
 # - CVE-2022-40897 (Regular Expression DoS - CVSS 5.9 MEDIUM)
 # - CVE-2025-47273 (Directory Traversal en _download_url - CVSS 6.8 MEDIUM)
-setuptools==78.1.1
+# - CVE-2026-59890 (Improper Handling of Unicode Encoding - MEDIUM)
+setuptools==83.0.0
 
 # zipp - Pathlib-compatible Zipfile object wrapper (dependencia transitiva de importlib-metadata)
 # Fijada explícitamente para resolver CVE-2024-5569 (Infinite loop DoS via Path module)

--- a/src/config/sentry_config.py
+++ b/src/config/sentry_config.py
@@ -122,6 +122,12 @@ def init_sentry() -> None:
         release="rydercup-backend@1.8.0",  # Versión actual del backend
         # Request data (incluir en eventos)
         send_default_pii=False,  # NO enviar PII automáticamente (GDPR compliance)
+        # SECURITY: send_default_pii=False NO cubre las variables locales de cada frame
+        # del stack trace -- el SDK las adjunta por defecto. Cualquier logger.error()
+        # dentro de un except que tenga en scope un secreto (p.ej. self.api_key en
+        # EmailService, o `token` en GitHubIssueService) lo habría mandado a Sentry
+        # íntegro. Causa raíz del incidente de fuga de la API key de Mailgun (Jul 2026).
+        include_local_variables=False,
         max_breadcrumbs=50,  # Máximo de breadcrumbs por evento
         # Debug mode (solo para desarrollo)
         debug=(settings.SENTRY_ENVIRONMENT == "development"),


### PR DESCRIPTION
## Summary
- Merges `main` into `develop` to bring in 4 commits that were only applied directly to `main`:
  - #91 `FIX(SECURITY): DISABLE SENTRY LOCAL VARIABLE CAPTURE`
  - #92/#93 temporary Sentry verification endpoint (added and reverted)
  - #94 `FIX(SECURITY): UPGRADE SETUPTOOLS TO 83.0.0 AND DOCUMENT DOCKER BASE IMAGE RISK`
- Follows the existing `sync/develop-with-main-*` pattern used for previous hotfixes
- Single trivial conflict in `.snyk` (comment wording only), resolved

## Test plan
- [x] `pytest tests/unit/ -q` → 1973 passed
- [x] `ruff check .` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated `setuptools` to address a reported security vulnerability.
  - Documented and managed inherited vulnerabilities from the application’s base image until patched versions are available.
  - Improved error-reporting privacy by preventing local variables from being included in Sentry events.
- **Documentation**
  - Added release notes describing the dependency update, base-image risks, and security mitigations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->