### PR TITLE
feat(quick-match): Add guest players and scorer assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - New tables `quick_matches` and `quick_match_hole_scores` (Alembic migration `a91cc79ba087`), with a GIN index on the `participants` JSONB column to support the "quick matches I'm in" query.
 - 77 unit tests (domain + 9 use cases + in-memory repos) + 5 integration tests (E2E via real DB, full flow: create → add friend → start → submit scores → complete).
 
+**Quick Match — Guest Players and Scorer Assignment**
+
+- `QuickMatchParticipant` now supports two variants: registered (`user_id`) and **guest** (no account — `first_name`/`last_name`/optional manual `handicap`, entered by the creator). Both share a stable `participant_id` (new `ParticipantId` Value Object) used for removal, scoring, and assignment regardless of type.
+- `POST /quick-matches/{id}/participants/guest`: creator adds a guest player by hand.
+- Starting a match now requires `scorer_ids` (1 to 4 **registered** participants, always including the creator): the subset who will actually operate the app to record scores during the round. `POST /quick-matches/{id}/start` body: `{"scorer_ids": [...]}`.
+- New `ScoringCoverageService` (pure domain service): computes who records for whom. Non-scorers (guests, or registered players not selected as scorers) are split as evenly as possible across all scorers; any remainder from an uneven split is absorbed by the creator.
+- `POST /quick-matches/{id}/participants/{participant_id}/holes/{n}/score`: a scorer records a hole score on behalf of a participant assigned to them (403 if the target isn't covered by that scorer). The existing self-submit endpoint now requires the caller to be a configured scorer (403 `NotAScorerError` otherwise).
+- `QuickMatchHoleScore` renamed `player_user_id` → `participant_id` (no FK to `users`, since guests aren't user rows) and gained `recorded_by_participant_id`, so every score carries who actually entered it.
+- `GET /quick-matches/{id}` detail response now includes `scorer_ids` and `scoring_assignments` (who covers whom), alongside the existing standing.
+- Migration `9a9440cebb07`: adds `quick_matches.scorer_ids` (JSONB); renames `quick_match_hole_scores.player_user_id` → `participant_id` (drops its FK to `users`, type changes `CHAR(36)` → `uuid`) and adds `recorded_by_participant_id`.
+- 109 unit tests (up from 77: new `ParticipantId`/guest-variant VO tests, `ScoringCoverageService` tests, `AddGuestToQuickMatchUseCase`, `SubmitProxyHoleScoreUseCase`, updated entity/use case tests for the new participant model) + 8 integration tests (up from 5: guest + proxy-scoring flow, non-scorer rejection, invalid scorer configuration).
+
 ## [2.1.0] - 2026-07-25
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,15 @@
 - **Seguridad**: añadir participante exige `Friendship` ACCEPTED (403 si no); solo el creador inicia/completa/cancela/añade; campo de golf debe estar `APPROVED`.
 - **Tests**: 77 unit + 5 integration (flujo completo E2E), 100% pasando. Lint y mypy limpios.
 - Validado además contra el clúster K8s local (imagen desplegada expone los 9 endpoints nuevos; tests de integración pasando contra el Postgres del clúster).
+- PR #116 (`feature/quick-match` → `feature/friends-system`), pendiente de review.
+
+### Módulo `quick_match` — invitados y reparto de anotación ✅
+
+- **Invitados sin cuenta**: `QuickMatchParticipant` admite jugadores invitados (nombre/apellidos/hándicap manual), identificados por un `ParticipantId` común a registrados e invitados.
+- **Anotadores configurables**: al iniciar la partida, el creador indica entre 1 y 4 participantes registrados (siempre incluido él mismo) que anotarán resultados. `ScoringCoverageService` reparte a los no-anotadores (invitados o registrados no seleccionados) lo más uniforme posible; el sobrante de un reparto no exacto lo absorbe el creador.
+- **Endpoint de delegación**: `POST /quick-matches/{id}/participants/{participant_id}/holes/{n}/score` permite a un anotador registrar el resultado de quien tenga asignado.
+- **Tests**: 109 unit + 8 integration, 100% pasando. Migración `9a9440cebb07` verificada (aplicada automáticamente al redesplegar en K8s, esquema correcto, sin pérdida de datos).
+- Rama `feature/quick-match-guests-scoring` (sobre `feature/quick-match`), pendiente de PR.
 
 ---
 

--- a/alembic/versions/9a9440cebb07_add_guests_and_scorer_assignment_to_.py
+++ b/alembic/versions/9a9440cebb07_add_guests_and_scorer_assignment_to_.py
@@ -1,0 +1,97 @@
+"""Add guests and scorer assignment to quick_match
+
+Revision ID: 9a9440cebb07
+Revises: a91cc79ba087
+Create Date: 2026-07-26 17:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "9a9440cebb07"
+down_revision = "a91cc79ba087"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # quick_matches: nueva columna scorer_ids (JSONB, lista de participant_id)
+    op.add_column(
+        "quick_matches",
+        sa.Column(
+            "scorer_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+    # quick_match_hole_scores: player_user_id (CHAR(36), FK a users) ->
+    # participant_id (UUID, sin FK: puede ser un invitado sin cuenta)
+    op.drop_constraint(
+        "uq_quick_match_hole_player", "quick_match_hole_scores", type_="unique"
+    )
+    op.drop_constraint(
+        "quick_match_hole_scores_player_user_id_fkey",
+        "quick_match_hole_scores",
+        type_="foreignkey",
+    )
+    op.execute(
+        "ALTER TABLE quick_match_hole_scores "
+        "RENAME COLUMN player_user_id TO participant_id"
+    )
+    op.execute(
+        "ALTER TABLE quick_match_hole_scores "
+        "ALTER COLUMN participant_id TYPE uuid USING participant_id::uuid"
+    )
+
+    # recorded_by_participant_id: quien registro el score (el propio jugador o
+    # el anotador que lo hizo por delegacion). Backfill = participant_id.
+    op.add_column(
+        "quick_match_hole_scores",
+        sa.Column("recorded_by_participant_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE quick_match_hole_scores SET recorded_by_participant_id = participant_id"
+    )
+    op.alter_column("quick_match_hole_scores", "recorded_by_participant_id", nullable=False)
+
+    op.create_unique_constraint(
+        "uq_quick_match_hole_participant",
+        "quick_match_hole_scores",
+        ["quick_match_id", "hole_number", "participant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_quick_match_hole_participant", "quick_match_hole_scores", type_="unique"
+    )
+    op.drop_column("quick_match_hole_scores", "recorded_by_participant_id")
+
+    op.execute(
+        "ALTER TABLE quick_match_hole_scores "
+        "ALTER COLUMN participant_id TYPE CHAR(36) USING participant_id::text"
+    )
+    op.execute(
+        "ALTER TABLE quick_match_hole_scores "
+        "RENAME COLUMN participant_id TO player_user_id"
+    )
+    op.create_foreign_key(
+        "quick_match_hole_scores_player_user_id_fkey",
+        "quick_match_hole_scores",
+        "users",
+        ["player_user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_quick_match_hole_player",
+        "quick_match_hole_scores",
+        ["quick_match_id", "hole_number", "player_user_id"],
+    )
+
+    op.drop_column("quick_matches", "scorer_ids")

--- a/alembic/versions/9a9440cebb07_add_guests_and_scorer_assignment_to_.py
+++ b/alembic/versions/9a9440cebb07_add_guests_and_scorer_assignment_to_.py
@@ -80,6 +80,12 @@ def downgrade() -> None:
         "ALTER TABLE quick_match_hole_scores "
         "RENAME COLUMN participant_id TO player_user_id"
     )
+    # Los scores de invitados (sin cuenta) no tienen fila en users: no se
+    # pueden conservar bajo la FK previa a este cambio, se eliminan.
+    op.execute(
+        "DELETE FROM quick_match_hole_scores "
+        "WHERE player_user_id NOT IN (SELECT id::text FROM users)"
+    )
     op.create_foreign_key(
         "quick_match_hole_scores_player_user_id_fkey",
         "quick_match_hole_scores",

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -201,6 +201,9 @@ from src.modules.golf_course.infrastructure.persistence.sqlalchemy.golf_course_u
 from src.modules.quick_match.application.use_cases.add_friend_to_quick_match_use_case import (
     AddFriendToQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.add_guest_to_quick_match_use_case import (
+    AddGuestToQuickMatchUseCase,
+)
 from src.modules.quick_match.application.use_cases.cancel_quick_match_use_case import (
     CancelQuickMatchUseCase,
 )
@@ -224,6 +227,9 @@ from src.modules.quick_match.application.use_cases.start_quick_match_use_case im
 )
 from src.modules.quick_match.application.use_cases.submit_hole_score_use_case import (
     SubmitQuickMatchHoleScoreUseCase,
+)
+from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
+    SubmitProxyHoleScoreUseCase,
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -1020,6 +1026,14 @@ def get_add_friend_to_quick_match_use_case(
     return AddFriendToQuickMatchUseCase(uow, social_uow, user_uow)
 
 
+def get_add_guest_to_quick_match_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AddGuestToQuickMatchUseCase:
+    """Proveedor del caso de uso AddGuestToQuickMatchUseCase."""
+    return AddGuestToQuickMatchUseCase(uow, user_uow)
+
+
 def get_remove_quick_match_participant_use_case(
     uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
@@ -1057,6 +1071,13 @@ def get_submit_quick_match_hole_score_use_case(
 ) -> SubmitQuickMatchHoleScoreUseCase:
     """Proveedor del caso de uso SubmitQuickMatchHoleScoreUseCase."""
     return SubmitQuickMatchHoleScoreUseCase(uow)
+
+
+def get_submit_quick_match_proxy_hole_score_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+) -> SubmitProxyHoleScoreUseCase:
+    """Proveedor del caso de uso SubmitProxyHoleScoreUseCase."""
+    return SubmitProxyHoleScoreUseCase(uow)
 
 
 def get_get_quick_match_use_case(

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-MAX_SCORERS = 4
+from src.modules.quick_match.domain.entities.quick_match import MAX_SCORERS
 
 
 class CreateQuickMatchRequestDTO(BaseModel):

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+MAX_SCORERS = 4
+
 
 class CreateQuickMatchRequestDTO(BaseModel):
     """DTO para crear una partida rapida."""
@@ -15,11 +17,22 @@ class CreateQuickMatchRequestDTO(BaseModel):
 
 
 class AddParticipantRequestDTO(BaseModel):
-    """DTO para añadir un amigo como participante."""
+    """DTO para añadir un amigo registrado como participante."""
 
     quick_match_id: UUID
     requester_id: UUID
     friend_user_id: UUID
+    team: str | None = Field(None, pattern="^(A|B)$")
+
+
+class AddGuestParticipantRequestDTO(BaseModel):
+    """DTO para añadir a mano un jugador invitado (sin cuenta) como participante."""
+
+    quick_match_id: UUID
+    requester_id: UUID
+    first_name: str = Field(..., min_length=1, max_length=100)
+    last_name: str = Field(..., min_length=1, max_length=100)
+    handicap: float | None = Field(None, ge=-10.0, le=54.0)
     team: str | None = Field(None, pattern="^(A|B)$")
 
 
@@ -28,11 +41,19 @@ class RemoveParticipantRequestDTO(BaseModel):
 
     quick_match_id: UUID
     requester_id: UUID
-    target_user_id: UUID
+    target_participant_id: UUID
+
+
+class StartQuickMatchRequestDTO(BaseModel):
+    """DTO para iniciar la partida, configurando quien anota (1 a 4 anotadores)."""
+
+    quick_match_id: UUID
+    requester_id: UUID
+    scorer_ids: list[UUID] = Field(..., min_length=1, max_length=MAX_SCORERS)
 
 
 class SubmitHoleScoreRequestDTO(BaseModel):
-    """DTO para registrar/actualizar el score propio de un hoyo."""
+    """DTO para registrar/actualizar el score propio de un hoyo (solo anotadores)."""
 
     quick_match_id: UUID
     player_user_id: UUID
@@ -40,12 +61,25 @@ class SubmitHoleScoreRequestDTO(BaseModel):
     score: int = Field(..., ge=1, le=15)
 
 
+class SubmitProxyHoleScoreRequestDTO(BaseModel):
+    """DTO para que un anotador registre el score de otro participante asignado."""
+
+    quick_match_id: UUID
+    scorer_user_id: UUID
+    target_participant_id: UUID
+    hole_number: int = Field(..., ge=1, le=18)
+    score: int = Field(..., ge=1, le=15)
+
+
 class QuickMatchParticipantDTO(BaseModel):
     """DTO de un participante enriquecido con su nombre."""
 
-    user_id: UUID
+    participant_id: UUID
+    user_id: UUID | None = None
     name: str
+    handicap: float | None = None
     team: str | None = None
+    is_guest: bool = False
 
 
 class QuickMatchResponseDTO(BaseModel):
@@ -57,6 +91,7 @@ class QuickMatchResponseDTO(BaseModel):
     match_format: str
     status: str
     participants: list[QuickMatchParticipantDTO]
+    scorer_ids: list[UUID]
     created_at: datetime
     updated_at: datetime
 
@@ -74,8 +109,9 @@ class HoleScoreResponseDTO(BaseModel):
     """DTO de un score de hoyo registrado."""
 
     hole_number: int
-    player_user_id: UUID
+    participant_id: UUID
     score: int
+    recorded_by_participant_id: UUID
 
 
 class QuickMatchStandingResponseDTO(BaseModel):
@@ -88,8 +124,17 @@ class QuickMatchStandingResponseDTO(BaseModel):
     is_decided: bool
 
 
+class ScoringAssignmentDTO(BaseModel):
+    """DTO del reparto de anotacion: que participantes cubre cada anotador."""
+
+    scorer_participant_id: UUID
+    scorer_name: str
+    covered_participant_ids: list[UUID]
+
+
 class QuickMatchDetailResponseDTO(QuickMatchResponseDTO):
-    """DTO de detalle: partida + scores + standing calculado."""
+    """DTO de detalle: partida + scores + standing + reparto de anotacion."""
 
     hole_scores: list[HoleScoreResponseDTO]
     standing: QuickMatchStandingResponseDTO | None = None
+    scoring_assignments: list[ScoringAssignmentDTO] = Field(default_factory=list)

--- a/src/modules/quick_match/application/exceptions.py
+++ b/src/modules/quick_match/application/exceptions.py
@@ -47,3 +47,15 @@ class NotQuickMatchParticipantError(Exception):
     """El usuario no es participante de esta partida rapida."""
 
     pass
+
+
+class TargetParticipantNotFoundError(Exception):
+    """El participante objetivo no existe en esta partida rapida."""
+
+    pass
+
+
+class NotAScorerError(Exception):
+    """El usuario no esta configurado como anotador de esta partida."""
+
+    pass

--- a/src/modules/quick_match/application/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/application/mappers/quick_match_mapper.py
@@ -20,10 +20,22 @@ class QuickMatchDTOMapper:
         async with user_uow:
             participants_dto = []
             for p in quick_match.participants:
-                user = await user_uow.users.find_by_id(p.user_id)
-                name = f"{user.first_name} {user.last_name}" if user else "Unknown"
+                if p.is_guest:
+                    name = f"{p.first_name} {p.last_name}"
+                    handicap = p.handicap
+                else:
+                    user = await user_uow.users.find_by_id(p.user_id)
+                    name = f"{user.first_name} {user.last_name}" if user else "Unknown"
+                    handicap = None
                 participants_dto.append(
-                    QuickMatchParticipantDTO(user_id=p.user_id.value, name=name, team=p.team)
+                    QuickMatchParticipantDTO(
+                        participant_id=p.participant_id.value,
+                        user_id=p.user_id.value if p.user_id else None,
+                        name=name,
+                        handicap=handicap,
+                        team=p.team,
+                        is_guest=p.is_guest,
+                    )
                 )
 
         return QuickMatchResponseDTO(
@@ -33,6 +45,7 @@ class QuickMatchDTOMapper:
             match_format=quick_match.match_format.value,
             status=quick_match.status.value,
             participants=participants_dto,
+            scorer_ids=[sid.value for sid in quick_match.scorer_ids],
             created_at=quick_match.created_at,
             updated_at=quick_match.updated_at,
         )

--- a/src/modules/quick_match/application/use_cases/add_friend_to_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/add_friend_to_quick_match_use_case.py
@@ -15,6 +15,9 @@ from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interf
     QuickMatchUnitOfWorkInterface,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
 )
@@ -70,7 +73,8 @@ class AddFriendToQuickMatchUseCase:
                     "Only the quick match creator can add participants."
                 )
 
-            quick_match.add_participant(friend_id, team=request.team)
+            participant = QuickMatchParticipant.for_user(friend_id, team=request.team)
+            quick_match.add_participant(participant)
             await self._uow.quick_matches.update(quick_match)
 
         return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
@@ -1,8 +1,8 @@
-"""Caso de Uso: Iniciar una Partida Rapida."""
+"""Caso de Uso: Añadir a mano un jugador invitado (sin cuenta) a una partida rapida."""
 
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    AddGuestParticipantRequestDTO,
     QuickMatchResponseDTO,
-    StartQuickMatchRequestDTO,
 )
 from src.modules.quick_match.application.exceptions import (
     NotQuickMatchCreatorError,
@@ -12,31 +12,31 @@ from src.modules.quick_match.application.mappers.quick_match_mapper import Quick
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
-from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
-class StartQuickMatchUseCase:
+class AddGuestToQuickMatchUseCase:
     """
-    El creador inicia la partida una vez el roster esta completo.
+    Añade a un jugador invitado (sin cuenta en la app) como participante.
 
-    Debe indicar `scorer_ids`: entre 1 y 4 participantes registrados (siempre
-    incluyendo al creador) que seran quienes anoten los resultados. El resto
-    de participantes (invitados o registrados no seleccionados) tendran su
-    puntuacion registrada por delegacion.
+    Solo el creador puede añadir participantes. El invitado se identifica con
+    nombre/apellidos y un handicap manual opcional; sus resultados tendran que
+    ser registrados por uno de los anotadores configurados al iniciar la partida.
     """
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
         self._uow = uow
         self._user_uow = user_uow
 
-    async def execute(self, request: StartQuickMatchRequestDTO) -> QuickMatchResponseDTO:
+    async def execute(self, request: AddGuestParticipantRequestDTO) -> QuickMatchResponseDTO:
         requester_id = UserId(request.requester_id)
-        scorer_ids = [ParticipantId(sid) for sid in request.scorer_ids]
 
         async with self._uow:
             quick_match = await self._uow.quick_matches.find_by_id(
@@ -46,9 +46,17 @@ class StartQuickMatchUseCase:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 
             if quick_match.creator_id != requester_id:
-                raise NotQuickMatchCreatorError("Only the creator can start the quick match.")
+                raise NotQuickMatchCreatorError(
+                    "Only the quick match creator can add participants."
+                )
 
-            quick_match.start(scorer_ids)
+            participant = QuickMatchParticipant.for_guest(
+                first_name=request.first_name,
+                last_name=request.last_name,
+                handicap=request.handicap,
+                team=request.team,
+            )
+            quick_match.add_participant(participant)
             await self._uow.quick_matches.update(quick_match)
 
         return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
@@ -39,7 +39,7 @@ class AddGuestToQuickMatchUseCase:
         requester_id = UserId(request.requester_id)
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
                 QuickMatchId(request.quick_match_id)
             )
             if not quick_match:

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -5,6 +5,7 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     HoleScoreResponseDTO,
     QuickMatchDetailResponseDTO,
     QuickMatchStandingResponseDTO,
+    ScoringAssignmentDTO,
 )
 from src.modules.quick_match.application.exceptions import (
     NotQuickMatchParticipantError,
@@ -14,6 +15,10 @@ from src.modules.quick_match.application.mappers.quick_match_mapper import Quick
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
@@ -24,17 +29,18 @@ TOTAL_HOLES = 18
 
 
 class GetQuickMatchUseCase:
-    """Obtiene el detalle de una partida rapida: datos, scores y standing calculado."""
+    """Obtiene el detalle de una partida rapida: datos, scores, standing y reparto de anotacion."""
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
         self._uow = uow
         self._user_uow = user_uow
         self._scoring_service = ScoringService()
+        self._coverage_service = ScoringCoverageService()
 
     async def execute(
         self, quick_match_id_raw: str, current_user_id_raw: str
     ) -> QuickMatchDetailResponseDTO:
-        current_user_id = UserId(current_user_id_raw)
+        current_participant_id = ParticipantId(UserId(current_user_id_raw).value)
 
         async with self._uow:
             quick_match = await self._uow.quick_matches.find_by_id(
@@ -43,7 +49,7 @@ class GetQuickMatchUseCase:
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {quick_match_id_raw}")
 
-            if not quick_match.is_participant(current_user_id):
+            if not quick_match.is_participant(current_participant_id):
                 raise NotQuickMatchParticipantError(
                     "You are not a participant of this quick match."
                 )
@@ -55,45 +61,73 @@ class GetQuickMatchUseCase:
         hole_scores_dto = [
             HoleScoreResponseDTO(
                 hole_number=hs.hole_number,
-                player_user_id=hs.player_user_id.value,
+                participant_id=hs.participant_id.value,
                 score=hs.score,
+                recorded_by_participant_id=hs.recorded_by_participant_id.value,
             )
             for hs in sorted(hole_scores, key=lambda h: h.hole_number)
         ]
 
         standing_dto = self._compute_standing(quick_match, hole_scores)
+        assignments_dto = await self._build_assignments(quick_match)
 
         return QuickMatchDetailResponseDTO(
             **base_dto.model_dump(),
             hole_scores=hole_scores_dto,
             standing=standing_dto,
+            scoring_assignments=assignments_dto,
         )
+
+    async def _build_assignments(self, quick_match) -> list[ScoringAssignmentDTO]:
+        if not quick_match.scorer_ids:
+            return []
+
+        assignments = self._coverage_service.compute_assignments(
+            participants=quick_match.participants,
+            scorer_ids=quick_match.scorer_ids,
+            creator_participant_id=quick_match.creator_participant_id,
+        )
+
+        result = []
+        for scorer_id, covered_ids in assignments.items():
+            scorer = quick_match.find_participant(scorer_id)
+            async with self._user_uow:
+                user = await self._user_uow.users.find_by_id(scorer.user_id) if scorer else None
+            scorer_name = f"{user.first_name} {user.last_name}" if user else "Unknown"
+            result.append(
+                ScoringAssignmentDTO(
+                    scorer_participant_id=scorer_id.value,
+                    scorer_name=scorer_name,
+                    covered_participant_ids=[cid.value for cid in covered_ids],
+                )
+            )
+        return result
 
     def _compute_standing(self, quick_match, hole_scores) -> QuickMatchStandingResponseDTO | None:
         participants = quick_match.participants
         if len(participants) < 2:  # noqa: PLR2004
             return None
 
-        team_a_ids = {p.user_id for p in participants if (p.team or "A") == "A"}
-        team_b_ids = {p.user_id for p in participants if p.team == "B"}
+        team_a_ids = {p.participant_id for p in participants if (p.team or "A") == "A"}
+        team_b_ids = {p.participant_id for p in participants if p.team == "B"}
         if not team_b_ids and len(participants) == 2:  # noqa: PLR2004 - SINGLES: no team field
-            team_a_ids = {participants[0].user_id}
-            team_b_ids = {participants[1].user_id}
+            team_a_ids = {participants[0].participant_id}
+            team_b_ids = {participants[1].participant_id}
 
         scores_by_hole: dict[int, dict] = {}
         for hs in hole_scores:
-            scores_by_hole.setdefault(hs.hole_number, {})[hs.player_user_id] = hs.score
+            scores_by_hole.setdefault(hs.hole_number, {})[hs.participant_id] = hs.score
 
         hole_results = []
         for hole_number in range(1, TOTAL_HOLES + 1):
             scores = scores_by_hole.get(hole_number)
             if not scores:
                 continue
-            if not all(uid in scores for uid in team_a_ids | team_b_ids):
+            if not all(pid in scores for pid in team_a_ids | team_b_ids):
                 continue
 
-            team_a_scores = [scores[uid] for uid in team_a_ids]
-            team_b_scores = [scores[uid] for uid in team_b_ids]
+            team_a_scores = [scores[pid] for pid in team_a_ids]
+            team_b_scores = [scores[pid] for pid in team_b_ids]
             hole_results.append(
                 self._scoring_service.calculate_hole_winner(
                     team_a_scores, team_b_scores, quick_match.match_format

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -56,7 +56,17 @@ class GetQuickMatchUseCase:
 
             hole_scores = await self._uow.quick_match_hole_scores.find_by_match(quick_match.id)
 
-        base_dto = await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        registered_ids = [p.user_id for p in quick_match.participants if p.user_id is not None]
+        async with self._user_uow:
+            users_by_id = {}
+            for user_id in registered_ids:
+                user = await self._user_uow.users.find_by_id(user_id)
+                if user:
+                    users_by_id[user_id] = user
+
+        base_dto = await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, users_by_id=users_by_id
+        )
 
         hole_scores_dto = [
             HoleScoreResponseDTO(
@@ -69,7 +79,7 @@ class GetQuickMatchUseCase:
         ]
 
         standing_dto = self._compute_standing(quick_match, hole_scores)
-        assignments_dto = await self._build_assignments(quick_match)
+        assignments_dto = self._build_assignments(quick_match, users_by_id)
 
         return QuickMatchDetailResponseDTO(
             **base_dto.model_dump(),
@@ -78,7 +88,7 @@ class GetQuickMatchUseCase:
             scoring_assignments=assignments_dto,
         )
 
-    async def _build_assignments(self, quick_match) -> list[ScoringAssignmentDTO]:
+    def _build_assignments(self, quick_match, users_by_id) -> list[ScoringAssignmentDTO]:
         if not quick_match.scorer_ids:
             return []
 
@@ -91,8 +101,7 @@ class GetQuickMatchUseCase:
         result = []
         for scorer_id, covered_ids in assignments.items():
             scorer = quick_match.find_participant(scorer_id)
-            async with self._user_uow:
-                user = await self._user_uow.users.find_by_id(scorer.user_id) if scorer else None
+            user = users_by_id.get(scorer.user_id) if scorer else None
             scorer_name = f"{user.first_name} {user.last_name}" if user else "Unknown"
             result.append(
                 ScoringAssignmentDTO(

--- a/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
+++ b/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
@@ -12,6 +12,7 @@ from src.modules.quick_match.application.mappers.quick_match_mapper import Quick
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
@@ -23,7 +24,8 @@ class RemoveParticipantUseCase:
     """
     Elimina a un participante de una partida rapida.
 
-    Autorizacion: el propio participante (leave) o el creador (kick).
+    Autorizacion: el propio participante registrado (leave) o el creador
+    (kick, unica via posible para eliminar a un invitado sin cuenta).
     """
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
@@ -32,7 +34,8 @@ class RemoveParticipantUseCase:
 
     async def execute(self, request: RemoveParticipantRequestDTO) -> QuickMatchResponseDTO:
         requester_id = UserId(request.requester_id)
-        target_id = UserId(request.target_user_id)
+        requester_participant_id = ParticipantId(requester_id.value)
+        target_participant_id = ParticipantId(request.target_participant_id)
 
         async with self._uow:
             quick_match = await self._uow.quick_matches.find_by_id(
@@ -41,12 +44,14 @@ class RemoveParticipantUseCase:
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 
-            if requester_id not in (target_id, quick_match.creator_id):
+            is_self_leave = requester_participant_id == target_participant_id
+            is_creator = quick_match.creator_id == requester_id
+            if not (is_self_leave or is_creator):
                 raise NotAuthorizedToRemoveError(
                     "Only the participant themselves or the creator can remove a participant."
                 )
 
-            quick_match.remove_participant(target_id)
+            quick_match.remove_participant(target_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
         return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
@@ -1,20 +1,24 @@
-"""Caso de Uso: Registrar/actualizar el score propio de un hoyo (anotadores)."""
+"""Caso de Uso: Registrar por delegacion el score de otro participante."""
 
 from src.modules.quick_match.application.dto.quick_match_dto import (
     HoleScoreResponseDTO,
-    SubmitHoleScoreRequestDTO,
+    SubmitProxyHoleScoreRequestDTO,
 )
 from src.modules.quick_match.application.exceptions import (
     NotAScorerError,
-    NotQuickMatchParticipantError,
     QuickMatchNotFoundError,
+    TargetParticipantNotFoundError,
 )
 from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     InvalidQuickMatchStatusViolation,
+    NotAssignedScorerViolation,
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
 )
 from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
@@ -25,22 +29,23 @@ from src.modules.quick_match.domain.value_objects.quick_match_status import Quic
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
-class SubmitQuickMatchHoleScoreUseCase:
+class SubmitProxyHoleScoreUseCase:
     """
-    Registra o actualiza el score propio de un jugador para un hoyo.
+    Registra el score de un hoyo en nombre de otro participante (invitado o
+    registrado no seleccionado como anotador).
 
-    Modelo simple (v1): sin validacion dual jugador/marcador. Solo un anotador
-    configurado (`scorer_ids`) puede registrar su propio score, y solo
-    mientras la partida esta IN_PROGRESS. Para registrar el score de otro
-    participante (invitado o no anotador), usar SubmitProxyHoleScoreUseCase.
+    Solo puede hacerlo el anotador al que ese participante le fue asignado
+    (segun el reparto calculado por ScoringCoverageService).
     """
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface):
         self._uow = uow
+        self._coverage_service = ScoringCoverageService()
 
-    async def execute(self, request: SubmitHoleScoreRequestDTO) -> HoleScoreResponseDTO:
-        player_id = UserId(request.player_user_id)
-        participant_id = ParticipantId(player_id.value)
+    async def execute(self, request: SubmitProxyHoleScoreRequestDTO) -> HoleScoreResponseDTO:
+        scorer_id = UserId(request.scorer_user_id)
+        scorer_participant_id = ParticipantId(scorer_id.value)
+        target_participant_id = ParticipantId(request.target_participant_id)
         quick_match_id = QuickMatchId(request.quick_match_id)
 
         async with self._uow:
@@ -48,28 +53,37 @@ class SubmitQuickMatchHoleScoreUseCase:
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 
-            if not quick_match.is_participant(participant_id):
-                raise NotQuickMatchParticipantError(
-                    "You are not a participant of this quick match."
-                )
-
             if quick_match.status != QuickMatchStatus.IN_PROGRESS:
                 raise InvalidQuickMatchStatusViolation(
                     "Scores can only be submitted while the quick match is IN_PROGRESS."
                 )
 
-            if not quick_match.is_scorer(participant_id):
-                raise NotAScorerError(
-                    "Only a configured scorer can self-report a hole score. "
-                    "Ask a scorer to record it for you."
+            if not quick_match.is_scorer(scorer_participant_id):
+                raise NotAScorerError("Only a configured scorer can record scores by proxy.")
+
+            if not quick_match.is_participant(target_participant_id):
+                raise TargetParticipantNotFoundError(
+                    f"{target_participant_id} is not a participant of this quick match."
+                )
+
+            assignments = self._coverage_service.compute_assignments(
+                participants=quick_match.participants,
+                scorer_ids=quick_match.scorer_ids,
+                creator_participant_id=quick_match.creator_participant_id,
+            )
+            if target_participant_id not in assignments.get(scorer_participant_id, []):
+                raise NotAssignedScorerViolation(
+                    f"{target_participant_id} is not assigned to this scorer."
                 )
 
             existing = await self._uow.quick_match_hole_scores.find_by_match_hole_and_participant(
-                quick_match_id, request.hole_number, participant_id
+                quick_match_id, request.hole_number, target_participant_id
             )
 
             if existing:
-                existing.update_score(request.score, recorded_by_participant_id=participant_id)
+                existing.update_score(
+                    request.score, recorded_by_participant_id=scorer_participant_id
+                )
                 await self._uow.quick_match_hole_scores.update(existing)
                 hole_score = existing
             else:
@@ -77,9 +91,9 @@ class SubmitQuickMatchHoleScoreUseCase:
                     id=QuickMatchHoleScoreId.generate(),
                     quick_match_id=quick_match_id,
                     hole_number=request.hole_number,
-                    participant_id=participant_id,
+                    participant_id=target_participant_id,
                     score=request.score,
-                    recorded_by_participant_id=participant_id,
+                    recorded_by_participant_id=scorer_participant_id,
                 )
                 await self._uow.quick_match_hole_scores.add(hole_score)
 

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -24,13 +24,17 @@ from ..exceptions.quick_match_violations import (
     DuplicateParticipantViolation,
     IncompleteRosterViolation,
     InvalidQuickMatchStatusViolation,
+    InvalidScorerConfigurationViolation,
     InvalidTeamAssignmentViolation,
     NotQuickMatchParticipantViolation,
     QuickMatchFullViolation,
 )
+from ..value_objects.participant_id import ParticipantId
 from ..value_objects.quick_match_id import QuickMatchId
 from ..value_objects.quick_match_participant import QuickMatchParticipant
 from ..value_objects.quick_match_status import QuickMatchStatus
+
+MAX_SCORERS = 4
 
 
 class QuickMatch:
@@ -38,14 +42,15 @@ class QuickMatch:
     Entidad QuickMatch (Aggregate Root) - Partida rapida entre amigos.
 
     Gestiona:
-    - Alta/baja de participantes mientras esta PENDING
-    - Inicio (roster completo) y finalizacion
+    - Alta/baja de participantes (registrados o invitados) mientras esta PENDING
+    - Inicio (roster completo + configuracion de anotadores) y finalizacion
     - Invariantes de capacidad por formato (SINGLES 1v1, FOURBALL/FOURSOMES 2v2)
 
     Invariantes:
-    - creator_id siempre es participante y nunca puede ser eliminado
+    - El participante del creador siempre existe y nunca puede ser eliminado
     - Solo PENDING permite añadir/quitar participantes
-    - start() exige el roster exacto del formato
+    - start() exige el roster exacto del formato y una configuracion de anotadores valida
+    - scorer_ids es siempre un subconjunto de participantes registrados que incluye al creador
     """
 
     def __init__(
@@ -56,6 +61,7 @@ class QuickMatch:
         match_format: MatchFormat,
         status: QuickMatchStatus,
         participants: list[QuickMatchParticipant],
+        scorer_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
@@ -66,6 +72,7 @@ class QuickMatch:
         self._match_format = match_format
         self._status = status
         self._participants = list(participants)
+        self._scorer_ids = list(scorer_ids) if scorer_ids else []
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
         self._domain_events: list[DomainEvent] = domain_events or []
@@ -85,6 +92,7 @@ class QuickMatch:
         """Factory method: crea una partida rapida con el creador como primer participante."""
         now = datetime.now()
         creator_team = None if match_format == MatchFormat.SINGLES else "A"
+        creator_participant = QuickMatchParticipant.for_user(creator_id, team=creator_team)
 
         quick_match = cls(
             id=id,
@@ -92,7 +100,7 @@ class QuickMatch:
             golf_course_id=golf_course_id,
             match_format=match_format,
             status=QuickMatchStatus.PENDING,
-            participants=[QuickMatchParticipant(user_id=creator_id, team=creator_team)],
+            participants=[creator_participant],
             created_at=now,
             updated_at=now,
         )
@@ -108,7 +116,7 @@ class QuickMatch:
         quick_match.add_domain_event(
             QuickMatchParticipantAddedEvent(
                 quick_match_id=str(quick_match._id),
-                user_id=str(creator_id),
+                participant_id=str(creator_participant.participant_id),
                 team=creator_team,
             )
         )
@@ -124,6 +132,7 @@ class QuickMatch:
         match_format: MatchFormat,
         status: QuickMatchStatus,
         participants: list[QuickMatchParticipant],
+        scorer_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ) -> "QuickMatch":
@@ -135,6 +144,7 @@ class QuickMatch:
             match_format=match_format,
             status=status,
             participants=participants,
+            scorer_ids=scorer_ids,
             created_at=created_at,
             updated_at=updated_at,
         )
@@ -150,6 +160,11 @@ class QuickMatch:
     @property
     def creator_id(self) -> UserId:
         return self._creator_id
+
+    @property
+    def creator_participant_id(self) -> ParticipantId:
+        """Derivado de creator_id — no se persiste como columna propia."""
+        return ParticipantId(self._creator_id.value)
 
     @property
     def golf_course_id(self) -> GolfCourseId:
@@ -168,6 +183,10 @@ class QuickMatch:
         return list(self._participants)
 
     @property
+    def scorer_ids(self) -> list[ParticipantId]:
+        return list(self._scorer_ids)
+
+    @property
     def created_at(self) -> datetime:
         return self._created_at
 
@@ -179,8 +198,17 @@ class QuickMatch:
     # METODOS DE CONSULTA (QUERIES)
     # ===========================================
 
-    def is_participant(self, user_id: UserId) -> bool:
-        return any(p.user_id == user_id for p in self._participants)
+    def is_participant(self, participant_id: ParticipantId) -> bool:
+        return any(p.participant_id == participant_id for p in self._participants)
+
+    def find_participant(self, participant_id: ParticipantId) -> QuickMatchParticipant | None:
+        for p in self._participants:
+            if p.participant_id == participant_id:
+                return p
+        return None
+
+    def is_scorer(self, participant_id: ParticipantId) -> bool:
+        return participant_id in self._scorer_ids
 
     def capacity(self) -> int:
         """Numero total de jugadores requeridos por el formato."""
@@ -189,6 +217,9 @@ class QuickMatch:
     def is_roster_complete(self) -> bool:
         return len(self._participants) == self.capacity()
 
+    def registered_participants(self) -> list[QuickMatchParticipant]:
+        return [p for p in self._participants if not p.is_guest]
+
     def _team_count(self, team: str) -> int:
         return sum(1 for p in self._participants if p.team == team)
 
@@ -196,16 +227,16 @@ class QuickMatch:
     # METODOS DE COMANDO (CAMBIOS DE ESTADO)
     # ===========================================
 
-    def add_participant(self, user_id: UserId, team: str | None = None) -> None:
-        """Añade un participante mientras la partida esta PENDING."""
+    def add_participant(self, participant: QuickMatchParticipant) -> None:
+        """Añade un participante (registrado o invitado) mientras la partida esta PENDING."""
         if not self._status.is_pending():
             raise InvalidQuickMatchStatusViolation(
                 f"Cannot add participants to a quick match in status {self._status.value}."
             )
 
-        if self.is_participant(user_id):
+        if self.is_participant(participant.participant_id):
             raise DuplicateParticipantViolation(
-                f"User {user_id} is already a participant of this quick match."
+                f"{participant.participant_id} is already a participant of this quick match."
             )
 
         if len(self._participants) >= self.capacity():
@@ -213,6 +244,7 @@ class QuickMatch:
                 f"Quick match already has the maximum of {self.capacity()} participants."
             )
 
+        team = participant.team
         if self._match_format == MatchFormat.SINGLES:
             if team is not None:
                 raise InvalidTeamAssignmentViolation("SINGLES matches do not use teams.")
@@ -225,42 +257,54 @@ class QuickMatch:
         now = datetime.now()
         # Reasignar (no `.append()` in-place) para que SQLAlchemy detecte el cambio
         # en la columna JSONB `participants` al hacer flush/commit.
-        self._participants = [*self._participants, QuickMatchParticipant(user_id=user_id, team=team)]
+        self._participants = [*self._participants, participant]
         self._updated_at = now
 
         self.add_domain_event(
             QuickMatchParticipantAddedEvent(
-                quick_match_id=str(self._id), user_id=str(user_id), team=team
+                quick_match_id=str(self._id),
+                participant_id=str(participant.participant_id),
+                team=team,
             )
         )
 
-    def remove_participant(self, user_id: UserId) -> None:
+    def remove_participant(self, participant_id: ParticipantId) -> None:
         """Elimina un participante mientras la partida esta PENDING."""
         if not self._status.is_pending():
             raise InvalidQuickMatchStatusViolation(
                 f"Cannot remove participants from a quick match in status {self._status.value}."
             )
 
-        if user_id == self._creator_id:
+        if participant_id == self.creator_participant_id:
             raise CreatorCannotBeRemovedViolation(
                 "The creator cannot be removed; cancel the quick match instead."
             )
 
-        if not self.is_participant(user_id):
+        if not self.is_participant(participant_id):
             raise NotQuickMatchParticipantViolation(
-                f"User {user_id} is not a participant of this quick match."
+                f"{participant_id} is not a participant of this quick match."
             )
 
         now = datetime.now()
-        self._participants = [p for p in self._participants if p.user_id != user_id]
+        self._participants = [p for p in self._participants if p.participant_id != participant_id]
         self._updated_at = now
 
         self.add_domain_event(
-            QuickMatchParticipantRemovedEvent(quick_match_id=str(self._id), user_id=str(user_id))
+            QuickMatchParticipantRemovedEvent(
+                quick_match_id=str(self._id), participant_id=str(participant_id)
+            )
         )
 
-    def start(self) -> None:
-        """Inicia la partida (PENDING -> IN_PROGRESS). Exige el roster completo."""
+    def start(self, scorer_ids: list[ParticipantId]) -> None:
+        """
+        Inicia la partida (PENDING -> IN_PROGRESS).
+
+        Exige el roster completo y una configuracion de anotadores valida:
+        - Entre 1 y 4 anotadores.
+        - Todos deben ser participantes registrados (no invitados).
+        - El creador debe estar siempre incluido.
+        - No puede haber mas anotadores que participantes registrados.
+        """
         if not self._status.can_transition_to(QuickMatchStatus.IN_PROGRESS):
             raise InvalidQuickMatchStatusViolation(
                 f"Cannot start a quick match in status {self._status.value}."
@@ -272,11 +316,38 @@ class QuickMatch:
                 f"({len(self._participants)} currently)."
             )
 
+        self._validate_scorer_ids(scorer_ids)
+
         now = datetime.now()
         self._status = QuickMatchStatus.IN_PROGRESS
+        self._scorer_ids = list(scorer_ids)
         self._updated_at = now
 
         self.add_domain_event(QuickMatchStartedEvent(quick_match_id=str(self._id)))
+
+    def _validate_scorer_ids(self, scorer_ids: list[ParticipantId]) -> None:
+        if not (1 <= len(scorer_ids) <= MAX_SCORERS):
+            raise InvalidScorerConfigurationViolation(
+                f"scorer_ids must contain between 1 and {MAX_SCORERS} participants."
+            )
+
+        if len(set(scorer_ids)) != len(scorer_ids):
+            raise InvalidScorerConfigurationViolation("scorer_ids cannot contain duplicates.")
+
+        if self.creator_participant_id not in scorer_ids:
+            raise InvalidScorerConfigurationViolation("The creator must always be a scorer.")
+
+        registered_ids = {p.participant_id for p in self.registered_participants()}
+        for sid in scorer_ids:
+            if sid not in registered_ids:
+                raise InvalidScorerConfigurationViolation(
+                    f"{sid} is not a registered participant and cannot be a scorer."
+                )
+
+        if len(scorer_ids) > len(registered_ids):
+            raise InvalidScorerConfigurationViolation(
+                "scorer_ids cannot exceed the number of registered participants."
+            )
 
     def complete(self) -> None:
         """Finaliza la partida (IN_PROGRESS -> COMPLETED)."""

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -344,11 +344,6 @@ class QuickMatch:
                     f"{sid} is not a registered participant and cannot be a scorer."
                 )
 
-        if len(scorer_ids) > len(registered_ids):
-            raise InvalidScorerConfigurationViolation(
-                "scorer_ids cannot exceed the number of registered participants."
-            )
-
     def complete(self) -> None:
         """Finaliza la partida (IN_PROGRESS -> COMPLETED)."""
         if not self._status.can_transition_to(QuickMatchStatus.COMPLETED):

--- a/src/modules/quick_match/domain/entities/quick_match_hole_score.py
+++ b/src/modules/quick_match/domain/entities/quick_match_hole_score.py
@@ -1,15 +1,17 @@
 """
-QuickMatchHoleScore Entity - Score de un jugador en un hoyo de una partida rapida.
+QuickMatchHoleScore Entity - Score de un participante en un hoyo de una partida rapida.
 
-Modelo simple (v1): un unico score por jugador y hoyo, sin validacion dual
-jugador/marcador (a diferencia de HoleScore en el modulo competition).
+Modelo simple (v1): un unico score por participante y hoyo, sin validacion dual
+jugador/marcador (a diferencia de HoleScore en el modulo competition). Se
+registra ademas quien lo introdujo (`recorded_by_participant_id`), ya que un
+anotador puede registrar el score de otro participante (invitado o registrado
+que no esta anotando en esta partida).
 """
 
 from datetime import datetime
 
-from src.modules.user.domain.value_objects.user_id import UserId
-
 from ..exceptions.quick_match_violations import InvalidHoleScoreViolation
+from ..value_objects.participant_id import ParticipantId
 from ..value_objects.quick_match_hole_score_id import QuickMatchHoleScoreId
 from ..value_objects.quick_match_id import QuickMatchId
 
@@ -21,7 +23,7 @@ MAX_HOLE_NUMBER = 18
 
 class QuickMatchHoleScore:
     """
-    Entidad QuickMatchHoleScore - Score de un jugador en un hoyo concreto.
+    Entidad QuickMatchHoleScore - Score de un participante en un hoyo concreto.
 
     Invariantes:
     - hole_number entre 1 y 18
@@ -33,8 +35,9 @@ class QuickMatchHoleScore:
         id: QuickMatchHoleScoreId,
         quick_match_id: QuickMatchId,
         hole_number: int,
-        player_user_id: UserId,
+        participant_id: ParticipantId,
         score: int,
+        recorded_by_participant_id: ParticipantId,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ):
@@ -44,8 +47,9 @@ class QuickMatchHoleScore:
         self._id = id
         self._quick_match_id = quick_match_id
         self._hole_number = hole_number
-        self._player_user_id = player_user_id
+        self._participant_id = participant_id
         self._score = score
+        self._recorded_by_participant_id = recorded_by_participant_id
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
 
@@ -71,16 +75,18 @@ class QuickMatchHoleScore:
         id: QuickMatchHoleScoreId,
         quick_match_id: QuickMatchId,
         hole_number: int,
-        player_user_id: UserId,
+        participant_id: ParticipantId,
         score: int,
+        recorded_by_participant_id: ParticipantId,
     ) -> "QuickMatchHoleScore":
         now = datetime.now()
         return cls(
             id=id,
             quick_match_id=quick_match_id,
             hole_number=hole_number,
-            player_user_id=player_user_id,
+            participant_id=participant_id,
             score=score,
+            recorded_by_participant_id=recorded_by_participant_id,
             created_at=now,
             updated_at=now,
         )
@@ -91,8 +97,9 @@ class QuickMatchHoleScore:
         id: QuickMatchHoleScoreId,
         quick_match_id: QuickMatchId,
         hole_number: int,
-        player_user_id: UserId,
+        participant_id: ParticipantId,
         score: int,
+        recorded_by_participant_id: ParticipantId,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ) -> "QuickMatchHoleScore":
@@ -100,8 +107,9 @@ class QuickMatchHoleScore:
             id=id,
             quick_match_id=quick_match_id,
             hole_number=hole_number,
-            player_user_id=player_user_id,
+            participant_id=participant_id,
             score=score,
+            recorded_by_participant_id=recorded_by_participant_id,
             created_at=created_at,
             updated_at=updated_at,
         )
@@ -123,12 +131,16 @@ class QuickMatchHoleScore:
         return self._hole_number
 
     @property
-    def player_user_id(self) -> UserId:
-        return self._player_user_id
+    def participant_id(self) -> ParticipantId:
+        return self._participant_id
 
     @property
     def score(self) -> int:
         return self._score
+
+    @property
+    def recorded_by_participant_id(self) -> ParticipantId:
+        return self._recorded_by_participant_id
 
     @property
     def created_at(self) -> datetime:
@@ -142,10 +154,11 @@ class QuickMatchHoleScore:
     # METODOS DE COMANDO
     # ===========================================
 
-    def update_score(self, score: int) -> None:
+    def update_score(self, score: int, recorded_by_participant_id: ParticipantId) -> None:
         """Actualiza el score (upsert desde el use case)."""
         self._validate_score(score)
         self._score = score
+        self._recorded_by_participant_id = recorded_by_participant_id
         self._updated_at = datetime.now()
 
     # ===========================================

--- a/src/modules/quick_match/domain/events/quick_match_participant_added_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_participant_added_event.py
@@ -10,5 +10,5 @@ class QuickMatchParticipantAddedEvent(DomainEvent):
     """Evento emitido cuando se añade un participante a una partida rapida."""
 
     quick_match_id: str
-    user_id: str
+    participant_id: str
     team: str | None

--- a/src/modules/quick_match/domain/events/quick_match_participant_removed_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_participant_removed_event.py
@@ -10,4 +10,4 @@ class QuickMatchParticipantRemovedEvent(DomainEvent):
     """Evento emitido cuando se elimina un participante de una partida rapida."""
 
     quick_match_id: str
-    user_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/exceptions/quick_match_violations.py
+++ b/src/modules/quick_match/domain/exceptions/quick_match_violations.py
@@ -53,3 +53,15 @@ class InvalidHoleScoreViolation(BusinessRuleViolation):
     """El score de hoyo indicado no es valido."""
 
     pass
+
+
+class InvalidScorerConfigurationViolation(BusinessRuleViolation):
+    """La configuracion de anotadores (scorer_ids) no es valida."""
+
+    pass
+
+
+class NotAssignedScorerViolation(BusinessRuleViolation):
+    """El usuario no es el anotador asignado para registrar este score."""
+
+    pass

--- a/src/modules/quick_match/domain/repositories/quick_match_hole_score_repository_interface.py
+++ b/src/modules/quick_match/domain/repositories/quick_match_hole_score_repository_interface.py
@@ -4,9 +4,8 @@ QuickMatchHoleScore Repository Interface - Domain Layer.
 
 from abc import ABC, abstractmethod
 
-from src.modules.user.domain.value_objects.user_id import UserId
-
 from ..entities.quick_match_hole_score import QuickMatchHoleScore
+from ..value_objects.participant_id import ParticipantId
 from ..value_objects.quick_match_hole_score_id import QuickMatchHoleScoreId
 from ..value_objects.quick_match_id import QuickMatchId
 
@@ -29,10 +28,10 @@ class QuickMatchHoleScoreRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    async def find_by_match_hole_and_player(
-        self, quick_match_id: QuickMatchId, hole_number: int, player_user_id: UserId
+    async def find_by_match_hole_and_participant(
+        self, quick_match_id: QuickMatchId, hole_number: int, participant_id: ParticipantId
     ) -> QuickMatchHoleScore | None:
-        """Busca el score de un jugador en un hoyo concreto (para upsert)."""
+        """Busca el score de un participante en un hoyo concreto (para upsert)."""
         pass
 
     @abstractmethod

--- a/src/modules/quick_match/domain/services/scoring_coverage_service.py
+++ b/src/modules/quick_match/domain/services/scoring_coverage_service.py
@@ -1,0 +1,58 @@
+"""
+ScoringCoverageService - Domain Service.
+
+Calcula el reparto de "quien anota a quien" en una partida rapida cuando no
+todos los participantes tienen la app (invitados, o registrados que no van
+a anotar en esa partida concreta).
+
+Es puro (sin dependencias de framework ni IO).
+
+Reglas (confirmadas con el usuario):
+- El creador es siempre uno de los anotadores.
+- El reparto de no-anotadores entre anotadores es lo mas uniforme posible.
+- El sobrante de un reparto no exacto lo absorbe el creador.
+"""
+
+from ..value_objects.participant_id import ParticipantId
+from ..value_objects.quick_match_participant import QuickMatchParticipant
+
+
+class ScoringCoverageService:
+    """Servicio de dominio para el reparto de anotacion en partidas rapidas."""
+
+    def compute_assignments(
+        self,
+        participants: list[QuickMatchParticipant],
+        scorer_ids: list[ParticipantId],
+        creator_participant_id: ParticipantId,
+    ) -> dict[ParticipantId, list[ParticipantId]]:
+        """
+        Calcula que participantes cubre cada anotador.
+
+        Cada anotador se cubre siempre a si mismo. Los participantes que no
+        son anotadores (invitados o registrados no seleccionados) se
+        reparten a partes iguales (division entera) entre TODOS los
+        anotadores, incluido el creador; el sobrante de una division no
+        exacta lo absorbe el creador.
+
+        Returns:
+            Dict {scorer_participant_id: [participant_ids cubiertos]}
+        """
+        all_ids = [p.participant_id for p in participants]
+        non_scorer_ids = [pid for pid in all_ids if pid not in scorer_ids]
+
+        assignments: dict[ParticipantId, list[ParticipantId]] = {sid: [sid] for sid in scorer_ids}
+
+        n_scorers = len(scorer_ids)
+        base = len(non_scorer_ids) // n_scorers
+        remainder = len(non_scorer_ids) % n_scorers
+
+        idx = 0
+        for scorer_id in scorer_ids:
+            assignments[scorer_id].extend(non_scorer_ids[idx : idx + base])
+            idx += base
+
+        if remainder:
+            assignments[creator_participant_id].extend(non_scorer_ids[idx:])
+
+        return assignments

--- a/src/modules/quick_match/domain/services/scoring_coverage_service.py
+++ b/src/modules/quick_match/domain/services/scoring_coverage_service.py
@@ -13,6 +13,7 @@ Reglas (confirmadas con el usuario):
 - El sobrante de un reparto no exacto lo absorbe el creador.
 """
 
+from ..exceptions.quick_match_violations import InvalidScorerConfigurationViolation
 from ..value_objects.participant_id import ParticipantId
 from ..value_objects.quick_match_participant import QuickMatchParticipant
 
@@ -38,6 +39,11 @@ class ScoringCoverageService:
         Returns:
             Dict {scorer_participant_id: [participant_ids cubiertos]}
         """
+        if creator_participant_id not in scorer_ids:
+            raise InvalidScorerConfigurationViolation(
+                "creator_participant_id must be included in scorer_ids."
+            )
+
         all_ids = [p.participant_id for p in participants]
         non_scorer_ids = [pid for pid in all_ids if pid not in scorer_ids]
 

--- a/src/modules/quick_match/domain/value_objects/participant_id.py
+++ b/src/modules/quick_match/domain/value_objects/participant_id.py
@@ -1,0 +1,51 @@
+"""
+ParticipantId Value Object - Identificador unico de un participante de partida rapida.
+
+Comun a participantes registrados (coincide con su UserId) e invitados
+(generado, sin cuenta de usuario asociada).
+"""
+
+import uuid
+from dataclasses import dataclass
+
+
+class InvalidParticipantIdError(Exception):
+    """Excepcion lanzada cuando un ParticipantId no es valido."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class ParticipantId:
+    """Value Object para identificadores unicos de participante."""
+
+    value: uuid.UUID
+
+    def __init__(self, value: uuid.UUID | str):
+        val = None
+        if isinstance(value, uuid.UUID):
+            val = value
+        elif isinstance(value, str):
+            try:
+                val = uuid.UUID(value)
+            except ValueError as e:
+                raise InvalidParticipantIdError(f"'{value}' no es un string UUID valido") from e
+        else:
+            raise InvalidParticipantIdError(
+                f"Se esperaba un UUID o un string, pero se recibio {type(value).__name__}"
+            )
+
+        object.__setattr__(self, "value", val)
+
+    @classmethod
+    def generate(cls) -> "ParticipantId":
+        return cls(uuid.uuid4())
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ParticipantId) and self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)

--- a/src/modules/quick_match/domain/value_objects/quick_match_participant.py
+++ b/src/modules/quick_match/domain/value_objects/quick_match_participant.py
@@ -45,6 +45,8 @@ class QuickMatchParticipant:
         if self.user_id is not None:
             if self.first_name is not None or self.last_name is not None:
                 raise ValueError("Un participante registrado no lleva first_name/last_name.")
+            if self.handicap is not None:
+                raise ValueError("Un participante registrado no lleva handicap manual.")
         else:
             if not self.first_name or not self.first_name.strip():
                 raise ValueError("Un participante invitado requiere first_name.")

--- a/src/modules/quick_match/domain/value_objects/quick_match_participant.py
+++ b/src/modules/quick_match/domain/value_objects/quick_match_participant.py
@@ -1,12 +1,24 @@
 """
 QuickMatchParticipant Value Object - Participante de una partida rapida.
+
+Admite dos variantes:
+- Registrado: tiene `user_id`, sin datos manuales.
+- Invitado: sin cuenta, con nombre/apellidos y handicap introducidos a mano.
+
+Ambas comparten `participant_id` como identificador estable (coincide con
+`user_id.value` para registrados; generado para invitados), usado para
+listar, eliminar y asignar anotador independientemente del tipo.
 """
 
 from dataclasses import dataclass
 
 from src.modules.user.domain.value_objects.user_id import UserId
 
+from .participant_id import ParticipantId
+
 VALID_TEAMS = {"A", "B"}
+MIN_HANDICAP = -10.0
+MAX_HANDICAP = 54.0
 
 
 @dataclass(frozen=True)
@@ -14,19 +26,73 @@ class QuickMatchParticipant:
     """
     Value Object que representa a un jugador dentro de una partida rapida.
 
-    - `team` es None para SINGLES (no hay equipos).
-    - `team` es "A" o "B" para FOURBALL/FOURSOMES.
+    - `team` es None para SINGLES (no hay equipos), "A" o "B" para FOURBALL/FOURSOMES.
+    - Registrado: `user_id` presente, `first_name`/`last_name`/`handicap` None.
+    - Invitado: `user_id` None, `first_name`/`last_name` obligatorios, `handicap` opcional.
     """
 
-    user_id: UserId
+    participant_id: ParticipantId
+    user_id: UserId | None
+    first_name: str | None
+    last_name: str | None
+    handicap: float | None
     team: str | None = None
 
     def __post_init__(self):
         if self.team is not None and self.team not in VALID_TEAMS:
             raise ValueError(f"team debe ser 'A', 'B' o None, recibido: {self.team!r}")
 
+        if self.user_id is not None:
+            if self.first_name is not None or self.last_name is not None:
+                raise ValueError("Un participante registrado no lleva first_name/last_name.")
+        else:
+            if not self.first_name or not self.first_name.strip():
+                raise ValueError("Un participante invitado requiere first_name.")
+            if not self.last_name or not self.last_name.strip():
+                raise ValueError("Un participante invitado requiere last_name.")
+
+        if self.handicap is not None and not (MIN_HANDICAP <= self.handicap <= MAX_HANDICAP):
+            raise ValueError(f"handicap debe estar entre {MIN_HANDICAP} y {MAX_HANDICAP}.")
+
+    @property
+    def is_guest(self) -> bool:
+        return self.user_id is None
+
+    @classmethod
+    def for_user(cls, user_id: UserId, team: str | None = None) -> "QuickMatchParticipant":
+        """Crea un participante registrado (identificado por su UserId)."""
+        return cls(
+            participant_id=ParticipantId(user_id.value),
+            user_id=user_id,
+            first_name=None,
+            last_name=None,
+            handicap=None,
+            team=team,
+        )
+
+    @classmethod
+    def for_guest(
+        cls,
+        first_name: str,
+        last_name: str,
+        handicap: float | None = None,
+        team: str | None = None,
+    ) -> "QuickMatchParticipant":
+        """Crea un participante invitado (sin cuenta de usuario)."""
+        return cls(
+            participant_id=ParticipantId.generate(),
+            user_id=None,
+            first_name=first_name.strip(),
+            last_name=last_name.strip(),
+            handicap=handicap,
+            team=team,
+        )
+
     def __eq__(self, other) -> bool:
-        return isinstance(other, QuickMatchParticipant) and self.user_id == other.user_id
+        return (
+            isinstance(other, QuickMatchParticipant)
+            and self.participant_id == other.participant_id
+        )
 
     def __hash__(self) -> int:
-        return hash(self.user_id)
+        return hash(self.participant_id)

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -9,7 +9,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from src.config.dependencies import (
     get_add_friend_to_quick_match_use_case,
@@ -135,6 +135,13 @@ class StartQuickMatchBody(BaseModel):
     """Body para iniciar la partida, indicando quien va a anotar (1 a 4)."""
 
     scorer_ids: list[UUID] = Field(..., min_length=1, max_length=MAX_SCORERS)
+
+    @field_validator("scorer_ids")
+    @classmethod
+    def _unique_scorer_ids(cls, v: list[UUID]) -> list[UUID]:
+        if len(set(v)) != len(v):
+            raise ValueError("scorer_ids must not contain duplicates.")
+        return v
 
 
 class SubmitHoleScoreBody(BaseModel):

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 from src.config.dependencies import (
     get_add_friend_to_quick_match_use_case,
+    get_add_guest_to_quick_match_use_case,
     get_cancel_quick_match_use_case,
     get_complete_quick_match_use_case,
     get_create_quick_match_use_case,
@@ -21,9 +22,11 @@ from src.config.dependencies import (
     get_remove_quick_match_participant_use_case,
     get_start_quick_match_use_case,
     get_submit_quick_match_hole_score_use_case,
+    get_submit_quick_match_proxy_hole_score_use_case,
 )
 from src.config.rate_limit import limiter
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    AddGuestParticipantRequestDTO,
     AddParticipantRequestDTO,
     CreateQuickMatchRequestDTO,
     HoleScoreResponseDTO,
@@ -31,20 +34,27 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     QuickMatchDetailResponseDTO,
     QuickMatchResponseDTO,
     RemoveParticipantRequestDTO,
+    StartQuickMatchRequestDTO,
     SubmitHoleScoreRequestDTO,
+    SubmitProxyHoleScoreRequestDTO,
 )
 from src.modules.quick_match.application.exceptions import (
     FriendUserNotFoundError,
     GolfCourseNotApprovedError,
     GolfCourseNotFoundError,
+    NotAScorerError,
     NotAuthorizedToRemoveError,
     NotFriendsError,
     NotQuickMatchCreatorError,
     NotQuickMatchParticipantError,
     QuickMatchNotFoundError,
+    TargetParticipantNotFoundError,
 )
 from src.modules.quick_match.application.use_cases.add_friend_to_quick_match_use_case import (
     AddFriendToQuickMatchUseCase,
+)
+from src.modules.quick_match.application.use_cases.add_guest_to_quick_match_use_case import (
+    AddGuestToQuickMatchUseCase,
 )
 from src.modules.quick_match.application.use_cases.cancel_quick_match_use_case import (
     CancelQuickMatchUseCase,
@@ -70,13 +80,18 @@ from src.modules.quick_match.application.use_cases.start_quick_match_use_case im
 from src.modules.quick_match.application.use_cases.submit_hole_score_use_case import (
     SubmitQuickMatchHoleScoreUseCase,
 )
+from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
+    SubmitProxyHoleScoreUseCase,
+)
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
     DuplicateParticipantViolation,
     IncompleteRosterViolation,
     InvalidHoleScoreViolation,
     InvalidQuickMatchStatusViolation,
+    InvalidScorerConfigurationViolation,
     InvalidTeamAssignmentViolation,
+    NotAssignedScorerViolation,
     QuickMatchFullViolation,
 )
 from src.modules.user.application.dto.user_dto import UserResponseDTO
@@ -102,6 +117,21 @@ class AddParticipantBody(BaseModel):
 
     friend_user_id: UUID
     team: str | None = Field(None, pattern="^(A|B)$")
+
+
+class AddGuestParticipantBody(BaseModel):
+    """Body para añadir a mano un jugador invitado (sin cuenta)."""
+
+    first_name: str = Field(..., min_length=1, max_length=100)
+    last_name: str = Field(..., min_length=1, max_length=100)
+    handicap: float | None = Field(None, ge=-10.0, le=54.0)
+    team: str | None = Field(None, pattern="^(A|B)$")
+
+
+class StartQuickMatchBody(BaseModel):
+    """Body para iniciar la partida, indicando quien va a anotar (1 a 4)."""
+
+    scorer_ids: list[UUID] = Field(..., min_length=1, max_length=4)
 
 
 class SubmitHoleScoreBody(BaseModel):
@@ -181,15 +211,54 @@ async def add_participant(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
 
 
+@router.post(
+    "/quick-matches/{quick_match_id}/participants/guest",
+    response_model=QuickMatchResponseDTO,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add guest to quick match",
+    description=(
+        "Creator adds a guest player (no account) by entering their name and handicap. "
+        "Their scores will be recorded by an assigned scorer once the match starts."
+    ),
+)
+async def add_guest_participant(
+    quick_match_id: UUID,
+    body: AddGuestParticipantBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AddGuestToQuickMatchUseCase = Depends(get_add_guest_to_quick_match_use_case),
+):
+    try:
+        request_dto = AddGuestParticipantRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+            first_name=body.first_name,
+            last_name=body.last_name,
+            handicap=body.handicap,
+            team=body.team,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except DuplicateParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except (QuickMatchFullViolation, InvalidTeamAssignmentViolation) as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+    except InvalidQuickMatchStatusViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
 @router.delete(
-    "/quick-matches/{quick_match_id}/participants/{target_user_id}",
+    "/quick-matches/{quick_match_id}/participants/{target_participant_id}",
     response_model=QuickMatchResponseDTO,
     summary="Remove participant",
-    description="Removes a participant (self-leave or creator kick).",
+    description="Removes a participant (self-leave for registered players, or creator kick).",
 )
 async def remove_participant(
     quick_match_id: UUID,
-    target_user_id: UUID,
+    target_participant_id: UUID,
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: RemoveParticipantUseCase = Depends(get_remove_quick_match_participant_use_case),
 ):
@@ -197,7 +266,7 @@ async def remove_participant(
         request_dto = RemoveParticipantRequestDTO(
             quick_match_id=quick_match_id,
             requester_id=current_user.id,
-            target_user_id=target_user_id,
+            target_participant_id=target_participant_id,
         )
         return await use_case.execute(request_dto)
 
@@ -215,21 +284,32 @@ async def remove_participant(
     "/quick-matches/{quick_match_id}/start",
     response_model=QuickMatchResponseDTO,
     summary="Start quick match",
-    description="Creator starts the quick match once the roster is complete.",
+    description=(
+        "Creator starts the quick match once the roster is complete, choosing between "
+        "1 and 4 registered participants (always including the creator) as scorers."
+    ),
 )
 async def start_quick_match(
     quick_match_id: UUID,
+    body: StartQuickMatchBody,
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: StartQuickMatchUseCase = Depends(get_start_quick_match_use_case),
 ):
     try:
-        return await use_case.execute(str(quick_match_id), str(current_user.id))
+        request_dto = StartQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+            scorer_ids=body.scorer_ids,
+        )
+        return await use_case.execute(request_dto)
 
     except QuickMatchNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except NotQuickMatchCreatorError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except IncompleteRosterViolation as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+    except InvalidScorerConfigurationViolation as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
@@ -282,8 +362,8 @@ async def cancel_quick_match(
 @router.post(
     "/quick-matches/{quick_match_id}/holes/{hole_number}/score",
     response_model=HoleScoreResponseDTO,
-    summary="Submit hole score",
-    description="Registers/updates the current user's own score for a hole (simple model).",
+    summary="Submit own hole score",
+    description="Registers/updates the current user's own score for a hole. Scorers only.",
 )
 async def submit_hole_score(
     quick_match_id: UUID,
@@ -304,6 +384,52 @@ async def submit_hole_score(
     except QuickMatchNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except NotQuickMatchParticipantError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except NotAScorerError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except InvalidQuickMatchStatusViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except InvalidHoleScoreViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+@router.post(
+    "/quick-matches/{quick_match_id}/participants/{target_participant_id}/holes/{hole_number}/score",
+    response_model=HoleScoreResponseDTO,
+    summary="Submit hole score by proxy",
+    description=(
+        "Records a hole score on behalf of another participant (guest, or registered "
+        "player not selected as a scorer). Only the scorer assigned to that "
+        "participant may do this."
+    ),
+)
+async def submit_proxy_hole_score(
+    quick_match_id: UUID,
+    target_participant_id: UUID,
+    hole_number: int,
+    body: SubmitHoleScoreBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: SubmitProxyHoleScoreUseCase = Depends(
+        get_submit_quick_match_proxy_hole_score_use_case
+    ),
+):
+    try:
+        request_dto = SubmitProxyHoleScoreRequestDTO(
+            quick_match_id=quick_match_id,
+            scorer_user_id=current_user.id,
+            target_participant_id=target_participant_id,
+            hole_number=hole_number,
+            score=body.score,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TargetParticipantNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotAScorerError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except NotAssignedScorerViolation as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
@@ -333,7 +459,10 @@ async def list_my_quick_matches(
     "/quick-matches/{quick_match_id}",
     response_model=QuickMatchDetailResponseDTO,
     summary="Get quick match detail",
-    description="Returns quick match detail, hole scores, and computed match standing.",
+    description=(
+        "Returns quick match detail, hole scores, computed match standing, and the "
+        "scorer coverage assignments (who records for whom)."
+    ),
 )
 async def get_quick_match(
     quick_match_id: UUID,

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -27,6 +27,7 @@ from src.config.dependencies import (
 )
 from src.config.rate_limit import limiter
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    MAX_SCORERS,
     AddGuestParticipantRequestDTO,
     AddParticipantRequestDTO,
     CreateQuickMatchRequestDTO,
@@ -133,7 +134,7 @@ class AddGuestParticipantBody(BaseModel):
 class StartQuickMatchBody(BaseModel):
     """Body para iniciar la partida, indicando quien va a anotar (1 a 4)."""
 
-    scorer_ids: list[UUID] = Field(..., min_length=1, max_length=4)
+    scorer_ids: list[UUID] = Field(..., min_length=1, max_length=MAX_SCORERS)
 
 
 class SubmitHoleScoreBody(BaseModel):
@@ -410,7 +411,7 @@ async def submit_hole_score(
 async def submit_proxy_hole_score(
     quick_match_id: UUID,
     target_participant_id: UUID,
-    hole_number: int,
+    hole_number: Annotated[int, Path(ge=1, le=18)],
     body: SubmitHoleScoreBody,
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: SubmitProxyHoleScoreUseCase = Depends(

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_hole_score_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_hole_score_repository.py
@@ -4,11 +4,11 @@ from src.modules.quick_match.domain.entities.quick_match_hole_score import Quick
 from src.modules.quick_match.domain.repositories.quick_match_hole_score_repository_interface import (
     QuickMatchHoleScoreRepositoryInterface,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
     QuickMatchHoleScoreId,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
-from src.modules.user.domain.value_objects.user_id import UserId
 
 
 class InMemoryQuickMatchHoleScoreRepository(QuickMatchHoleScoreRepositoryInterface):
@@ -29,14 +29,14 @@ class InMemoryQuickMatchHoleScoreRepository(QuickMatchHoleScoreRepositoryInterfa
     ) -> QuickMatchHoleScore | None:
         return self._hole_scores.get(hole_score_id)
 
-    async def find_by_match_hole_and_player(
-        self, quick_match_id: QuickMatchId, hole_number: int, player_user_id: UserId
+    async def find_by_match_hole_and_participant(
+        self, quick_match_id: QuickMatchId, hole_number: int, participant_id: ParticipantId
     ) -> QuickMatchHoleScore | None:
         for hs in self._hole_scores.values():
             if (
                 hs.quick_match_id == quick_match_id
                 and hs.hole_number == hole_number
-                and hs.player_user_id == player_user_id
+                and hs.participant_id == participant_id
             ):
                 return hs
         return None

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -4,6 +4,7 @@ from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.repositories.quick_match_repository_interface import (
     QuickMatchRepositoryInterface,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -35,7 +36,7 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         results = [
             qm
             for qm in self._quick_matches.values()
-            if qm.is_participant(user_id) and (status is None or qm.status == status)
+            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
         ]
         results.sort(key=lambda x: x.created_at, reverse=True)
         return results[offset : offset + limit]
@@ -46,5 +47,5 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         return sum(
             1
             for qm in self._quick_matches.values()
-            if qm.is_participant(user_id) and (status is None or qm.status == status)
+            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
         )

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -2,7 +2,7 @@
 SQLAlchemy Mapper for QuickMatch aggregate (QuickMatch module).
 
 Tablas:
-- quick_matches (agregado raiz; participantes como JSONB embebido)
+- quick_matches (agregado raiz; participantes y scorer_ids como JSONB embebido)
 - quick_match_hole_scores (scores por hoyo, modelo simple sin validacion dual)
 """
 
@@ -18,6 +18,7 @@ from src.modules.competition.domain.value_objects.match_format import MatchForma
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
     QuickMatchHoleScoreId,
 )
@@ -70,6 +71,25 @@ class QuickMatchHoleScoreIdType(sqlalchemy.types.TypeDecorator[QuickMatchHoleSco
         if value is None:
             return None
         return QuickMatchHoleScoreId(value)
+
+
+class ParticipantIdType(sqlalchemy.types.TypeDecorator[ParticipantId]):
+    """TypeDecorator para ParticipantId Value Object."""
+
+    impl = UUID(as_uuid=True)
+    cache_ok = True
+
+    def process_bind_param(self, value: ParticipantId | None, dialect: Any) -> uuid.UUID | None:
+        if value is None:
+            return None
+        return value.value
+
+    def process_result_value(
+        self, value: uuid.UUID | None, dialect: Any
+    ) -> ParticipantId | None:
+        if value is None:
+            return None
+        return ParticipantId(value)
 
 
 class QuickMatchUserIdType(sqlalchemy.types.TypeDecorator[UserId]):
@@ -153,7 +173,14 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
     TypeDecorator para serializar list[QuickMatchParticipant] a/desde JSONB.
 
     Cada QuickMatchParticipant se serializa como:
-    {"user_id": "uuid-string", "team": "A" | "B" | null}
+    {
+        "participant_id": "uuid-string",
+        "user_id": "uuid-string" | null,       # null para invitados
+        "first_name": "..." | null,             # solo invitados
+        "last_name": "..." | null,              # solo invitados
+        "handicap": number | null,              # solo invitados (opcional)
+        "team": "A" | "B" | null
+    }
     """
 
     impl = JSONB
@@ -162,15 +189,51 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
     def process_bind_param(self, value: list | None, dialect: Any) -> list | None:
         if value is None:
             return None
-        return [{"user_id": str(p.user_id.value), "team": p.team} for p in value]
+        return [
+            {
+                "participant_id": str(p.participant_id.value),
+                "user_id": str(p.user_id.value) if p.user_id else None,
+                "first_name": p.first_name,
+                "last_name": p.last_name,
+                "handicap": p.handicap,
+                "team": p.team,
+            }
+            for p in value
+        ]
 
     def process_result_value(self, value: list | None, dialect: Any) -> list | None:
         if value is None:
             return None
-        return [
-            QuickMatchParticipant(user_id=UserId(uuid.UUID(p["user_id"])), team=p["team"])
-            for p in value
-        ]
+        participants = []
+        for p in value:
+            participants.append(
+                QuickMatchParticipant(
+                    participant_id=ParticipantId(p["participant_id"]),
+                    user_id=UserId(uuid.UUID(p["user_id"])) if p.get("user_id") else None,
+                    first_name=p.get("first_name"),
+                    last_name=p.get("last_name"),
+                    handicap=p.get("handicap"),
+                    team=p.get("team"),
+                )
+            )
+        return participants
+
+
+class ScorerIdsJsonType(sqlalchemy.types.TypeDecorator[list]):
+    """TypeDecorator para serializar list[ParticipantId] (scorer_ids) a/desde JSONB."""
+
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: list | None, dialect: Any) -> list | None:
+        if value is None:
+            return None
+        return [str(pid.value) for pid in value]
+
+    def process_result_value(self, value: list | None, dialect: Any) -> list | None:
+        if value is None:
+            return []
+        return [ParticipantId(v) for v in value]
 
 
 # ============================================================================
@@ -196,6 +259,7 @@ quick_matches_table = Table(
     Column("match_format", MatchFormatType, nullable=False),
     Column("status", QuickMatchStatusType, nullable=False),
     Column("participants", QuickMatchParticipantsJsonType, nullable=False),
+    Column("scorer_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
 )
@@ -216,13 +280,10 @@ quick_match_hole_scores_table = Table(
         nullable=False,
     ),
     Column("hole_number", Integer, nullable=False),
-    Column(
-        "player_user_id",
-        QuickMatchUserIdType,
-        ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
-    ),
+    # participant_id NO tiene FK a `users`: puede ser un invitado sin cuenta.
+    Column("participant_id", ParticipantIdType, nullable=False),
     Column("score", Integer, nullable=False),
+    Column("recorded_by_participant_id", ParticipantIdType, nullable=False),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
 )
@@ -245,6 +306,7 @@ def start_quick_match_mappers() -> None:
                 "_match_format": quick_matches_table.c.match_format,
                 "_status": quick_matches_table.c.status,
                 "_participants": quick_matches_table.c.participants,
+                "_scorer_ids": quick_matches_table.c.scorer_ids,
                 "_created_at": quick_matches_table.c.created_at,
                 "_updated_at": quick_matches_table.c.updated_at,
             },
@@ -258,8 +320,11 @@ def start_quick_match_mappers() -> None:
                 "_id": quick_match_hole_scores_table.c.id,
                 "_quick_match_id": quick_match_hole_scores_table.c.quick_match_id,
                 "_hole_number": quick_match_hole_scores_table.c.hole_number,
-                "_player_user_id": quick_match_hole_scores_table.c.player_user_id,
+                "_participant_id": quick_match_hole_scores_table.c.participant_id,
                 "_score": quick_match_hole_scores_table.c.score,
+                "_recorded_by_participant_id": (
+                    quick_match_hole_scores_table.c.recorded_by_participant_id
+                ),
                 "_created_at": quick_match_hole_scores_table.c.created_at,
                 "_updated_at": quick_match_hole_scores_table.c.updated_at,
             },

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_hole_score_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_hole_score_repository.py
@@ -7,11 +7,11 @@ from src.modules.quick_match.domain.entities.quick_match_hole_score import Quick
 from src.modules.quick_match.domain.repositories.quick_match_hole_score_repository_interface import (
     QuickMatchHoleScoreRepositoryInterface,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
     QuickMatchHoleScoreId,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
-from src.modules.user.domain.value_objects.user_id import UserId
 
 
 class SQLAlchemyQuickMatchHoleScoreRepository(QuickMatchHoleScoreRepositoryInterface):
@@ -31,14 +31,14 @@ class SQLAlchemyQuickMatchHoleScoreRepository(QuickMatchHoleScoreRepositoryInter
     ) -> QuickMatchHoleScore | None:
         return await self._session.get(QuickMatchHoleScore, hole_score_id)
 
-    async def find_by_match_hole_and_player(
-        self, quick_match_id: QuickMatchId, hole_number: int, player_user_id: UserId
+    async def find_by_match_hole_and_participant(
+        self, quick_match_id: QuickMatchId, hole_number: int, participant_id: ParticipantId
     ) -> QuickMatchHoleScore | None:
         stmt = select(QuickMatchHoleScore).where(
             and_(
                 QuickMatchHoleScore._quick_match_id == quick_match_id,
                 QuickMatchHoleScore._hole_number == hole_number,
-                QuickMatchHoleScore._player_user_id == player_user_id,
+                QuickMatchHoleScore._participant_id == participant_id,
             )
         )
         result = await self._session.execute(stmt)

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -62,6 +62,7 @@ class TestCreateQuickMatch:
         data = response.json()
         assert data["status"] == "PENDING"
         assert len(data["participants"]) == 1
+        assert data["scorer_ids"] == []
 
     @pytest.mark.asyncio
     async def test_create_with_unapproved_course_returns_422(self, client: AsyncClient):
@@ -106,9 +107,12 @@ class TestQuickMatchFullFlow:
             json={"friend_user_id": friend["user"]["id"]},
         )
         assert add_response.status_code == 201
-        assert len(add_response.json()["participants"]) == 2
+        assert len(add_response.json()["participants"]) == 2  # noqa: PLR2004
 
-        start_response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/start")
+        start_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"], friend["user"]["id"]]},
+        )
         assert start_response.status_code == 200, start_response.text
         assert start_response.json()["status"] == "IN_PROGRESS"
 
@@ -116,7 +120,7 @@ class TestQuickMatchFullFlow:
             f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={"score": 4}
         )
         assert score_response.status_code == 200
-        assert score_response.json()["score"] == 4
+        assert score_response.json()["score"] == 4  # noqa: PLR2004
 
         set_auth_cookies(client, friend["cookies"])
         friend_score_response = await client.post(
@@ -127,7 +131,7 @@ class TestQuickMatchFullFlow:
         detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
         assert detail_response.status_code == 200
         detail = detail_response.json()
-        assert len(detail["hole_scores"]) == 2
+        assert len(detail["hole_scores"]) == 2  # noqa: PLR2004
         assert detail["standing"]["holes_played"] == 1
 
         set_auth_cookies(client, creator["cookies"])
@@ -181,3 +185,129 @@ class TestQuickMatchFullFlow:
         assert response.status_code == 200
         data = response.json()
         assert data["total_count"] == 1
+
+
+class TestQuickMatchGuestsAndScoringAssignment:
+    """Flujo con jugador invitado (sin cuenta) y anotacion por delegacion."""
+
+    @pytest.mark.asyncio
+    async def test_add_guest_and_proxy_score(self, client: AsyncClient):
+        admin = await create_admin_user(client, "qm_admin5@test.com", "P@ssw0rd123!", "Admin", "Five")
+        creator = await create_authenticated_user(
+            client, "qm_creator6@test.com", "P@ssw0rd123!", "Creator", "Six"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+
+        guest_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/guest",
+            json={"first_name": "Jane", "last_name": "Doe", "handicap": 18.4},
+        )
+        assert guest_response.status_code == 201, guest_response.text
+        guest_dto = next(p for p in guest_response.json()["participants"] if p["is_guest"])
+        assert guest_dto["name"] == "Jane Doe"
+        assert guest_dto["handicap"] == 18.4  # noqa: PLR2004
+        guest_participant_id = guest_dto["participant_id"]
+
+        # Solo el creador anota (1 anotador): debe cubrir tambien al invitado.
+        start_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"]]},
+        )
+        assert start_response.status_code == 200, start_response.text
+
+        own_score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={"score": 4}
+        )
+        assert own_score_response.status_code == 200
+
+        proxy_score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{guest_participant_id}"
+            "/holes/1/score",
+            json={"score": 6},
+        )
+        assert proxy_score_response.status_code == 200, proxy_score_response.text
+        proxy_data = proxy_score_response.json()
+        assert proxy_data["participant_id"] == guest_participant_id
+        assert proxy_data["recorded_by_participant_id"] == creator["user"]["id"]
+
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        assert detail_response.status_code == 200
+        detail = detail_response.json()
+        assert len(detail["hole_scores"]) == 2  # noqa: PLR2004
+        assert len(detail["scoring_assignments"]) == 1
+        assert set(detail["scoring_assignments"][0]["covered_participant_ids"]) == {
+            creator["user"]["id"],
+            guest_participant_id,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_scorer_cannot_self_submit(self, client: AsyncClient):
+        admin = await create_admin_user(client, "qm_admin6@test.com", "P@ssw0rd123!", "Admin", "Six")
+        creator = await create_authenticated_user(
+            client, "qm_creator7@test.com", "P@ssw0rd123!", "Creator", "Seven"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend7@test.com", "P@ssw0rd123!", "Friend", "Seven"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        # Solo el creador anota; `friend` es participante pero no anotador.
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"]]},
+        )
+
+        set_auth_cookies(client, friend["cookies"])
+        response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={"score": 5}
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_start_without_creator_as_scorer_returns_422(self, client: AsyncClient):
+        admin = await create_admin_user(client, "qm_admin7@test.com", "P@ssw0rd123!", "Admin", "Seven")
+        creator = await create_authenticated_user(
+            client, "qm_creator8@test.com", "P@ssw0rd123!", "Creator", "Eight"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend8@test.com", "P@ssw0rd123!", "Friend", "Eight"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+
+        response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [friend["user"]["id"]]},
+        )
+
+        assert response.status_code == 422

--- a/tests/unit/modules/quick_match/application/use_cases/test_add_guest_to_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_add_guest_to_quick_match_use_case.py
@@ -1,0 +1,85 @@
+"""Tests para AddGuestToQuickMatchUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    AddGuestParticipantRequestDTO,
+)
+from src.modules.quick_match.application.exceptions import (
+    NotQuickMatchCreatorError,
+    QuickMatchNotFoundError,
+)
+from src.modules.quick_match.application.use_cases.add_guest_to_quick_match_use_case import (
+    AddGuestToQuickMatchUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from tests.unit.modules.quick_match.conftest import create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_pending_match(qm_uow, creator_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm
+
+
+class TestAddGuestToQuickMatchUseCase:
+    async def test_creator_adds_guest_succeeds(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator@test.com")
+        qm = await _create_pending_match(qm_uow, creator.id)
+
+        use_case = AddGuestToQuickMatchUseCase(qm_uow, user_uow)
+        response = await use_case.execute(
+            AddGuestParticipantRequestDTO(
+                quick_match_id=qm.id.value,
+                requester_id=creator.id.value,
+                first_name="Jane",
+                last_name="Doe",
+                handicap=18.4,
+            )
+        )
+
+        assert len(response.participants) == 2
+        guest_dto = next(p for p in response.participants if p.is_guest)
+        assert guest_dto.name == "Jane Doe"
+        assert guest_dto.handicap == 18.4
+        assert guest_dto.user_id is None
+
+    async def test_non_creator_cannot_add_guest(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator2@test.com")
+        qm = await _create_pending_match(qm_uow, creator.id)
+
+        use_case = AddGuestToQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(NotQuickMatchCreatorError):
+            await use_case.execute(
+                AddGuestParticipantRequestDTO(
+                    quick_match_id=qm.id.value,
+                    requester_id=uuid4(),
+                    first_name="Jane",
+                    last_name="Doe",
+                )
+            )
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = AddGuestToQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                AddGuestParticipantRequestDTO(
+                    quick_match_id=uuid4(),
+                    requester_id=uuid4(),
+                    first_name="Jane",
+                    last_name="Doe",
+                )
+            )

--- a/tests/unit/modules/quick_match/application/use_cases/test_add_guest_to_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_add_guest_to_quick_match_use_case.py
@@ -57,6 +57,13 @@ class TestAddGuestToQuickMatchUseCase:
         assert guest_dto.handicap == 18.4
         assert guest_dto.user_id is None
 
+        persisted = await qm_uow.quick_matches.find_by_id(qm.id)
+        guest = next(p for p in persisted.participants if p.is_guest)
+        assert guest.participant_id.value == guest_dto.participant_id
+        assert guest.first_name == "Jane"
+        assert guest.last_name == "Doe"
+        assert guest.handicap == 18.4
+
     async def test_non_creator_cannot_add_guest(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator2@test.com")
         qm = await _create_pending_match(qm_uow, creator.id)

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -6,7 +6,10 @@ import pytest
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
-from src.modules.quick_match.application.dto.quick_match_dto import SubmitHoleScoreRequestDTO
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    SubmitHoleScoreRequestDTO,
+    SubmitProxyHoleScoreRequestDTO,
+)
 from src.modules.quick_match.application.exceptions import (
     NotQuickMatchParticipantError,
     QuickMatchNotFoundError,
@@ -17,8 +20,14 @@ from src.modules.quick_match.application.use_cases.get_quick_match_use_case impo
 from src.modules.quick_match.application.use_cases.submit_hole_score_use_case import (
     SubmitQuickMatchHoleScoreUseCase,
 )
+from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
+    SubmitProxyHoleScoreUseCase,
+)
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 from tests.unit.modules.quick_match.conftest import create_user
 
@@ -32,8 +41,8 @@ async def _create_in_progress_match(qm_uow, creator_id, other_id):
         golf_course_id=GolfCourseId(uuid4()),
         match_format=MatchFormat.SINGLES,
     )
-    qm.add_participant(other_id)
-    qm.start()
+    qm.add_participant(QuickMatchParticipant.for_user(other_id))
+    qm.start([qm.creator_participant_id])
     async with qm_uow:
         await qm_uow.quick_matches.add(qm)
     return qm
@@ -51,6 +60,12 @@ class TestGetQuickMatchUseCase:
         assert detail.status == "IN_PROGRESS"
         assert detail.hole_scores == []
         assert detail.standing is None
+        assert len(detail.scoring_assignments) == 1
+        assert detail.scoring_assignments[0].scorer_participant_id == creator.id.value
+        assert set(detail.scoring_assignments[0].covered_participant_ids) == {
+            creator.id.value,
+            other.id.value,
+        }
 
     async def test_non_participant_cannot_view(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator2@test.com")
@@ -71,6 +86,8 @@ class TestGetQuickMatchUseCase:
         other = await create_user(user_uow, "other3@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
+        # Solo el creador es anotador: registra su propio score y, por
+        # delegacion, el de `other` (que no es anotador en esta partida).
         submit_uc = SubmitQuickMatchHoleScoreUseCase(qm_uow)
         await submit_uc.execute(
             SubmitHoleScoreRequestDTO(
@@ -80,10 +97,12 @@ class TestGetQuickMatchUseCase:
                 score=4,
             )
         )
-        await submit_uc.execute(
-            SubmitHoleScoreRequestDTO(
+        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow)
+        await proxy_uc.execute(
+            SubmitProxyHoleScoreRequestDTO(
                 quick_match_id=qm.id.value,
-                player_user_id=other.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=other.id.value,
                 hole_number=1,
                 score=5,
             )
@@ -92,6 +111,7 @@ class TestGetQuickMatchUseCase:
         get_uc = GetQuickMatchUseCase(qm_uow, user_uow)
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
+        assert len(detail.hole_scores) == 2
         assert detail.standing is not None
         assert detail.standing.holes_played == 1
         assert detail.standing.leading_team == "A"

--- a/tests/unit/modules/quick_match/application/use_cases/test_remove_participant_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_remove_participant_use_case.py
@@ -16,70 +16,70 @@ from src.modules.quick_match.application.use_cases.remove_participant_use_case i
 )
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
-from tests.unit.modules.quick_match.conftest import create_user
 
 pytestmark = pytest.mark.asyncio
 
 
-async def _create_pending_match_with_participant(qm_uow, creator_id, other_id):
+async def _create_pending_match_with_participant(qm_uow, creator_id):
     qm = QuickMatch.create(
         id=QuickMatchId.generate(),
         creator_id=creator_id,
         golf_course_id=GolfCourseId(uuid4()),
         match_format=MatchFormat.SINGLES,
     )
-    qm.add_participant(other_id)
+    other = QuickMatchParticipant.for_user(UserId(uuid4()))
+    qm.add_participant(other)
     async with qm_uow:
         await qm_uow.quick_matches.add(qm)
-    return qm
+    return qm, other
 
 
 class TestRemoveParticipantUseCase:
     async def test_self_leave_succeeds(self, qm_uow, user_uow):
-        creator = await create_user(user_uow, "creator@test.com")
-        other = await create_user(user_uow, "other@test.com")
-        qm = await _create_pending_match_with_participant(qm_uow, creator.id, other.id)
+        creator = UserId(uuid4())
+        qm, other = await _create_pending_match_with_participant(qm_uow, creator)
 
         use_case = RemoveParticipantUseCase(qm_uow, user_uow)
         response = await use_case.execute(
             RemoveParticipantRequestDTO(
                 quick_match_id=qm.id.value,
-                requester_id=other.id.value,
-                target_user_id=other.id.value,
+                requester_id=other.user_id.value,
+                target_participant_id=other.participant_id.value,
             )
         )
 
         assert len(response.participants) == 1
 
     async def test_creator_can_kick_participant(self, qm_uow, user_uow):
-        creator = await create_user(user_uow, "creator2@test.com")
-        other = await create_user(user_uow, "other2@test.com")
-        qm = await _create_pending_match_with_participant(qm_uow, creator.id, other.id)
+        creator = UserId(uuid4())
+        qm, other = await _create_pending_match_with_participant(qm_uow, creator)
 
         use_case = RemoveParticipantUseCase(qm_uow, user_uow)
         response = await use_case.execute(
             RemoveParticipantRequestDTO(
                 quick_match_id=qm.id.value,
-                requester_id=creator.id.value,
-                target_user_id=other.id.value,
+                requester_id=creator.value,
+                target_participant_id=other.participant_id.value,
             )
         )
 
         assert len(response.participants) == 1
 
     async def test_third_party_cannot_remove(self, qm_uow, user_uow):
-        creator = await create_user(user_uow, "creator3@test.com")
-        other = await create_user(user_uow, "other3@test.com")
-        qm = await _create_pending_match_with_participant(qm_uow, creator.id, other.id)
+        creator = UserId(uuid4())
+        qm, other = await _create_pending_match_with_participant(qm_uow, creator)
 
         use_case = RemoveParticipantUseCase(qm_uow, user_uow)
         with pytest.raises(NotAuthorizedToRemoveError):
             await use_case.execute(
                 RemoveParticipantRequestDTO(
                     quick_match_id=qm.id.value,
-                    requester_id=str(UserId(uuid4()).value),
-                    target_user_id=other.id.value,
+                    requester_id=uuid4(),
+                    target_participant_id=other.participant_id.value,
                 )
             )
 
@@ -88,6 +88,6 @@ class TestRemoveParticipantUseCase:
         with pytest.raises(QuickMatchNotFoundError):
             await use_case.execute(
                 RemoveParticipantRequestDTO(
-                    quick_match_id=uuid4(), requester_id=uuid4(), target_user_id=uuid4()
+                    quick_match_id=uuid4(), requester_id=uuid4(), target_participant_id=uuid4()
                 )
             )

--- a/tests/unit/modules/quick_match/application/use_cases/test_start_complete_cancel_quick_match_use_cases.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_start_complete_cancel_quick_match_use_cases.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import StartQuickMatchRequestDTO
 from src.modules.quick_match.application.exceptions import (
     NotQuickMatchCreatorError,
     QuickMatchNotFoundError,
@@ -24,6 +25,9 @@ from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     IncompleteRosterViolation,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 from tests.unit.modules.quick_match.conftest import create_user
 
@@ -38,7 +42,7 @@ async def _create_match(qm_uow, creator_id, with_full_roster=False):
         match_format=MatchFormat.SINGLES,
     )
     if with_full_roster:
-        qm.add_participant(UserId(uuid4()))
+        qm.add_participant(QuickMatchParticipant.for_user(UserId(uuid4())))
     async with qm_uow:
         await qm_uow.quick_matches.add(qm)
     return qm
@@ -50,9 +54,16 @@ class TestStartQuickMatchUseCase:
         qm = await _create_match(qm_uow, creator.id, with_full_roster=True)
 
         use_case = StartQuickMatchUseCase(qm_uow, user_uow)
-        response = await use_case.execute(str(qm.id.value), str(creator.id.value))
+        response = await use_case.execute(
+            StartQuickMatchRequestDTO(
+                quick_match_id=qm.id.value,
+                requester_id=creator.id.value,
+                scorer_ids=[creator.id.value],
+            )
+        )
 
         assert response.status == "IN_PROGRESS"
+        assert response.scorer_ids == [creator.id.value]
 
     async def test_incomplete_roster_raises(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator2@test.com")
@@ -60,7 +71,13 @@ class TestStartQuickMatchUseCase:
 
         use_case = StartQuickMatchUseCase(qm_uow, user_uow)
         with pytest.raises(IncompleteRosterViolation):
-            await use_case.execute(str(qm.id.value), str(creator.id.value))
+            await use_case.execute(
+                StartQuickMatchRequestDTO(
+                    quick_match_id=qm.id.value,
+                    requester_id=creator.id.value,
+                    scorer_ids=[creator.id.value],
+                )
+            )
 
     async def test_non_creator_cannot_start(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator3@test.com")
@@ -68,19 +85,27 @@ class TestStartQuickMatchUseCase:
 
         use_case = StartQuickMatchUseCase(qm_uow, user_uow)
         with pytest.raises(NotQuickMatchCreatorError):
-            await use_case.execute(str(qm.id.value), str(uuid4()))
+            await use_case.execute(
+                StartQuickMatchRequestDTO(
+                    quick_match_id=qm.id.value, requester_id=uuid4(), scorer_ids=[uuid4()]
+                )
+            )
 
     async def test_not_found_raises(self, qm_uow, user_uow):
         use_case = StartQuickMatchUseCase(qm_uow, user_uow)
         with pytest.raises(QuickMatchNotFoundError):
-            await use_case.execute(str(uuid4()), str(uuid4()))
+            await use_case.execute(
+                StartQuickMatchRequestDTO(
+                    quick_match_id=uuid4(), requester_id=uuid4(), scorer_ids=[uuid4()]
+                )
+            )
 
 
 class TestCompleteQuickMatchUseCase:
     async def test_creator_completes_in_progress_match(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator4@test.com")
         qm = await _create_match(qm_uow, creator.id, with_full_roster=True)
-        qm.start()
+        qm.start([qm.creator_participant_id])
         async with qm_uow:
             await qm_uow.quick_matches.update(qm)
 

--- a/tests/unit/modules/quick_match/application/use_cases/test_submit_hole_score_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_submit_hole_score_use_case.py
@@ -8,6 +8,7 @@ from src.modules.competition.domain.value_objects.match_format import MatchForma
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.quick_match.application.dto.quick_match_dto import SubmitHoleScoreRequestDTO
 from src.modules.quick_match.application.exceptions import (
+    NotAScorerError,
     NotQuickMatchParticipantError,
     QuickMatchNotFoundError,
 )
@@ -19,21 +20,24 @@ from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     InvalidQuickMatchStatusViolation,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 from tests.unit.modules.quick_match.conftest import create_user
 
 pytestmark = pytest.mark.asyncio
 
 
-async def _create_in_progress_match(qm_uow, creator_id, other_id):
+async def _create_in_progress_match(qm_uow, creator_id, other_id, scorer_ids=None):
     qm = QuickMatch.create(
         id=QuickMatchId.generate(),
         creator_id=creator_id,
         golf_course_id=GolfCourseId(uuid4()),
         match_format=MatchFormat.SINGLES,
     )
-    qm.add_participant(other_id)
-    qm.start()
+    qm.add_participant(QuickMatchParticipant.for_user(other_id))
+    qm.start(scorer_ids or [qm.creator_participant_id])
     async with qm_uow:
         await qm_uow.quick_matches.add(qm)
     return qm
@@ -56,6 +60,7 @@ class TestSubmitQuickMatchHoleScoreUseCase:
         )
 
         assert response.score == 4
+        assert response.recorded_by_participant_id == creator.id.value
 
     async def test_resubmit_updates_existing_score(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator2@test.com")
@@ -89,6 +94,25 @@ class TestSubmitQuickMatchHoleScoreUseCase:
                 SubmitHoleScoreRequestDTO(
                     quick_match_id=qm.id.value,
                     player_user_id=UserId(uuid4()).value,
+                    hole_number=1,
+                    score=4,
+                )
+            )
+
+    async def test_non_scorer_participant_cannot_self_submit(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator5@test.com")
+        other = await create_user(user_uow, "other5@test.com")
+        # Solo el creador es anotador; `other` es participante pero no anotador.
+        qm = await _create_in_progress_match(
+            qm_uow, creator.id, other.id, scorer_ids=None
+        )
+
+        use_case = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        with pytest.raises(NotAScorerError):
+            await use_case.execute(
+                SubmitHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    player_user_id=other.id.value,
                     hole_number=1,
                     score=4,
                 )

--- a/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
@@ -1,0 +1,148 @@
+"""Tests para SubmitProxyHoleScoreUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    SubmitProxyHoleScoreRequestDTO,
+)
+from src.modules.quick_match.application.exceptions import (
+    NotAScorerError,
+    TargetParticipantNotFoundError,
+)
+from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
+    SubmitProxyHoleScoreUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    NotAssignedScorerViolation,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from tests.unit.modules.quick_match.conftest import create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_in_progress_match_with_guest(qm_uow, creator_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    guest = QuickMatchParticipant.for_guest(first_name="Guest", last_name="Player")
+    qm.add_participant(guest)
+    qm.start([qm.creator_participant_id])
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm, guest
+
+
+class TestSubmitProxyHoleScoreUseCase:
+    async def test_scorer_can_submit_for_assigned_guest(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator@test.com")
+        qm, guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
+
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        response = await use_case.execute(
+            SubmitProxyHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=guest.participant_id.value,
+                hole_number=1,
+                score=5,
+            )
+        )
+
+        assert response.score == 5
+        assert response.participant_id == guest.participant_id.value
+        assert response.recorded_by_participant_id == creator.id.value
+
+    async def test_non_scorer_cannot_submit_by_proxy(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator2@test.com")
+        qm, guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
+
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        with pytest.raises(NotAScorerError):
+            await use_case.execute(
+                SubmitProxyHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    scorer_user_id=uuid4(),
+                    target_participant_id=guest.participant_id.value,
+                    hole_number=1,
+                    score=5,
+                )
+            )
+
+    async def test_target_not_found_raises(self, qm_uow, user_uow):
+        creator = await create_user(user_uow, "creator3@test.com")
+        qm, _guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
+
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        with pytest.raises(TargetParticipantNotFoundError):
+            await use_case.execute(
+                SubmitProxyHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    scorer_user_id=creator.id.value,
+                    target_participant_id=uuid4(),
+                    hole_number=1,
+                    score=5,
+                )
+            )
+
+    async def test_scorer_cannot_submit_for_participant_not_assigned_to_them(
+        self, qm_uow, user_uow
+    ):
+        creator = await create_user(user_uow, "creator4@test.com")
+        other = await create_user(user_uow, "other4@test.com")
+        qm = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=creator.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.FOURBALL,
+        )
+        scorer_b = QuickMatchParticipant.for_user(other.id, team="A")
+        guest_a = QuickMatchParticipant.for_guest(
+            first_name="Guest", last_name="A", team="B"
+        )
+        guest_b = QuickMatchParticipant.for_guest(
+            first_name="Guest", last_name="B", team="B"
+        )
+        qm.add_participant(scorer_b)
+        qm.add_participant(guest_a)
+        qm.add_participant(guest_b)
+        qm.start([qm.creator_participant_id, scorer_b.participant_id])
+        async with qm_uow:
+            await qm_uow.quick_matches.add(qm)
+
+        # Con 2 anotadores y 2 no-anotadores, el reparto es 1 y 1: cada guest
+        # queda asignado a un anotador distinto. Forzamos que "other" intente
+        # anotar al invitado que NO le corresponde.
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        assignments = use_case._coverage_service.compute_assignments(
+            participants=qm.participants,
+            scorer_ids=qm.scorer_ids,
+            creator_participant_id=qm.creator_participant_id,
+        )
+        not_assigned_to_other = next(
+            g
+            for g in (guest_a, guest_b)
+            if g.participant_id not in assignments[scorer_b.participant_id]
+        )
+
+        with pytest.raises(NotAssignedScorerViolation):
+            await use_case.execute(
+                SubmitProxyHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    scorer_user_id=other.id.value,
+                    target_participant_id=not_assigned_to_other.participant_id.value,
+                    hole_number=1,
+                    score=5,
+                )
+            )

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -30,11 +30,16 @@ from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     DuplicateParticipantViolation,
     IncompleteRosterViolation,
     InvalidQuickMatchStatusViolation,
+    InvalidScorerConfigurationViolation,
     InvalidTeamAssignmentViolation,
     NotQuickMatchParticipantViolation,
     QuickMatchFullViolation,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
 from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
 from src.modules.user.domain.value_objects.user_id import UserId
 
@@ -50,6 +55,14 @@ def _make_quick_match(match_format=MatchFormat.SINGLES, **overrides):
     return QuickMatch.create(**defaults)
 
 
+def _registered(team=None):
+    return QuickMatchParticipant.for_user(UserId(uuid4()), team=team)
+
+
+def _guest(team=None):
+    return QuickMatchParticipant.for_guest(first_name="Guest", last_name="Player", team=team)
+
+
 class TestQuickMatchCreate:
     def test_create_sets_pending_status(self):
         qm = _make_quick_match()
@@ -58,7 +71,7 @@ class TestQuickMatchCreate:
     def test_create_adds_creator_as_first_participant(self):
         qm = _make_quick_match()
         assert len(qm.participants) == 1
-        assert qm.participants[0].user_id == qm.creator_id
+        assert qm.participants[0].participant_id == qm.creator_participant_id
 
     def test_create_singles_creator_has_no_team(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
@@ -76,33 +89,41 @@ class TestQuickMatchCreate:
 
 
 class TestQuickMatchAddParticipant:
-    def test_add_participant_singles_succeeds(self):
+    def test_add_registered_participant_singles_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         qm.clear_domain_events()
-        other = UserId(uuid4())
+        other = _registered()
         qm.add_participant(other)
 
-        assert qm.is_participant(other)
+        assert qm.is_participant(other.participant_id)
         assert qm.is_roster_complete()
         events = qm.get_domain_events()
         assert len(events) == 1
         assert isinstance(events[0], QuickMatchParticipantAddedEvent)
 
+    def test_add_guest_participant_succeeds(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        guest = _guest()
+        qm.add_participant(guest)
+
+        assert qm.is_participant(guest.participant_id)
+        assert qm.find_participant(guest.participant_id).is_guest
+
     def test_add_participant_singles_rejects_team(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         with pytest.raises(InvalidTeamAssignmentViolation):
-            qm.add_participant(UserId(uuid4()), team="A")
+            qm.add_participant(_registered(team="A"))
 
     def test_add_participant_fourball_requires_team(self):
         qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
         with pytest.raises(InvalidTeamAssignmentViolation):
-            qm.add_participant(UserId(uuid4()), team=None)
+            qm.add_participant(_registered(team=None))
 
     def test_add_participant_fourball_fills_teams(self):
         qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
-        qm.add_participant(UserId(uuid4()), team="A")
-        qm.add_participant(UserId(uuid4()), team="B")
-        qm.add_participant(UserId(uuid4()), team="B")
+        qm.add_participant(_registered(team="A"))
+        qm.add_participant(_registered(team="B"))
+        qm.add_participant(_guest(team="B"))
 
         assert qm.is_roster_complete()
         assert qm._team_count("A") == 2
@@ -110,39 +131,41 @@ class TestQuickMatchAddParticipant:
 
     def test_add_participant_team_full_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
-        qm.add_participant(UserId(uuid4()), team="A")
+        qm.add_participant(_registered(team="A"))
         with pytest.raises(QuickMatchFullViolation):
-            qm.add_participant(UserId(uuid4()), team="A")
+            qm.add_participant(_registered(team="A"))
 
     def test_add_duplicate_participant_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        creator_participant = QuickMatchParticipant.for_user(qm.creator_id)
         with pytest.raises(DuplicateParticipantViolation):
-            qm.add_participant(qm.creator_id)
+            qm.add_participant(creator_participant)
 
     def test_add_participant_when_full_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
+        qm.add_participant(_registered())
         with pytest.raises(QuickMatchFullViolation):
-            qm.add_participant(UserId(uuid4()))
+            qm.add_participant(_registered())
 
     def test_add_participant_not_pending_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
-        qm.start()
+        other = _registered()
+        qm.add_participant(other)
+        qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
-            qm.add_participant(UserId(uuid4()))
+            qm.add_participant(_registered())
 
 
 class TestQuickMatchRemoveParticipant:
     def test_remove_participant_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        other = UserId(uuid4())
+        other = _registered()
         qm.add_participant(other)
         qm.clear_domain_events()
 
-        qm.remove_participant(other)
+        qm.remove_participant(other.participant_id)
 
-        assert not qm.is_participant(other)
+        assert not qm.is_participant(other.participant_id)
         events = qm.get_domain_events()
         assert len(events) == 1
         assert isinstance(events[0], QuickMatchParticipantRemovedEvent)
@@ -150,31 +173,32 @@ class TestQuickMatchRemoveParticipant:
     def test_remove_creator_raises(self):
         qm = _make_quick_match()
         with pytest.raises(CreatorCannotBeRemovedViolation):
-            qm.remove_participant(qm.creator_id)
+            qm.remove_participant(qm.creator_participant_id)
 
     def test_remove_non_participant_raises(self):
         qm = _make_quick_match()
         with pytest.raises(NotQuickMatchParticipantViolation):
-            qm.remove_participant(UserId(uuid4()))
+            qm.remove_participant(ParticipantId.generate())
 
     def test_remove_participant_not_pending_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        other = UserId(uuid4())
+        other = _registered()
         qm.add_participant(other)
-        qm.start()
+        qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
-            qm.remove_participant(other)
+            qm.remove_participant(other.participant_id)
 
 
 class TestQuickMatchStart:
     def test_start_with_complete_roster_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
+        qm.add_participant(_registered())
         qm.clear_domain_events()
 
-        qm.start()
+        qm.start([qm.creator_participant_id])
 
         assert qm.status == QuickMatchStatus.IN_PROGRESS
+        assert qm.scorer_ids == [qm.creator_participant_id]
         events = qm.get_domain_events()
         assert len(events) == 1
         assert isinstance(events[0], QuickMatchStartedEvent)
@@ -182,21 +206,49 @@ class TestQuickMatchStart:
     def test_start_with_incomplete_roster_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         with pytest.raises(IncompleteRosterViolation):
-            qm.start()
+            qm.start([qm.creator_participant_id])
 
     def test_start_when_not_pending_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
-        qm.start()
+        qm.add_participant(_registered())
+        qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
-            qm.start()
+            qm.start([qm.creator_participant_id])
+
+    def test_start_without_creator_in_scorers_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        with pytest.raises(InvalidScorerConfigurationViolation, match="creator"):
+            qm.start([other.participant_id])
+
+    def test_start_with_guest_as_scorer_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
+        qm.add_participant(_registered(team="A"))
+        qm.add_participant(_registered(team="B"))
+        guest = _guest(team="B")
+        qm.add_participant(guest)
+        with pytest.raises(InvalidScorerConfigurationViolation, match="not a registered"):
+            qm.start([qm.creator_participant_id, guest.participant_id])
+
+    def test_start_with_too_many_scorers_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        qm.add_participant(_registered())
+        with pytest.raises(InvalidScorerConfigurationViolation):
+            qm.start([qm.creator_participant_id, ParticipantId.generate(), ParticipantId.generate()])
+
+    def test_start_with_duplicate_scorers_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        qm.add_participant(_registered())
+        with pytest.raises(InvalidScorerConfigurationViolation, match="duplicates"):
+            qm.start([qm.creator_participant_id, qm.creator_participant_id])
 
 
 class TestQuickMatchComplete:
     def test_complete_from_in_progress_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
-        qm.start()
+        qm.add_participant(_registered())
+        qm.start([qm.creator_participant_id])
         qm.clear_domain_events()
 
         qm.complete()
@@ -221,15 +273,15 @@ class TestQuickMatchCancel:
 
     def test_cancel_from_in_progress_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
-        qm.start()
+        qm.add_participant(_registered())
+        qm.start([qm.creator_participant_id])
         qm.cancel()
         assert qm.status == QuickMatchStatus.CANCELLED
 
     def test_cancel_from_completed_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
-        qm.add_participant(UserId(uuid4()))
-        qm.start()
+        qm.add_participant(_registered())
+        qm.start([qm.creator_participant_id])
         qm.complete()
         with pytest.raises(InvalidQuickMatchStatusViolation):
             qm.cancel()
@@ -241,6 +293,14 @@ class TestQuickMatchQueries:
 
     def test_capacity_fourball(self):
         assert _make_quick_match(match_format=MatchFormat.FOURBALL).capacity() == 4
+
+    def test_registered_participants_excludes_guests(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        guest = _guest()
+        qm.add_participant(guest)
+        registered = qm.registered_participants()
+        assert guest not in registered
+        assert len(registered) == 1
 
     def test_reconstruct_does_not_emit_events(self):
         qm = QuickMatch.reconstruct(

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -231,10 +231,10 @@ class TestQuickMatchStart:
         with pytest.raises(InvalidScorerConfigurationViolation, match="not a registered"):
             qm.start([qm.creator_participant_id, guest.participant_id])
 
-    def test_start_with_too_many_scorers_raises(self):
+    def test_start_with_non_registered_scorer_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         qm.add_participant(_registered())
-        with pytest.raises(InvalidScorerConfigurationViolation):
+        with pytest.raises(InvalidScorerConfigurationViolation, match="not a registered participant"):
             qm.start([qm.creator_participant_id, ParticipantId.generate(), ParticipantId.generate()])
 
     def test_start_with_duplicate_scorers_raises(self):

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match_hole_score.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match_hole_score.py
@@ -1,18 +1,16 @@
 """Tests para QuickMatchHoleScore Entity."""
 
-from uuid import uuid4
-
 import pytest
 
 from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     InvalidHoleScoreViolation,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
     QuickMatchHoleScoreId,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
-from src.modules.user.domain.value_objects.user_id import UserId
 
 
 def _make_hole_score(**overrides):
@@ -20,8 +18,9 @@ def _make_hole_score(**overrides):
         "id": QuickMatchHoleScoreId.generate(),
         "quick_match_id": QuickMatchId.generate(),
         "hole_number": 1,
-        "player_user_id": UserId(uuid4()),
+        "participant_id": ParticipantId.generate(),
         "score": 4,
+        "recorded_by_participant_id": ParticipantId.generate(),
     }
     defaults.update(overrides)
     return QuickMatchHoleScore.create(**defaults)
@@ -32,6 +31,11 @@ class TestQuickMatchHoleScoreCreate:
         hs = _make_hole_score(hole_number=9, score=5)
         assert hs.hole_number == 9
         assert hs.score == 5
+
+    def test_create_records_who_recorded_it(self):
+        recorder = ParticipantId.generate()
+        hs = _make_hole_score(recorded_by_participant_id=recorder)
+        assert hs.recorded_by_participant_id == recorder
 
     @pytest.mark.parametrize("hole_number", [0, 19, -1])
     def test_create_rejects_invalid_hole_number(self, hole_number):
@@ -47,10 +51,12 @@ class TestQuickMatchHoleScoreCreate:
 class TestQuickMatchHoleScoreUpdate:
     def test_update_score_succeeds(self):
         hs = _make_hole_score(score=4)
-        hs.update_score(6)
+        new_recorder = ParticipantId.generate()
+        hs.update_score(6, recorded_by_participant_id=new_recorder)
         assert hs.score == 6
+        assert hs.recorded_by_participant_id == new_recorder
 
     def test_update_score_rejects_invalid_value(self):
         hs = _make_hole_score()
         with pytest.raises(InvalidHoleScoreViolation):
-            hs.update_score(20)
+            hs.update_score(20, recorded_by_participant_id=ParticipantId.generate())

--- a/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
@@ -1,0 +1,99 @@
+"""Tests para ScoringCoverageService."""
+
+from uuid import uuid4
+
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+def _registered():
+    return QuickMatchParticipant.for_user(UserId(uuid4()))
+
+
+def _guest():
+    return QuickMatchParticipant.for_guest(first_name="Guest", last_name="Player")
+
+
+class TestScoringCoverageService:
+    def setup_method(self):
+        self.service = ScoringCoverageService()
+
+    def test_single_scorer_covers_everyone(self):
+        creator = _registered()
+        others = [_registered(), _guest(), _guest()]
+        participants = [creator, *others]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[creator.participant_id],
+            creator_participant_id=creator.participant_id,
+        )
+
+        assert set(assignments[creator.participant_id]) == {p.participant_id for p in participants}
+
+    def test_two_scorers_split_evenly_four_players(self):
+        creator = _registered()
+        scorer_b = _registered()
+        non_scorers = [_guest(), _guest()]
+        participants = [creator, scorer_b, *non_scorers]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[creator.participant_id, scorer_b.participant_id],
+            creator_participant_id=creator.participant_id,
+        )
+
+        assert len(assignments[creator.participant_id]) == 2
+        assert len(assignments[scorer_b.participant_id]) == 2
+        covered = assignments[creator.participant_id] + assignments[scorer_b.participant_id]
+        assert set(covered) == {p.participant_id for p in participants}
+
+    def test_three_scorers_four_players_creator_absorbs_remainder(self):
+        creator = _registered()
+        scorer_b = _registered()
+        scorer_c = _registered()
+        non_scorer = _guest()
+        participants = [creator, scorer_b, scorer_c, non_scorer]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[creator.participant_id, scorer_b.participant_id, scorer_c.participant_id],
+            creator_participant_id=creator.participant_id,
+        )
+
+        assert len(assignments[creator.participant_id]) == 2
+        assert non_scorer.participant_id in assignments[creator.participant_id]
+        assert len(assignments[scorer_b.participant_id]) == 1
+        assert len(assignments[scorer_c.participant_id]) == 1
+
+    def test_four_scorers_each_covers_only_self(self):
+        creator = _registered()
+        others = [_registered(), _registered(), _registered()]
+        participants = [creator, *others]
+        scorer_ids = [creator.participant_id, *[p.participant_id for p in others]]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=scorer_ids,
+            creator_participant_id=creator.participant_id,
+        )
+
+        for p in participants:
+            assert assignments[p.participant_id] == [p.participant_id]
+
+    def test_scorer_always_covers_self(self):
+        creator = _registered()
+        participants = [creator]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[creator.participant_id],
+            creator_participant_id=creator.participant_id,
+        )
+
+        assert assignments[creator.participant_id] == [creator.participant_id]

--- a/tests/unit/modules/quick_match/domain/value_objects/test_participant_id.py
+++ b/tests/unit/modules/quick_match/domain/value_objects/test_participant_id.py
@@ -1,0 +1,29 @@
+"""Tests para ParticipantId Value Object."""
+
+import uuid
+
+import pytest
+
+from src.modules.quick_match.domain.value_objects.participant_id import (
+    InvalidParticipantIdError,
+    ParticipantId,
+)
+
+
+class TestParticipantId:
+    def test_generate_creates_valid_id(self):
+        pid = ParticipantId.generate()
+        assert isinstance(pid.value, uuid.UUID)
+
+    def test_accepts_uuid_string(self):
+        u = uuid.uuid4()
+        assert ParticipantId(str(u)).value == u
+
+    def test_rejects_invalid_string(self):
+        with pytest.raises(InvalidParticipantIdError):
+            ParticipantId("not-a-uuid")
+
+    def test_equality_and_hash(self):
+        u = uuid.uuid4()
+        assert ParticipantId(u) == ParticipantId(u)
+        assert hash(ParticipantId(u)) == hash(ParticipantId(u))

--- a/tests/unit/modules/quick_match/domain/value_objects/test_quick_match_participant.py
+++ b/tests/unit/modules/quick_match/domain/value_objects/test_quick_match_participant.py
@@ -4,27 +4,76 @@ from uuid import uuid4
 
 import pytest
 
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
-class TestQuickMatchParticipant:
-    def test_creates_with_no_team(self):
-        p = QuickMatchParticipant(user_id=UserId(uuid4()))
+class TestQuickMatchParticipantForUser:
+    def test_for_user_creates_with_no_team(self):
+        user_id = UserId(uuid4())
+        p = QuickMatchParticipant.for_user(user_id)
         assert p.team is None
+        assert p.user_id == user_id
+        assert not p.is_guest
+        assert p.participant_id == ParticipantId(user_id.value)
 
-    def test_creates_with_valid_team(self):
-        p = QuickMatchParticipant(user_id=UserId(uuid4()), team="A")
+    def test_for_user_creates_with_valid_team(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4()), team="A")
         assert p.team == "A"
 
-    def test_rejects_invalid_team(self):
+    def test_for_user_rejects_invalid_team(self):
         with pytest.raises(ValueError, match="team debe ser"):
-            QuickMatchParticipant(user_id=UserId(uuid4()), team="C")
+            QuickMatchParticipant.for_user(UserId(uuid4()), team="C")
 
-    def test_equality_by_user_id_only(self):
-        uid = UserId(uuid4())
-        assert QuickMatchParticipant(user_id=uid, team="A") == QuickMatchParticipant(
-            user_id=uid, team="B"
-        )
+    def test_for_user_has_no_manual_fields(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4()))
+        assert p.first_name is None
+        assert p.last_name is None
+        assert p.handicap is None
+
+
+class TestQuickMatchParticipantForGuest:
+    def test_for_guest_creates_without_user_id(self):
+        p = QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe")
+        assert p.is_guest
+        assert p.user_id is None
+        assert p.first_name == "Jane"
+        assert p.last_name == "Doe"
+        assert p.handicap is None
+
+    def test_for_guest_accepts_optional_handicap(self):
+        p = QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe", handicap=18.4)
+        assert p.handicap == 18.4
+
+    def test_for_guest_rejects_out_of_range_handicap(self):
+        with pytest.raises(ValueError, match="handicap debe estar entre"):
+            QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe", handicap=99)
+
+    def test_for_guest_requires_first_name(self):
+        with pytest.raises(ValueError, match="first_name"):
+            QuickMatchParticipant.for_guest(first_name="", last_name="Doe")
+
+    def test_for_guest_requires_last_name(self):
+        with pytest.raises(ValueError, match="last_name"):
+            QuickMatchParticipant.for_guest(first_name="Jane", last_name="")
+
+    def test_for_guest_generates_unique_participant_id(self):
+        a = QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe")
+        b = QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe")
+        assert a.participant_id != b.participant_id
+
+
+class TestQuickMatchParticipantEquality:
+    def test_equality_by_participant_id_only(self):
+        user_id = UserId(uuid4())
+        a = QuickMatchParticipant.for_user(user_id, team="A")
+        b = QuickMatchParticipant.for_user(user_id, team="B")
+        assert a == b
+
+    def test_hash_by_participant_id(self):
+        user_id = UserId(uuid4())
+        a = QuickMatchParticipant.for_user(user_id)
+        assert hash(a) == hash(ParticipantId(user_id.value))


### PR DESCRIPTION
## ⚠️ Stacked on #116
Third branch in the stack: `feature/friends-system` (#115) → `feature/quick-match` (#116) → this one. Base should be retargeted to `feature/quick-match` → eventually `develop`, in merge order.

## Summary
Extends BE #104 (quick match) per follow-up product requirements discussed during implementation:

- **Guest players**: `QuickMatchParticipant` now supports two variants — registered (`user_id`) and guest (no account: `first_name`/`last_name`/optional manual `handicap`, entered by the creator). Both share a new `ParticipantId` Value Object.
- **Scorer assignment**: starting a match now requires `scorer_ids` — 1 to 4 registered participants (always including the creator) who will operate the app during the round. New `ScoringCoverageService` (pure domain service) computes who covers whom:
  - Non-scorers (guests, or registered players not selected) are split as evenly as possible (integer division) across **all** scorers, creator included.
  - Any remainder from an uneven split is absorbed by the creator.
  - Confirmed with product: 1 scorer → covers everyone; 2 scorers/4 players → 2 each; 3 scorers/4 players → creator takes the extra one.
- **Proxy score submission**: new `POST /quick-matches/{id}/participants/{participant_id}/holes/{n}/score` — a scorer records a score on behalf of their assigned participant (403 otherwise). The existing self-submit endpoint now requires the caller to be a configured scorer.
- `QuickMatchHoleScore.player_user_id` → `participant_id` (drops the FK to `users`, since guests aren't user rows) + new `recorded_by_participant_id` for auditability.
- `GET /quick-matches/{id}` detail now includes `scorer_ids` and `scoring_assignments`.

## Test plan
- [x] 109 unit tests (up from 77): new `ParticipantId`/guest-variant VO tests, `ScoringCoverageService` (all confirmed distribution rules), `AddGuestToQuickMatchUseCase`, `SubmitProxyHoleScoreUseCase`, updated entity/use case tests — all passing
- [x] 8 integration tests (up from 5): guest + proxy-scoring full flow, non-scorer self-submit rejection (403), invalid scorer config (422) — all passing
- [x] `ruff check` clean, `mypy src/modules/quick_match` clean
- [x] Full existing suite (2156 unit + 280 integration) unaffected — no regressions
- [x] Found and fixed a real bug during testing: `QuickMatch.add_participant()` used in-place `list.append()`, which SQLAlchemy doesn't detect as a change on a JSONB column — participants added after the first weren't persisted. Fixed by reassigning the list.
- [x] Migration `9a9440cebb07` verified applied automatically on redeploy to the project's local Kind cluster (deployment runs `alembic upgrade head` on startup); schema verified correct via `\d`, no data loss (7 existing users intact); integration suite re-run against the cluster's Postgres, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guest participants to Quick Matches (manual name/team, optional handicap).
  * Match start now requires selecting 1–4 scorers (including the creator) to define scoring coverage.
  * Added scorer assignments/coverage to Quick Match details.
  * Added proxy hole scoring so assigned scorers can submit hole scores on behalf of covered participants.
* **Bug Fixes**
  * Enforced scorer-only hole submission and prevented unauthorized self/proxy scoring.
* **Tests**
  * Expanded unit/integration coverage for guests, scorer assignment/validation, proxy scoring, and new response fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->