### PR TITLE
chore(merge): Sync develop with main after v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — feature/scoring-improvements
+## [Unreleased]
+
+## [2.1.0] - 2026-07-25
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Merge-back of `main` into `develop` after the v2.1.0 release (PR #98), per GitFlow.

## Test plan
- [ ] CI green