### PR TITLE
fix(social): Flush delete before insert when resending declined friend request

### DIFF
--- a/src/modules/social/application/use_cases/send_friend_request_use_case.py
+++ b/src/modules/social/application/use_cases/send_friend_request_use_case.py
@@ -57,7 +57,11 @@ class SendFriendRequestUseCase:
                         "A friendship or pending request already exists between both users."
                     )
                 # DECLINED es terminal: se elimina el registro anterior y se reenvia.
+                # Flush explicito: el indice unico uq_friendship_pair (LEAST/GREATEST)
+                # rechaza el INSERT si el DELETE no se ha aplicado ya en BD (SQLAlchemy
+                # ordena inserts antes que deletes en el flush por defecto).
                 await self._uow.friendships.remove(existing)
+                await self._uow.flush()
 
             friendship = Friendship.create(
                 id=FriendshipId.generate(),

--- a/tests/integration/api/v1/test_friend_endpoints.py
+++ b/tests/integration/api/v1/test_friend_endpoints.py
@@ -64,6 +64,34 @@ class TestSendFriendRequest:
 
         assert response.status_code == 409
 
+    @pytest.mark.asyncio
+    async def test_resend_after_decline_succeeds(self, client: AsyncClient):
+        a = await create_authenticated_user(
+            client, "friend_o@test.com", "P@ssw0rd123!", "Friend", "Oo"
+        )
+        b = await create_authenticated_user(
+            client, "friend_p@test.com", "P@ssw0rd123!", "Friend", "Pp"
+        )
+
+        set_auth_cookies(client, a["cookies"])
+        first_response = await client.post(
+            "/api/v1/friends/requests", json={"addressee_id": b["user"]["id"]}
+        )
+        friendship_id = first_response.json()["id"]
+
+        set_auth_cookies(client, b["cookies"])
+        await client.post(
+            f"/api/v1/friends/requests/{friendship_id}/respond", json={"action": "DECLINE"}
+        )
+
+        set_auth_cookies(client, a["cookies"])
+        second_response = await client.post(
+            "/api/v1/friends/requests", json={"addressee_id": b["user"]["id"]}
+        )
+
+        assert second_response.status_code == 201
+        assert second_response.json()["status"] == "PENDING"
+
 
 class TestRespondFriendRequest:
     """Tests para POST /api/v1/friends/requests/{id}/respond"""


### PR DESCRIPTION
## Summary
- Resending a friend request to a user who previously declined it failed with a 500 (surfaced client-side as a CORS error, since the unhandled exception never got CORS headers attached).
- Root cause: `SendFriendRequestUseCase` removed the old `DECLINED` row and added the new `PENDING` one in the same transaction. SQLAlchemy's default flush order emits INSERTs before DELETEs, so the INSERT hit the `uq_friendship_pair` unique index (`LEAST/GREATEST(requester_id, addressee_id)`) while the old row still existed, raising an `IntegrityError`. Confirmed via the local K8s pod traceback.
- Fix: explicit `await self._uow.flush()` between `remove(existing)` and creating the new `Friendship`, forcing the DELETE to reach the DB first.

## Test plan
- [x] `pytest tests/unit/modules/social/ -q` — 77 passed
- [x] Added regression integration test `test_resend_after_decline_succeeds`; verified it reproduces the original `IntegrityError` when the fix is reverted, and passes with the fix
- [x] `pytest tests/integration/api/v1/test_friend_endpoints.py -q` — 9 passed (full file, against local K8s Postgres)
- [x] `ruff check` / `mypy` clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Friend requests can now be resent successfully after the previous request was declined.
  * Resent requests are correctly created with a pending status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->