### PR TITLE
fix(security): Upgrade nltk to 3.10.0 to resolve path traversal and signature verification CVEs

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -18,16 +18,13 @@ ignore:
         reason: 'setuptools upgraded to 78.1.1 in requirements.txt (resolves CVE-2025-47273)'
   SNYK-PYTHON-NLTK-17356385:
     - '*':
-        expires: '2027-01-08T00:00:00.000Z'
-        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+        reason: 'nltk upgraded to 3.10.0 in requirements.txt (resolves CVE-2026-54293, Directory Traversal)'
   SNYK-PYTHON-NLTK-17817780:
     - '*':
-        expires: '2027-01-08T00:00:00.000Z'
-        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+        reason: 'nltk upgraded to 3.10.0 in requirements.txt (resolves CVE-2026-12243, Directory Traversal)'
   SNYK-PYTHON-NLTK-17821336:
     - '*':
-        expires: '2027-01-08T00:00:00.000Z'
-        reason: 'No upgrade or patch available. nltk is a transitive dependency of safety (dev/audit tool only), not used in src/. Real risk is null.'
+        reason: 'nltk upgraded to 3.10.0 in requirements.txt (resolves CVE-2026-12252, Improper Verification of Cryptographic Signature)'
   SNYK-DEBIAN13-ATTR-17678182:
     - '*':
         expires: '2026-10-22T00:00:00.000Z'

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,7 +153,8 @@ mako==1.3.12
 # nltk - Natural Language Toolkit (dependencia transitiva de safety)
 # Fijada explícitamente para resolver:
 # - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
-nltk==3.9.4
+# - CVE-2026-54293, CVE-2026-12243, CVE-2026-12252 (path traversal / firma criptográfica, GHSA Dependabot #29/#31)
+nltk==3.10.0
 
 # click - Command line interface creation kit (dependencia transitiva de nltk/safety/typer/uvicorn)
 # Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)


### PR DESCRIPTION
## Summary
- Resolves Dependabot alerts **#29** (`requirements.txt`) and **#31** (`requirements-dev.txt`, which inherits the pin transitively via `-r requirements.txt`).
- `nltk` was pinned at `3.9.4` with `.snyk` documenting it as "no upgrade or patch available" — that was stale. `nltk 3.10.0` is published on PyPI and patches:
  - CVE-2026-54293 / SNYK-PYTHON-NLTK-17356385 (URL-encoded path traversal in `nltk.data.load()`)
  - CVE-2026-12243 / SNYK-PYTHON-NLTK-17817780 (same class, different advisory)
  - CVE-2026-12252 / SNYK-PYTHON-NLTK-17821336 (improper cryptographic signature verification)
- `safety>=3.2.0` (the package that pulls `nltk` in transitively) only requires `nltk>=3.9`, so the upgrade is compatible — no other dependency needed changes.
- Updated `.snyk` to reflect "resolved via upgrade" for the 3 NLTK entries, same pattern already used for the setuptools entries, instead of the previous accepted-risk wording.

## Test plan
- [x] `pip install nltk==3.10.0` in venv, `pip-audit -r requirements.txt` → no known vulnerabilities found
- [x] `pytest tests/unit/ -q` → 1973 passed
- [x] `ruff check .` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the NLTK dependency to version 3.10.0.
  * Addressed additional reported security vulnerabilities and updated related security tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->