### PR TITLE
chore(github): Add issue templates for typology-based workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugfix.yml
+++ b/.github/ISSUE_TEMPLATE/bugfix.yml
@@ -1,0 +1,56 @@
+name: "🔴 Bug"
+description: "Algo no funciona como debería"
+title: "[Bug]: "
+labels: ["type:bugfix"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción del bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Pasos para reproducir
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamiento esperado
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportamiento actual
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Entorno
+      placeholder: "Python 3.11 / Docker local / develop branch..."
+    validations:
+      required: false
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional (logs, stacktrace...)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,22 @@
+name: "✅ Chore"
+description: "Mantenimiento, tooling, dependencias, configuración"
+title: "[Chore]: "
+labels: ["type:chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,22 @@
+name: "📄 Docs"
+description: "Cambios solo en documentación"
+title: "[Docs]: "
+labels: ["type:docs"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: ¿Qué documentación falta o hay que corregir?
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,38 @@
+name: "🟣 Feature"
+description: "Nueva funcionalidad o mejora"
+title: "[Feature]: "
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción
+      description: ¿Qué se quiere construir y por qué?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de aceptación
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,35 @@
+name: "🔄 Refactor"
+description: "Cambio interno sin alterar el comportamiento externo"
+title: "[Refactor]: "
+labels: ["type:refactor"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: ¿Qué parte del código se refactoriza?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivación
+      description: Deuda técnica, legibilidad, performance, preparación para otra tarea...
+    validations:
+      required: true
+  - type: textarea
+    id: risk
+    attributes:
+      label: Riesgo / impacto en tests existentes
+    validations:
+      required: false
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,34 @@
+name: "🔒 Security"
+description: "Vulnerabilidad o hardening de seguridad (uso interno, no público)"
+title: "[Security]: "
+labels: ["type:security"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción de la vulnerabilidad o riesgo
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impacto / componente afectado
+    validations:
+      required: true
+  - type: textarea
+    id: remediation
+    attributes:
+      label: Propuesta de solución
+    validations:
+      required: false
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      description: Añade también la label priority:P0/P1/P2 correspondiente
+      options:
+        - P0 — Crítico
+        - P1 — Alto
+        - P2 — Normal
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Add issue forms for feature, bugfix, refactor, chore, docs and security
- Each template maps to the new `type:*` label scheme and includes a priority dropdown aligned with `priority:P0/P1/P2`
- Disable blank issues to enforce using a template

## Test plan
- [ ] Open "New issue" on GitHub and confirm all 6 templates appear with correct labels pre-filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added structured issue forms for bug reports, features, documentation, refactoring, maintenance, and security concerns.
  - Forms provide guided prompts, priority selection, optional supporting context, and automatic categorization.
  - Added Spanish-language prompts where applicable.

- **Chores**
  - Disabled creation of blank issues.
  - Added consistent title prefixes and labels to improve issue organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->