### PR TITLE
refactor(user): Encapsulate User and PasswordHistory entity attributes

### DIFF
--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -321,7 +321,7 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
 
         # Si hay búsqueda por creador, necesitamos hacer JOIN con User
         if search_creator:
-            query = query.join(User, Competition._creator_id == User.id)
+            query = query.join(User, Competition._creator_id == User._id)
 
         # Lista de condiciones WHERE
         conditions = []
@@ -334,8 +334,8 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
         if search_creator:
             conditions.append(
                 or_(
-                    User.first_name.ilike(f"%{search_creator}%"),
-                    User.last_name.ilike(f"%{search_creator}%"),
+                    User._first_name.ilike(f"%{search_creator}%"),
+                    User._last_name.ilike(f"%{search_creator}%"),
                 )
             )
 

--- a/src/modules/user/application/use_cases/resend_verification_email_use_case.py
+++ b/src/modules/user/application/use_cases/resend_verification_email_use_case.py
@@ -105,7 +105,7 @@ class ResendVerificationEmailUseCase:
                 raise ResendVerificationError(GENERIC_ERROR_MESSAGE)
 
             # Asignar el token generado fuera de transacción
-            user.verification_token = verification_token
+            user.set_verification_token(verification_token)
 
             await self._uow.users.save(user)
             # El context manager (__aexit__) hace commit automático

--- a/src/modules/user/domain/entities/password_history.py
+++ b/src/modules/user/domain/entities/password_history.py
@@ -51,11 +51,31 @@ class PasswordHistory:
             created_at: Timestamp de creación (None para NOW())
             domain_events: Eventos de dominio pendientes
         """
-        self.id = id or PasswordHistoryId.generate()
-        self.user_id = user_id
-        self.password_hash = password_hash
-        self.created_at = created_at or datetime.now()
+        self._id = id or PasswordHistoryId.generate()
+        self._user_id = user_id
+        self._password_hash = password_hash
+        self._created_at = created_at or datetime.now()
         self._domain_events = domain_events or []
+
+    # ===========================================
+    # PROPERTIES (Encapsulación — solo lectura)
+    # ===========================================
+
+    @property
+    def id(self) -> PasswordHistoryId:
+        return self._id
+
+    @property
+    def user_id(self) -> UserId:
+        return self._user_id
+
+    @property
+    def password_hash(self) -> str:
+        return self._password_hash
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
 
     @classmethod
     def create(
@@ -112,7 +132,7 @@ class PasswordHistory:
             bool: True si el registro es más antiguo que N días
 
         Example:
-            >>> history.created_at = datetime.now() - timedelta(days=400)
+            >>> # Asumiendo un registro creado hace 400 días
             >>> history.is_older_than(365)
             True
         """

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -82,7 +82,7 @@ class User:
         password: Password | None,
         first_name: str,
         last_name: str,
-        handicap: float | None = None,
+        handicap: Handicap | None = None,
         handicap_updated_at: datetime | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
@@ -97,25 +97,102 @@ class User:
         gender: Gender | None = None,
         domain_events: list[DomainEvent] | None = None,
     ):
-        self.id = id
-        self.email = email
-        self.password = password
-        self.first_name = first_name
-        self.last_name = last_name
-        self.handicap = handicap
-        self.handicap_updated_at = handicap_updated_at
-        self.created_at = created_at or datetime.now()
-        self.updated_at = updated_at or datetime.now()
-        self.email_verified = email_verified
-        self.verification_token = verification_token
-        self.country_code = country_code
-        self.password_reset_token = password_reset_token
-        self.reset_token_expires_at = reset_token_expires_at
-        self.failed_login_attempts = failed_login_attempts
-        self.locked_until = locked_until
-        self.is_admin = is_admin
-        self.gender = gender
+        # Asignación de atributos privados (encapsulación)
+        self._id = id
+        self._email = email
+        self._password = password
+        self._first_name = first_name
+        self._last_name = last_name
+        self._handicap = handicap
+        self._handicap_updated_at = handicap_updated_at
+        self._created_at = created_at or datetime.now()
+        self._updated_at = updated_at or datetime.now()
+        self._email_verified = email_verified
+        self._verification_token = verification_token
+        self._country_code = country_code
+        self._password_reset_token = password_reset_token
+        self._reset_token_expires_at = reset_token_expires_at
+        self._failed_login_attempts = failed_login_attempts
+        self._locked_until = locked_until
+        self._is_admin = is_admin
+        self._gender = gender
         self._domain_events = domain_events or []
+
+    # ===========================================
+    # PROPERTIES (Encapsulación — solo lectura)
+    # ===========================================
+
+    @property
+    def id(self) -> UserId | None:
+        return self._id
+
+    @property
+    def email(self) -> Email | None:
+        return self._email
+
+    @property
+    def password(self) -> Password | None:
+        return self._password
+
+    @property
+    def first_name(self) -> str:
+        return self._first_name
+
+    @property
+    def last_name(self) -> str:
+        return self._last_name
+
+    @property
+    def handicap(self) -> Handicap | None:
+        return self._handicap
+
+    @property
+    def handicap_updated_at(self) -> datetime | None:
+        return self._handicap_updated_at
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
+
+    @property
+    def email_verified(self) -> bool:
+        return self._email_verified
+
+    @property
+    def verification_token(self) -> str | None:
+        return self._verification_token
+
+    @property
+    def country_code(self) -> CountryCode | None:
+        return self._country_code
+
+    @property
+    def password_reset_token(self) -> str | None:
+        return self._password_reset_token
+
+    @property
+    def reset_token_expires_at(self) -> datetime | None:
+        return self._reset_token_expires_at
+
+    @property
+    def failed_login_attempts(self) -> int:
+        return self._failed_login_attempts
+
+    @property
+    def locked_until(self) -> datetime | None:
+        return self._locked_until
+
+    @property
+    def is_admin(self) -> bool:
+        return self._is_admin
+
+    @property
+    def gender(self) -> Gender | None:
+        return self._gender
 
     def get_full_name(self) -> str:
         """Devuelve el nombre completo del usuario."""
@@ -166,21 +243,21 @@ class User:
         Raises:
             ValueError: Si el hándicap no está en el rango válido
         """
-        old_handicap = getattr(self, "handicap", None)
+        old_handicap = self._handicap
 
         # Validar si es un Handicap válido usando el Value Object
         if new_handicap is not None:
             validated = Handicap(new_handicap)  # Valida el rango
-            self.handicap = validated
+            self._handicap = validated
         else:
-            self.handicap = None
+            self._handicap = None
 
         # Actualizar timestamps
         # handicap_updated_at se guarda en UTC (columna timezone-aware) para que el
         # frontend pueda convertirlo correctamente a la hora local del usuario.
         now = datetime.now()
-        self.handicap_updated_at = datetime.now(UTC)
-        self.updated_at = now
+        self._handicap_updated_at = datetime.now(UTC)
+        self._updated_at = now
 
         # Emitir evento solo si cambió
         if old_handicap != self.handicap:
@@ -347,8 +424,8 @@ class User:
         Solo actúa si el email aún no está verificado.
         """
         if not self.email_verified:
-            self.email_verified = True
-            self.updated_at = datetime.now()
+            self._email_verified = True
+            self._updated_at = datetime.now()
 
     def record_google_unlinked(self, provider: str, unlinked_at: datetime) -> None:
         """
@@ -440,15 +517,15 @@ class User:
             return
 
         if first_name_changed:
-            self.first_name = first_name
+            self._first_name = first_name
         if last_name_changed:
-            self.last_name = last_name
+            self._last_name = last_name
         if country_code_changed:
-            self.country_code = new_country_code
+            self._country_code = new_country_code
         if gender_changed:
-            self.gender = new_gender
+            self._gender = new_gender
 
-        self.updated_at = datetime.now()
+        self._updated_at = datetime.now()
 
         self._add_domain_event(
             UserProfileUpdatedEvent(
@@ -482,9 +559,9 @@ class User:
         if new_email == old_email_str:
             return  # No cambió nada
 
-        self.email = new_email_vo
-        self.email_verified = False  # Requiere nueva verificación
-        self.updated_at = datetime.now()
+        self._email = new_email_vo
+        self._email_verified = False  # Requiere nueva verificación
+        self._updated_at = datetime.now()
 
         self._add_domain_event(
             UserEmailChangedEvent(
@@ -506,8 +583,8 @@ class User:
             ValueError: Si el password no es válido
         """
         new_password_vo = Password.from_plain_text(new_password)
-        self.password = new_password_vo
-        self.updated_at = datetime.now()
+        self._password = new_password_vo
+        self._updated_at = datetime.now()
 
         self._add_domain_event(
             UserPasswordChangedEvent(
@@ -525,9 +602,25 @@ class User:
             str: Token de verificación único
         """
         token = secrets.token_urlsafe(32)
-        self.verification_token = token
-        self.updated_at = datetime.now()
+        self._verification_token = token
+        self._updated_at = datetime.now()
         return token
+
+    def set_verification_token(self, token: str) -> None:
+        """
+        Asigna un token de verificación ya generado externamente.
+
+        A diferencia de `generate_verification_token()`, este método no genera
+        el token internamente ni actualiza `updated_at`: solo persiste un token
+        creado previamente por el caller. Existe para casos de uso que necesitan
+        generar el token ANTES de enviarlo por email y solo guardarlo si el envío
+        tuvo éxito (ver `ResendVerificationEmailUseCase`), evitando que dicho caso
+        de uso escriba directamente sobre el estado privado de la entidad.
+
+        Args:
+            token: Token de verificación generado previamente
+        """
+        self._verification_token = token
 
     def verify_email(self, token: str) -> bool:
         """
@@ -549,9 +642,9 @@ class User:
             raise ValueError("Token de verificación inválido")
 
         # Token válido - proceder con verificación
-        self.email_verified = True
-        self.verification_token = None
-        self.updated_at = datetime.now()
+        self._email_verified = True
+        self._verification_token = None
+        self._updated_at = datetime.now()
 
         # Emitir evento de dominio
         self._add_domain_event(
@@ -629,12 +722,13 @@ class User:
         """
         # Generar token seguro (mismo método que email verification)
         token = secrets.token_urlsafe(32)
-        self.password_reset_token = token
+        self._password_reset_token = token
 
         # Establecer expiración a 24 horas desde ahora
         now = datetime.now()
-        self.reset_token_expires_at = now + timedelta(hours=24)
-        self.updated_at = now
+        expires_at = now + timedelta(hours=24)
+        self._reset_token_expires_at = expires_at
+        self._updated_at = now
 
         # Emitir evento de dominio para auditoría
         self._add_domain_event(
@@ -642,7 +736,7 @@ class User:
                 user_id=str(self.id.value),
                 email=str(self.email.value),
                 requested_at=now,
-                reset_token_expires_at=self.reset_token_expires_at,
+                reset_token_expires_at=expires_at,
                 ip_address=ip_address,
                 user_agent=user_agent,
             )
@@ -745,15 +839,15 @@ class User:
 
         # Cambiar la contraseña (Password VO valida la política de seguridad)
         new_password_vo = Password.from_plain_text(new_password)
-        self.password = new_password_vo
+        self._password = new_password_vo
 
         # Invalidar el token (uso único)
-        self.password_reset_token = None
-        self.reset_token_expires_at = None
+        self._password_reset_token = None
+        self._reset_token_expires_at = None
 
         # Actualizar timestamp
         now = datetime.now()
-        self.updated_at = now
+        self._updated_at = now
 
         # Emitir evento de dominio (trigger para invalidar refresh tokens)
         self._add_domain_event(
@@ -796,19 +890,20 @@ class User:
             >>> user.is_locked()
             True
         """
-        self.failed_login_attempts += 1
-        self.updated_at = datetime.now()
+        self._failed_login_attempts += 1
+        self._updated_at = datetime.now()
 
         # Bloquear si alcanza el límite
         if self.failed_login_attempts >= MAX_FAILED_ATTEMPTS:
             now = datetime.now()
-            self.locked_until = now + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
+            locked_until = now + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
+            self._locked_until = locked_until
 
             # Emitir evento de bloqueo
             self._add_domain_event(
                 AccountLockedEvent(
                     user_id=str(self.id.value),
-                    locked_until=self.locked_until,
+                    locked_until=locked_until,
                     failed_attempts=self.failed_login_attempts,
                     locked_at=now,
                 )
@@ -831,10 +926,12 @@ class User:
             - No requiere intervención manual para desbloqueos temporales
 
         Ejemplo:
-            >>> user.locked_until = datetime.now() + timedelta(minutes=10)
+            >>> # Tras alcanzar MAX_FAILED_ATTEMPTS, record_failed_login() bloquea la cuenta
+            >>> user.locked_until is not None
+            True
             >>> user.is_locked()
             True
-            >>> # Después de 10 minutos...
+            >>> # Después de 30 minutos...
             >>> user.is_locked()
             False
         """
@@ -881,9 +978,9 @@ class User:
         old_failed_attempts = self.failed_login_attempts
 
         # Resetear estado de bloqueo
-        self.failed_login_attempts = 0
-        self.locked_until = None
-        self.updated_at = now
+        self._failed_login_attempts = 0
+        self._locked_until = None
+        self._updated_at = now
 
         # Emitir evento de desbloqueo
         self._add_domain_event(
@@ -913,14 +1010,14 @@ class User:
             - Si la cuenta está bloqueada, permanece bloqueada hasta expiración o unlock manual
 
         Ejemplo:
-            >>> user.failed_login_attempts = 5
+            >>> # Asumiendo que ya hay intentos fallidos registrados (record_failed_login())
             >>> user.reset_failed_attempts()
             >>> user.failed_login_attempts
             0
         """
         if self.failed_login_attempts > 0:
-            self.failed_login_attempts = 0
-            self.updated_at = datetime.now()
+            self._failed_login_attempts = 0
+            self._updated_at = datetime.now()
 
     def __str__(self) -> str:
         """Representación string del usuario (sin mostrar password)."""

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -148,15 +148,31 @@ def start_mappers():
             User,
             users_table,
             properties={
-                # Mapeamos las columnas de los ValueObjects a atributos "privados"
-                # para que SQLAlchemy no intente mapearlas automáticamente a los públicos.
-                "_email": users_table.c.email,
-                "_password": users_table.c.password,
-                # Ahora, creamos los atributos públicos usando 'composite' y apuntando
-                # a los atributos privados que acabamos de definir.
-                "email": composite(Email, "_email"),
-                "password": composite(Password, "_password"),
-                # handicap se mapea directamente - el HandicapDecorator maneja la conversión y None
+                # Scalar fields → private attrs (encapsulación, issue #109)
+                "_id": users_table.c.id,
+                "_first_name": users_table.c.first_name,
+                "_last_name": users_table.c.last_name,
+                "_handicap": users_table.c.handicap,
+                "_handicap_updated_at": users_table.c.handicap_updated_at,
+                "_created_at": users_table.c.created_at,
+                "_updated_at": users_table.c.updated_at,
+                "_email_verified": users_table.c.email_verified,
+                "_verification_token": users_table.c.verification_token,
+                "_country_code": users_table.c.country_code,
+                "_password_reset_token": users_table.c.password_reset_token,
+                "_reset_token_expires_at": users_table.c.reset_token_expires_at,
+                "_failed_login_attempts": users_table.c.failed_login_attempts,
+                "_locked_until": users_table.c.locked_until,
+                "_is_admin": users_table.c.is_admin,
+                "_gender": users_table.c.gender,
+                # Value Objects de una columna (Email, Password) → mapeamos la columna
+                # cruda a un atributo "_value" y componemos el VO real sobre el
+                # atributo privado "_email"/"_password" que respalda la @property
+                # pública de solo lectura del dominio.
+                "_email_value": users_table.c.email,
+                "_password_value": users_table.c.password,
+                "_email": composite(Email, "_email_value"),
+                "_password": composite(Password, "_password_value"),
             },
         )
 

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/password_history_mapper.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/password_history_mapper.py
@@ -97,7 +97,12 @@ def start_mappers():
             PasswordHistory,
             password_history_table,
             properties={
-                # Mapeo directo de columnas a atributos
-                # Los Value Objects (PasswordHistoryId, UserId) se manejan con TypeDecorators
+                # Mapeo directo de columnas a atributos privados (encapsulación,
+                # issue #109). Los Value Objects (PasswordHistoryId, UserId) se
+                # manejan con TypeDecorators, por lo que no requieren composite().
+                "_id": password_history_table.c.id,
+                "_user_id": password_history_table.c.user_id,
+                "_password_hash": password_history_table.c.password_hash,
+                "_created_at": password_history_table.c.created_at,
             },
         )

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -37,8 +37,8 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def find_by_email(self, email: Email) -> User | None:
         """Busca un usuario por su email."""
-        # Para composites, necesitamos usar where() y comparar con el atributo privado
-        statement = select(User).where(User._email == email.value)
+        # _email es un composite(Email, "_email_value"): comparar contra el VO completo
+        statement = select(User).where(User._email == email)
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
@@ -110,8 +110,8 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def exists_by_email(self, email: Email) -> bool:
         """Verifica si un usuario existe por su email."""
-        # Para composites, necesitamos usar where() y comparar con el atributo privado
-        statement = select(func.count()).select_from(User).where(User._email == email.value)
+        # _email es un composite(Email, "_email_value"): comparar contra el VO completo
+        statement = select(func.count()).select_from(User).where(User._email == email)
         result = await self._session.execute(statement)
         return result.scalar_one() > 0
 
@@ -123,7 +123,7 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def find_by_verification_token(self, token: str) -> User | None:
         """Busca un usuario por su token de verificación."""
-        statement = select(User).filter_by(verification_token=token)
+        statement = select(User).filter_by(_verification_token=token)
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
@@ -141,6 +141,6 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
             - Usa índice ix_users_password_reset_token para búsqueda rápida
             - NO valida expiración (esa lógica está en User.can_reset_password())
         """
-        statement = select(User).filter_by(password_reset_token=token)
+        statement = select(User).filter_by(_password_reset_token=token)
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -31,7 +31,7 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         """Busca múltiples usuarios por sus IDs en una sola consulta."""
         if not user_ids:
             return []
-        statement = select(User).where(User.id.in_([str(uid) for uid in user_ids]))  # type: ignore[union-attr]
+        statement = select(User).where(User._id.in_([str(uid) for uid in user_ids]))  # type: ignore[union-attr]
         result = await self._session.execute(statement)
         return list(result.scalars().all())
 
@@ -74,8 +74,8 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
             last_name = " ".join(name_parts[i:])
 
             statement = select(User).filter(
-                func.lower(User.first_name) == func.lower(first_name),
-                func.lower(User.last_name) == func.lower(last_name),
+                func.lower(User._first_name) == func.lower(first_name),
+                func.lower(User._last_name) == func.lower(last_name),
             )
             result = await self._session.execute(statement)
             user = result.scalar_one_or_none()
@@ -96,9 +96,11 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
             select(User)
             .filter(
                 or_(
-                    func.lower(User.first_name).contains(q, autoescape=True),
-                    func.lower(User.last_name).contains(q, autoescape=True),
-                    func.lower(User.first_name + " " + User.last_name).contains(q, autoescape=True),
+                    func.lower(User._first_name).contains(q, autoescape=True),
+                    func.lower(User._last_name).contains(q, autoescape=True),
+                    func.lower(User._first_name + " " + User._last_name).contains(
+                        q, autoescape=True
+                    ),
                 )
             )
             .limit(limit)

--- a/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
@@ -29,6 +29,40 @@ from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_wor
 from src.shared.infrastructure.security.jwt_handler import JWTTokenService
 
 
+def _rebuild_user(user: User, **overrides) -> User:
+    """
+    Reconstruye un User con los mismos valores, sobrescribiendo los indicados.
+
+    Tras la encapsulación de User (issue #109), sus atributos son de solo
+    lectura vía @property. Los tests que necesitan simular un estado concreto
+    (p.ej. una cuenta ya bloqueada) reconstruyen la entidad en vez de mutar
+    atributos directamente.
+    """
+    fields = {
+        "id": user.id,
+        "email": user.email,
+        "password": user.password,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "handicap": user.handicap,
+        "handicap_updated_at": user.handicap_updated_at,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "email_verified": user.email_verified,
+        "verification_token": user.verification_token,
+        "country_code": user.country_code,
+        "password_reset_token": user.password_reset_token,
+        "reset_token_expires_at": user.reset_token_expires_at,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": user.locked_until,
+        "is_admin": user.is_admin,
+        "gender": user.gender,
+        "domain_events": user.get_domain_events(),
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
 @pytest.fixture
 def uow():
     return InMemoryUnitOfWork()
@@ -298,8 +332,11 @@ class TestGoogleLoginUseCaseLockout:
         # Bloquear la cuenta
         from datetime import timedelta
 
-        user.locked_until = datetime.now() + timedelta(minutes=30)
-        user.failed_login_attempts = 10
+        user = _rebuild_user(
+            user,
+            locked_until=datetime.now() + timedelta(minutes=30),
+            failed_login_attempts=10,
+        )
 
         async with uow:
             await uow.users.save(user)

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -19,6 +19,40 @@ from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_wor
 from src.shared.infrastructure.security.jwt_handler import JWTTokenService
 
 
+def _rebuild_user(user: User, **overrides) -> User:
+    """
+    Reconstruye un User con los mismos valores, sobrescribiendo los indicados.
+
+    Tras la encapsulación de User (issue #109), sus atributos son de solo
+    lectura vía @property. Los tests que necesitan simular un estado concreto
+    (p.ej. un handicap desactualizado) reconstruyen la entidad en vez de mutar
+    atributos directamente.
+    """
+    fields = {
+        "id": user.id,
+        "email": user.email,
+        "password": user.password,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "handicap": user.handicap,
+        "handicap_updated_at": user.handicap_updated_at,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "email_verified": user.email_verified,
+        "verification_token": user.verification_token,
+        "country_code": user.country_code,
+        "password_reset_token": user.password_reset_token,
+        "reset_token_expires_at": user.reset_token_expires_at,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": user.locked_until,
+        "is_admin": user.is_admin,
+        "gender": user.gender,
+        "domain_events": user.get_domain_events(),
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
 @pytest.fixture
 def uow():
     """Fixture que proporciona un Unit of Work en memoria."""
@@ -380,7 +414,9 @@ class TestLoginUserUseCaseHandicapRFEG:
             country_code_str="ES",
         )
         user.update_handicap(12.5)
-        user.handicap_updated_at = user.handicap_updated_at - timedelta(days=1)
+        user = _rebuild_user(
+            user, handicap_updated_at=user.handicap_updated_at - timedelta(days=1)
+        )
         async with uow:
             await uow.users.save(user)
             await uow.commit()

--- a/tests/unit/modules/user/application/use_cases/test_reset_password_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_reset_password_use_case.py
@@ -34,6 +34,40 @@ from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_wor
 pytestmark = pytest.mark.asyncio
 
 
+def _rebuild_user(user: User, **overrides) -> User:
+    """
+    Reconstruye un User con los mismos valores, sobrescribiendo los indicados.
+
+    Tras la encapsulación de User (issue #109), sus atributos son de solo
+    lectura vía @property. Los tests que necesitan simular un estado concreto
+    (p.ej. un token ya expirado) reconstruyen la entidad en vez de mutar
+    atributos directamente.
+    """
+    fields = {
+        "id": user.id,
+        "email": user.email,
+        "password": user.password,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "handicap": user.handicap,
+        "handicap_updated_at": user.handicap_updated_at,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "email_verified": user.email_verified,
+        "verification_token": user.verification_token,
+        "country_code": user.country_code,
+        "password_reset_token": user.password_reset_token,
+        "reset_token_expires_at": user.reset_token_expires_at,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": user.locked_until,
+        "is_admin": user.is_admin,
+        "gender": user.gender,
+        "domain_events": user.get_domain_events(),
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
 class TestResetPasswordSuccess:
     """Tests para el flujo exitoso de reseteo de contraseña"""
 
@@ -219,7 +253,7 @@ class TestResetPasswordInvalidToken:
         old_password_hash = user.password.hashed_value
 
         # Simular expiración (hace 2 horas)
-        user.reset_token_expires_at = datetime.now() - timedelta(hours=2)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() - timedelta(hours=2))
 
         async with uow:
             await uow.users.save(user)
@@ -389,7 +423,7 @@ class TestResetPasswordSecurityFeatures:
         )
         token = user.generate_password_reset_token()
         # Expirar el token
-        user.reset_token_expires_at = datetime.now() - timedelta(hours=2)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() - timedelta(hours=2))
         async with uow:
             await uow.users.save(user)
 

--- a/tests/unit/modules/user/application/use_cases/test_validate_reset_token_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_validate_reset_token_use_case.py
@@ -29,6 +29,40 @@ from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_wor
 pytestmark = pytest.mark.asyncio
 
 
+def _rebuild_user(user: User, **overrides) -> User:
+    """
+    Reconstruye un User con los mismos valores, sobrescribiendo los indicados.
+
+    Tras la encapsulación de User (issue #109), sus atributos son de solo
+    lectura vía @property. Los tests que necesitan simular un estado concreto
+    (p.ej. un token ya expirado) reconstruyen la entidad en vez de mutar
+    atributos directamente.
+    """
+    fields = {
+        "id": user.id,
+        "email": user.email,
+        "password": user.password,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "handicap": user.handicap,
+        "handicap_updated_at": user.handicap_updated_at,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "email_verified": user.email_verified,
+        "verification_token": user.verification_token,
+        "country_code": user.country_code,
+        "password_reset_token": user.password_reset_token,
+        "reset_token_expires_at": user.reset_token_expires_at,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": user.locked_until,
+        "is_admin": user.is_admin,
+        "gender": user.gender,
+        "domain_events": user.get_domain_events(),
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
 class TestValidateResetTokenValid:
     """Tests para tokens válidos"""
 
@@ -84,7 +118,7 @@ class TestValidateResetTokenValid:
         token = user.generate_password_reset_token()
 
         # Simular que el token fue generado hace 12 horas (aún válido)
-        user.reset_token_expires_at = datetime.now() + timedelta(hours=12)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() + timedelta(hours=12))
 
         async with uow:
             await uow.users.save(user)
@@ -144,7 +178,7 @@ class TestValidateResetTokenInvalid:
         token = user.generate_password_reset_token()
 
         # Simular expiración (hace 2 horas)
-        user.reset_token_expires_at = datetime.now() - timedelta(hours=2)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() - timedelta(hours=2))
 
         async with uow:
             await uow.users.save(user)
@@ -181,7 +215,7 @@ class TestValidateResetTokenInvalid:
         token = user.generate_password_reset_token()
 
         # Establecer expiración exactamente ahora (boundary)
-        user.reset_token_expires_at = datetime.now()
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now())
 
         async with uow:
             await uow.users.save(user)
@@ -214,8 +248,7 @@ class TestValidateResetTokenInvalid:
         token = user.generate_password_reset_token()
 
         # Invalidar el token manualmente (simulando que ya fue usado)
-        user.password_reset_token = None
-        user.reset_token_expires_at = None
+        user = _rebuild_user(user, password_reset_token=None, reset_token_expires_at=None)
 
         async with uow:
             await uow.users.save(user)

--- a/tests/unit/modules/user/domain/entities/test_user_password_reset.py
+++ b/tests/unit/modules/user/domain/entities/test_user_password_reset.py
@@ -25,6 +25,40 @@ from src.modules.user.domain.events.password_reset_requested_event import (
 )
 
 
+def _rebuild_user(user: User, **overrides) -> User:
+    """
+    Reconstruye un User con los mismos valores, sobrescribiendo los indicados.
+
+    Tras la encapsulación de User (issue #109), sus atributos son de solo
+    lectura vía @property. Los tests que necesitan simular un estado concreto
+    (p.ej. un token ya expirado) reconstruyen la entidad en vez de mutar
+    atributos directamente.
+    """
+    fields = {
+        "id": user.id,
+        "email": user.email,
+        "password": user.password,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "handicap": user.handicap,
+        "handicap_updated_at": user.handicap_updated_at,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "email_verified": user.email_verified,
+        "verification_token": user.verification_token,
+        "country_code": user.country_code,
+        "password_reset_token": user.password_reset_token,
+        "reset_token_expires_at": user.reset_token_expires_at,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": user.locked_until,
+        "is_admin": user.is_admin,
+        "gender": user.gender,
+        "domain_events": user.get_domain_events(),
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
 class TestGeneratePasswordResetToken:
     """Tests para el método generate_password_reset_token()"""
 
@@ -220,7 +254,7 @@ class TestCanResetPassword:
         token = user.generate_password_reset_token()
 
         # Simular que pasaron 25 horas (token expirado)
-        user.reset_token_expires_at = datetime.now() - timedelta(hours=1)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() - timedelta(hours=1))
 
         # Act
         result = user.can_reset_password(token)
@@ -267,7 +301,7 @@ class TestCanResetPassword:
         token = user.generate_password_reset_token()
 
         # Establecer expiración exactamente ahora (boundary)
-        user.reset_token_expires_at = datetime.now()
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now())
 
         # Act
         result = user.can_reset_password(token)
@@ -369,7 +403,7 @@ class TestResetPassword:
         token = user.generate_password_reset_token()
 
         # Simular expiración (hace 2 horas)
-        user.reset_token_expires_at = datetime.now() - timedelta(hours=2)
+        user = _rebuild_user(user, reset_token_expires_at=datetime.now() - timedelta(hours=2))
 
         # Act & Assert
         with pytest.raises(ValueError, match="Token de reseteo inválido o expirado"):


### PR DESCRIPTION
## Summary

- Converts every public attribute on the `User` aggregate root and `PasswordHistory` entity to private (`_attr`) with read-only `@property` accessors, matching the pattern already established by `Competition` (15 properties, 0 public attrs) and `GolfCourse` (14 properties).
- Closes the one real encapsulation bypass found in application code: `ResendVerificationEmailUseCase` wrote directly to `user.verification_token` to persist a token generated before sending the email (needed so the token is only saved if the email send succeeds). Added `User.set_verification_token(token)` so the use case no longer touches private domain state directly.
- Updated the SQLAlchemy imperative mappers (`mappers.py`, `password_history_mapper.py`) to map table columns onto the new private attributes, following exactly the approach `Competition`'s mapper already uses successfully: scalar columns map directly to `_attr`, and the `Email`/`Password` value objects are mapped via `composite()` onto `_email`/`_password` (the attributes backing the read-only public properties), with the raw string columns behind `_email_value`/`_password_value`.
- Fixed two repositories that referenced `User.id` / `User.first_name` / `User.last_name` as SQLAlchemy class-level query expressions (`user_repository.py`, `competition_repository.py`'s `find_by_filters` join/ilike filters) — these now query via the private, SQLAlchemy-instrumented attributes (`User._id`, `User._first_name`, `User._last_name`), matching how `Competition`'s repository already queries via its own private attrs.
- Updated 5 test files that mutated `User` state directly for test setup (token-expiry simulation, account-lockout simulation) to reconstruct the entity via its constructor instead of writing to the now-read-only properties.

No behavior, validation logic, domain events, or public method signatures changed — this is a pure encapsulation refactor.

## Test plan

- [x] `pytest tests/unit/ -q` — 1973 passed, 0 failed
- [x] `ruff check .` — all checks passed
- [x] `mypy src/ --ignore-missing-imports` — 0 errors (baseline was already 0; verified via `git stash` that the pre-refactor tree also reports 0 errors, so no regression)
- [ ] Integration tests against a real Postgres DB were not run in this environment (no local Docker daemon available) — the mapper logic was verified by reading SQLAlchemy's `descriptor_props.py` to confirm `composite()` auto-derives `__composite_values__` from dataclasses (`Email`/`Password` are `@dataclass(frozen=True)`), and by mirroring the exact, already-tested `Competition` mapper pattern byte-for-byte in structure.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of competition and user searches, including creator and name filtering.
  * Fixed verification-token updates to use the user’s domain behavior, ensuring consistent persistence.
  * Preserved expected password reset, email verification, account lockout, and profile update behavior.

* **Refactor**
  * Strengthened encapsulation for user and password-history data while maintaining existing functionality.
  * Improved persistence mapping for user-related information and value objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->