### PR TITLE
feat(quick-match): Add participant handicap override before match start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Migration `b8e2f4a6c1d7`: adds `quick_matches.allowance_percentage` (nullable integer); tee selection lives inside the existing `participants` JSONB column, no schema change needed there.
 - New unit tests (participant tee fields, entity allowance validation/defaults, handicap-mapping regression) + 4 integration tests (default/custom allowance, invalid allowance → 422, tee round-trip through create + add-friend + detail).
 
+**Quick Match — Participant Handicap Override**
+
+- New `PATCH /api/v1/quick-matches/{id}/participants/{participant_id}/handicap` endpoint: the creator can set/override a participant's handicap while the match is `PENDING` — a manual value for guests, or a new `custom_handicap` override (takes precedence over `User.handicap`) for registered players, e.g. one without a handicap on their profile. 403 for non-creators, 409 once the match has started, 422 out of range (-10 to 54). No migration needed — `custom_handicap` lives inside the existing `participants` JSONB column.
+- Fixed a persistence bug found while testing this: `QuickMatchParticipant.__eq__` only compares `participant_id` (by design, for list operations like `is_participant`/`find_participant`), so SQLAlchemy's default dirty-check on the `participants` column — a same-length list `==` comparison — couldn't see a change when only one entry's handicap differed, and silently skipped the `UPDATE`. Editing a second participant would then persist only that one, discarding the first one's already-"saved" (but never actually written) override. Fixed by forcing `flag_modified()` in `SQLAlchemyQuickMatchRepository.update()`.
+- 20 new unit tests (VO override field, entity method, use case) + 6 integration tests against real Postgres, including a regression test that reproduces the exact persistence bug and re-fetches via a fresh request to prove the write actually reached the database.
+
 ## [2.1.0] - 2026-07-25
 
 ### Fixed

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -222,6 +222,9 @@ from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_cas
 from src.modules.quick_match.application.use_cases.remove_participant_use_case import (
     RemoveParticipantUseCase,
 )
+from src.modules.quick_match.application.use_cases.set_participant_handicap_use_case import (
+    SetParticipantHandicapUseCase,
+)
 from src.modules.quick_match.application.use_cases.start_quick_match_use_case import (
     StartQuickMatchUseCase,
 )
@@ -1042,6 +1045,14 @@ def get_remove_quick_match_participant_use_case(
 ) -> RemoveParticipantUseCase:
     """Proveedor del caso de uso RemoveParticipantUseCase."""
     return RemoveParticipantUseCase(uow, user_uow)
+
+
+def get_set_quick_match_participant_handicap_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> SetParticipantHandicapUseCase:
+    """Proveedor del caso de uso SetParticipantHandicapUseCase."""
+    return SetParticipantHandicapUseCase(uow, user_uow)
 
 
 def get_start_quick_match_use_case(

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -6,6 +6,10 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.modules.quick_match.domain.entities.quick_match import MAX_NAME_LENGTH, MAX_SCORERS
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    MAX_HANDICAP,
+    MIN_HANDICAP,
+)
 
 TEE_CATEGORY_PATTERN = "^(CHAMPIONSHIP|AMATEUR|SENIOR|FORWARD|JUNIOR)$"
 TEE_GENDER_PATTERN = "^(MALE|FEMALE)$"
@@ -90,7 +94,7 @@ class SetParticipantHandicapRequestDTO(BaseModel):
     quick_match_id: UUID
     requester_id: UUID
     target_participant_id: UUID
-    handicap: float | None = Field(None, ge=-10.0, le=54.0)
+    handicap: float | None = Field(None, ge=MIN_HANDICAP, le=MAX_HANDICAP)
 
 
 class RemoveParticipantRequestDTO(BaseModel):

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -84,6 +84,15 @@ class AddGuestParticipantRequestDTO(BaseModel):
         return self
 
 
+class SetParticipantHandicapRequestDTO(BaseModel):
+    """DTO para editar el handicap (manual u override) de un participante, en PENDING."""
+
+    quick_match_id: UUID
+    requester_id: UUID
+    target_participant_id: UUID
+    handicap: float | None = Field(None, ge=-10.0, le=54.0)
+
+
 class RemoveParticipantRequestDTO(BaseModel):
     """DTO para eliminar un participante (leave o kick por el creador)."""
 

--- a/src/modules/quick_match/application/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/application/mappers/quick_match_mapper.py
@@ -46,7 +46,8 @@ class QuickMatchDTOMapper:
             else:
                 user = users_by_id.get(p.user_id)
                 name = f"{user.first_name} {user.last_name}" if user else "Unknown"
-                handicap = user.handicap.value if user and user.handicap else None
+                profile_handicap = user.handicap.value if user and user.handicap else None
+                handicap = p.custom_handicap if p.custom_handicap is not None else profile_handicap
             participants_dto.append(
                 QuickMatchParticipantDTO(
                     participant_id=p.participant_id.value,

--- a/src/modules/quick_match/application/use_cases/set_participant_handicap_use_case.py
+++ b/src/modules/quick_match/application/use_cases/set_participant_handicap_use_case.py
@@ -1,0 +1,55 @@
+"""Caso de Uso: Editar el handicap de un participante antes de iniciar la partida."""
+
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    QuickMatchResponseDTO,
+    SetParticipantHandicapRequestDTO,
+)
+from src.modules.quick_match.application.exceptions import (
+    NotQuickMatchCreatorError,
+    QuickMatchNotFoundError,
+)
+from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SetParticipantHandicapUseCase:
+    """
+    Edita el handicap de un participante (manual para invitados, override para
+    registrados) mientras la partida esta PENDING — pensado para el resumen
+    previo a `start()`.
+
+    Solo el creador puede editarlo.
+    """
+
+    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(self, request: SetParticipantHandicapRequestDTO) -> QuickMatchResponseDTO:
+        requester_id = UserId(request.requester_id)
+        target_participant_id = ParticipantId(request.target_participant_id)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
+                QuickMatchId(request.quick_match_id)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
+
+            if quick_match.creator_id != requester_id:
+                raise NotQuickMatchCreatorError(
+                    "Only the quick match creator can edit a participant's handicap."
+                )
+
+            quick_match.set_participant_handicap(target_participant_id, request.handicap)
+            await self._uow.quick_matches.update(quick_match)
+
+        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -19,6 +19,9 @@ from ..events.quick_match_cancelled_event import QuickMatchCancelledEvent
 from ..events.quick_match_completed_event import QuickMatchCompletedEvent
 from ..events.quick_match_created_event import QuickMatchCreatedEvent
 from ..events.quick_match_participant_added_event import QuickMatchParticipantAddedEvent
+from ..events.quick_match_participant_handicap_updated_event import (
+    QuickMatchParticipantHandicapUpdatedEvent,
+)
 from ..events.quick_match_participant_removed_event import QuickMatchParticipantRemovedEvent
 from ..events.quick_match_started_event import QuickMatchStartedEvent
 from ..exceptions.quick_match_violations import (
@@ -421,6 +424,41 @@ class QuickMatch:
         self.add_domain_event(
             QuickMatchParticipantRemovedEvent(
                 quick_match_id=str(self._id), participant_id=str(participant_id)
+            )
+        )
+
+    def set_participant_handicap(self, participant_id: ParticipantId, handicap: float | None) -> None:
+        """
+        Edita el handicap de un participante mientras la partida esta PENDING.
+
+        Manual (`handicap`) para invitados, override (`custom_handicap`) para
+        registrados — pensado para el resumen previo a `start()`, donde el creador
+        puede ajustar el handicap de quien no tenga uno en su perfil.
+        """
+        if not self._status.is_pending():
+            raise InvalidQuickMatchStatusViolation(
+                f"Cannot edit participant handicap in status {self._status.value}."
+            )
+
+        participant = self.find_participant(participant_id)
+        if participant is None:
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        updated_participant = participant.with_handicap(handicap)
+        now = datetime.now()
+        self._participants = [
+            updated_participant if p.participant_id == participant_id else p
+            for p in self._participants
+        ]
+        self._updated_at = now
+
+        self.add_domain_event(
+            QuickMatchParticipantHandicapUpdatedEvent(
+                quick_match_id=str(self._id),
+                participant_id=str(participant_id),
+                handicap=handicap,
             )
         )
 

--- a/src/modules/quick_match/domain/events/quick_match_participant_handicap_updated_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_participant_handicap_updated_event.py
@@ -1,0 +1,14 @@
+"""QuickMatchParticipantHandicapUpdatedEvent - Se emite al editar el handicap de un participante."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchParticipantHandicapUpdatedEvent(DomainEvent):
+    """Evento emitido cuando el creador edita el handicap (manual u override) de un participante."""
+
+    quick_match_id: str
+    participant_id: str
+    handicap: float | None

--- a/src/modules/quick_match/domain/value_objects/quick_match_participant.py
+++ b/src/modules/quick_match/domain/value_objects/quick_match_participant.py
@@ -2,15 +2,17 @@
 QuickMatchParticipant Value Object - Participante de una partida rapida.
 
 Admite dos variantes:
-- Registrado: tiene `user_id`, sin datos manuales.
-- Invitado: sin cuenta, con nombre/apellidos y handicap introducidos a mano.
+- Registrado: tiene `user_id`, sin datos manuales; opcionalmente `custom_handicap`
+  como override del handicap de su perfil (`User.handicap`), fijado por el creador
+  antes de confirmar la partida (p.ej. si el registrado no tiene handicap propio).
+- Invitado: sin cuenta, con nombre/apellidos y `handicap` introducido a mano.
 
 Ambas comparten `participant_id` como identificador estable (coincide con
 `user_id.value` para registrados; generado para invitados), usado para
 listar, eliminar y asignar anotador independientemente del tipo.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -29,8 +31,10 @@ class QuickMatchParticipant:
     Value Object que representa a un jugador dentro de una partida rapida.
 
     - `team` es None para SINGLES (no hay equipos), "A" o "B" para FOURBALL/FOURSOMES.
-    - Registrado: `user_id` presente, `first_name`/`last_name`/`handicap` None.
-    - Invitado: `user_id` None, `first_name`/`last_name` obligatorios, `handicap` opcional.
+    - Registrado: `user_id` presente, `first_name`/`last_name`/`handicap` None,
+      `custom_handicap` opcional (override manual).
+    - Invitado: `user_id` None, `first_name`/`last_name` obligatorios, `handicap`
+      opcional, sin `custom_handicap` (usa `handicap` para lo mismo).
     - `tee_category`/`tee_gender` identifican el tee elegido para el Playing Handicap
       (par unico junto con `tee_gender` en el campo de golf, igual que `Enrollment.tee_category`
       en `competition`); opcionales, sin tee elegido no se calcula Playing Handicap.
@@ -44,6 +48,7 @@ class QuickMatchParticipant:
     team: str | None = None
     tee_category: TeeCategory | None = None
     tee_gender: Gender | None = None
+    custom_handicap: float | None = None
 
     def __post_init__(self):
         if self.team is not None and self.team not in VALID_TEAMS:
@@ -59,9 +64,15 @@ class QuickMatchParticipant:
                 raise ValueError("Un participante invitado requiere first_name.")
             if not self.last_name or not self.last_name.strip():
                 raise ValueError("Un participante invitado requiere last_name.")
+            if self.custom_handicap is not None:
+                raise ValueError("Un invitado no lleva custom_handicap; usa handicap.")
 
         if self.handicap is not None and not (MIN_HANDICAP <= self.handicap <= MAX_HANDICAP):
             raise ValueError(f"handicap debe estar entre {MIN_HANDICAP} y {MAX_HANDICAP}.")
+        if self.custom_handicap is not None and not (
+            MIN_HANDICAP <= self.custom_handicap <= MAX_HANDICAP
+        ):
+            raise ValueError(f"custom_handicap debe estar entre {MIN_HANDICAP} y {MAX_HANDICAP}.")
 
         if self.tee_gender is not None and self.tee_category is None:
             raise ValueError("tee_gender requiere tee_category (un genero solo no identifica un tee).")
@@ -69,6 +80,15 @@ class QuickMatchParticipant:
     @property
     def is_guest(self) -> bool:
         return self.user_id is None
+
+    def with_handicap(self, handicap: float | None) -> "QuickMatchParticipant":
+        """
+        Devuelve una copia con el handicap actualizado: `handicap` manual si es
+        invitado, `custom_handicap` (override) si es registrado.
+        """
+        if self.is_guest:
+            return replace(self, handicap=handicap)
+        return replace(self, custom_handicap=handicap)
 
     @classmethod
     def for_user(

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -21,6 +21,7 @@ from src.config.dependencies import (
     get_get_quick_match_use_case,
     get_list_my_quick_matches_use_case,
     get_remove_quick_match_participant_use_case,
+    get_set_quick_match_participant_handicap_use_case,
     get_start_quick_match_use_case,
     get_submit_quick_match_hole_score_use_case,
     get_submit_quick_match_proxy_hole_score_use_case,
@@ -37,6 +38,7 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     QuickMatchDetailResponseDTO,
     QuickMatchResponseDTO,
     RemoveParticipantRequestDTO,
+    SetParticipantHandicapRequestDTO,
     StartQuickMatchRequestDTO,
     SubmitHoleScoreRequestDTO,
     SubmitProxyHoleScoreRequestDTO,
@@ -77,6 +79,9 @@ from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_cas
 )
 from src.modules.quick_match.application.use_cases.remove_participant_use_case import (
     RemoveParticipantUseCase,
+)
+from src.modules.quick_match.application.use_cases.set_participant_handicap_use_case import (
+    SetParticipantHandicapUseCase,
 )
 from src.modules.quick_match.application.use_cases.start_quick_match_use_case import (
     StartQuickMatchUseCase,
@@ -177,6 +182,12 @@ class AddGuestParticipantBody(BaseModel):
     def _tee_gender_requires_category(self) -> "AddGuestParticipantBody":
         _require_tee_category_for_gender(self.tee_category, self.tee_gender)
         return self
+
+
+class SetParticipantHandicapBody(BaseModel):
+    """Body para editar el handicap de un participante (manual u override)."""
+
+    handicap: float | None = Field(None, ge=-10.0, le=54.0)
 
 
 class StartQuickMatchBody(BaseModel):
@@ -351,6 +362,44 @@ async def remove_participant(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except CreatorCannotBeRemovedViolation as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except InvalidQuickMatchStatusViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.patch(
+    "/quick-matches/{quick_match_id}/participants/{target_participant_id}/handicap",
+    response_model=QuickMatchResponseDTO,
+    summary="Set participant handicap",
+    description=(
+        "Creator sets/overrides a participant's handicap before starting the match — "
+        "a manual value for guests, or an override for registered players (e.g. one "
+        "without a handicap on their profile). Only allowed while the match is PENDING."
+    ),
+)
+async def set_participant_handicap(
+    quick_match_id: UUID,
+    target_participant_id: UUID,
+    body: SetParticipantHandicapBody,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: SetParticipantHandicapUseCase = Depends(
+        get_set_quick_match_participant_handicap_use_case
+    ),
+):
+    try:
+        request_dto = SetParticipantHandicapRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+            target_participant_id=target_participant_id,
+            handicap=body.handicap,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchCreatorError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotQuickMatchParticipantViolation as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -28,8 +28,10 @@ from src.config.dependencies import (
 )
 from src.config.rate_limit import limiter
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    MAX_HANDICAP,
     MAX_NAME_LENGTH,
     MAX_SCORERS,
+    MIN_HANDICAP,
     AddGuestParticipantRequestDTO,
     AddParticipantRequestDTO,
     CreateQuickMatchRequestDTO,
@@ -187,7 +189,7 @@ class AddGuestParticipantBody(BaseModel):
 class SetParticipantHandicapBody(BaseModel):
     """Body para editar el handicap de un participante (manual u override)."""
 
-    handicap: float | None = Field(None, ge=-10.0, le=54.0)
+    handicap: float | None = Field(None, ge=MIN_HANDICAP, le=MAX_HANDICAP)
 
 
 class StartQuickMatchBody(BaseModel):
@@ -404,6 +406,8 @@ async def set_participant_handicap(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post(

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -199,6 +199,7 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
         "first_name": "..." | null,             # solo invitados
         "last_name": "..." | null,              # solo invitados
         "handicap": number | null,              # solo invitados (opcional)
+        "custom_handicap": number | null,       # solo registrados (override, opcional)
         "team": "A" | "B" | null,
         "tee_category": "AMATEUR" | ... | null,
         "tee_gender": "MALE" | "FEMALE" | null
@@ -218,6 +219,7 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
                 "first_name": p.first_name,
                 "last_name": p.last_name,
                 "handicap": p.handicap,
+                "custom_handicap": p.custom_handicap,
                 "team": p.team,
                 "tee_category": p.tee_category.value if p.tee_category else None,
                 "tee_gender": p.tee_gender.value if p.tee_gender else None,
@@ -237,6 +239,7 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
                     first_name=p.get("first_name"),
                     last_name=p.get("last_name"),
                     handicap=p.get("handicap"),
+                    custom_handicap=p.get("custom_handicap"),
                     team=p.get("team"),
                     tee_category=(
                         TeeCategory(p["tee_category"]) if p.get("tee_category") else None

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -3,6 +3,7 @@
 from sqlalchemy import and_, cast, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.repositories.quick_match_repository_interface import (
@@ -27,6 +28,12 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
 
     async def update(self, quick_match: QuickMatch) -> None:
         self._session.add(quick_match)
+        # QuickMatchParticipant.__eq__ compares only participant_id (by domain design,
+        # for stable identity across list ops) — so SQLAlchemy's default dirty-check
+        # on the `participants` JSONB column (list equality via `==`) can't see a
+        # same-length list where only e.g. custom_handicap changed on one entry, and
+        # silently skips writing it. Force it into every UPDATE regardless.
+        flag_modified(quick_match, "_participants")
 
     async def find_by_id(self, quick_match_id: QuickMatchId) -> QuickMatch | None:
         return await self._session.get(QuickMatch, quick_match_id)

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -664,3 +664,267 @@ class TestQuickMatchGuestsAndScoringAssignment:
         )
 
         assert response.status_code == 422
+
+
+class TestQuickMatchSetParticipantHandicap:
+    """Tests para PATCH /api/v1/quick-matches/{id}/participants/{participant_id}/handicap"""
+
+    @pytest.mark.asyncio
+    async def test_creator_overrides_registered_participant_without_profile_handicap(
+        self, client: AsyncClient
+    ):
+        admin = await create_admin_user(
+            client, "qm_admin_hc1@test.com", "P@ssw0rd123!", "Admin", "HcOne"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc1@test.com", "P@ssw0rd123!", "Creator", "HcOne"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_hc1@test.com", "P@ssw0rd123!", "Friend", "HcOne"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        add_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        friend_dto = next(
+            p for p in add_response.json()["participants"] if p["user_id"] == friend["user"]["id"]
+        )
+        assert friend_dto["handicap"] is None
+
+        response = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{friend_dto['participant_id']}"
+            "/handicap",
+            json={"handicap": 16.4},
+        )
+
+        assert response.status_code == 200, response.text
+        updated_dto = next(
+            p for p in response.json()["participants"] if p["participant_id"] == friend_dto["participant_id"]
+        )
+        assert updated_dto["handicap"] == 16.4
+
+        # Re-fetch on a fresh request/DB session — the PATCH response alone reflects
+        # the in-memory entity and doesn't prove the write actually reached Postgres.
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        persisted_dto = next(
+            p
+            for p in detail_response.json()["participants"]
+            if p["participant_id"] == friend_dto["participant_id"]
+        )
+        assert persisted_dto["handicap"] == 16.4
+
+    @pytest.mark.asyncio
+    async def test_editing_two_participants_handicaps_both_persist(self, client: AsyncClient):
+        """
+        Regression test: QuickMatchParticipant.__eq__ only compares participant_id
+        (by domain design), so SQLAlchemy's default dirty-check on the `participants`
+        JSONB column — which compares old vs new Python list via `==` — couldn't see
+        a same-length list where only one entry's handicap changed, and silently
+        skipped writing it. Editing a second participant would then persist only
+        that one, discarding the first one's already-"saved" (but never actually
+        written) override. Fixed by force-flagging the column as modified in
+        SQLAlchemyQuickMatchRepository.update().
+        """
+        admin = await create_admin_user(
+            client, "qm_admin_hc6@test.com", "P@ssw0rd123!", "Admin", "HcSix"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc6@test.com", "P@ssw0rd123!", "Creator", "HcSix"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_hc6@test.com", "P@ssw0rd123!", "Friend", "HcSix"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        add_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        friend_participant_id = next(
+            p["participant_id"]
+            for p in add_response.json()["participants"]
+            if p["user_id"] == friend["user"]["id"]
+        )
+        creator_participant_id = creator["user"]["id"]
+
+        first_patch = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{creator_participant_id}"
+            "/handicap",
+            json={"handicap": 15.0},
+        )
+        assert first_patch.status_code == 200, first_patch.text
+
+        second_patch = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{friend_participant_id}"
+            "/handicap",
+            json={"handicap": 20.0},
+        )
+        assert second_patch.status_code == 200, second_patch.text
+
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        participants_by_id = {
+            p["participant_id"]: p["handicap"] for p in detail_response.json()["participants"]
+        }
+        assert participants_by_id[creator_participant_id] == 15.0
+        assert participants_by_id[friend_participant_id] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_creator_edits_guest_handicap(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "qm_admin_hc2@test.com", "P@ssw0rd123!", "Admin", "HcTwo"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc2@test.com", "P@ssw0rd123!", "Creator", "HcTwo"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        guest_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/guest",
+            json={"first_name": "Jane", "last_name": "Doe", "handicap": 18.4},
+        )
+        guest_participant_id = next(
+            p for p in guest_response.json()["participants"] if p["is_guest"]
+        )["participant_id"]
+
+        response = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{guest_participant_id}"
+            "/handicap",
+            json={"handicap": 20.1},
+        )
+
+        assert response.status_code == 200, response.text
+        updated_dto = next(
+            p for p in response.json()["participants"] if p["participant_id"] == guest_participant_id
+        )
+        assert updated_dto["handicap"] == 20.1
+
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        persisted_dto = next(
+            p
+            for p in detail_response.json()["participants"]
+            if p["participant_id"] == guest_participant_id
+        )
+        assert persisted_dto["handicap"] == 20.1
+
+    @pytest.mark.asyncio
+    async def test_non_creator_cannot_edit_handicap_returns_403(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "qm_admin_hc3@test.com", "P@ssw0rd123!", "Admin", "HcThree"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc3@test.com", "P@ssw0rd123!", "Creator", "HcThree"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_hc3@test.com", "P@ssw0rd123!", "Friend", "HcThree"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        add_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        friend_participant_id = next(
+            p["participant_id"]
+            for p in add_response.json()["participants"]
+            if p["user_id"] == friend["user"]["id"]
+        )
+
+        set_auth_cookies(client, friend["cookies"])
+        response = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{friend_participant_id}"
+            "/handicap",
+            json={"handicap": 10.0},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_edit_handicap_after_start_returns_409(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "qm_admin_hc4@test.com", "P@ssw0rd123!", "Admin", "HcFour"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc4@test.com", "P@ssw0rd123!", "Creator", "HcFour"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        guest_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/guest",
+            json={"first_name": "Jane", "last_name": "Doe"},
+        )
+        guest_participant_id = next(
+            p for p in guest_response.json()["participants"] if p["is_guest"]
+        )["participant_id"]
+
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"]]},
+        )
+
+        response = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{guest_participant_id}"
+            "/handicap",
+            json={"handicap": 10.0},
+        )
+
+        assert response.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_edit_handicap_out_of_range_returns_422(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "qm_admin_hc5@test.com", "P@ssw0rd123!", "Admin", "HcFive"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hc5@test.com", "P@ssw0rd123!", "Creator", "HcFive"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+
+        response = await client.patch(
+            f"/api/v1/quick-matches/{quick_match_id}/participants/{creator['user']['id']}"
+            "/handicap",
+            json={"handicap": 99},
+        )
+
+        assert response.status_code == 422

--- a/tests/unit/modules/quick_match/application/use_cases/test_set_participant_handicap_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_set_participant_handicap_use_case.py
@@ -1,0 +1,159 @@
+"""Tests para SetParticipantHandicapUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    SetParticipantHandicapRequestDTO,
+)
+from src.modules.quick_match.application.exceptions import (
+    NotQuickMatchCreatorError,
+    QuickMatchNotFoundError,
+)
+from src.modules.quick_match.application.use_cases.set_participant_handicap_use_case import (
+    SetParticipantHandicapUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidQuickMatchStatusViolation,
+    NotQuickMatchParticipantViolation,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from tests.unit.modules.quick_match.conftest import create_user, unique_email
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_pending_match_with_participant(qm_uow, creator_id, other_user_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    other = QuickMatchParticipant.for_user(other_user_id)
+    qm.add_participant(other)
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm, other
+
+
+class TestSetParticipantHandicapUseCase:
+    async def test_creator_sets_override_for_registered_without_profile_handicap(
+        self, qm_uow, user_uow
+    ):
+        creator_user = await create_user(user_uow, unique_email("creator"), handicap=10.0)
+        other_user = await create_user(user_uow, unique_email("other"), handicap=None)
+        qm, other = await _create_pending_match_with_participant(
+            qm_uow, creator_user.id, other_user.id
+        )
+
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        response = await use_case.execute(
+            SetParticipantHandicapRequestDTO(
+                quick_match_id=qm.id.value,
+                requester_id=creator_user.id.value,
+                target_participant_id=other.participant_id.value,
+                handicap=16.4,
+            )
+        )
+
+        target_dto = next(
+            p for p in response.participants if p.participant_id == other.participant_id.value
+        )
+        assert target_dto.handicap == 16.4
+
+    async def test_override_takes_precedence_over_profile_handicap(self, qm_uow, user_uow):
+        creator_user = await create_user(user_uow, unique_email("creator"), handicap=10.0)
+        other_user = await create_user(user_uow, unique_email("other"), handicap=8.0)
+        qm, other = await _create_pending_match_with_participant(
+            qm_uow, creator_user.id, other_user.id
+        )
+
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        response = await use_case.execute(
+            SetParticipantHandicapRequestDTO(
+                quick_match_id=qm.id.value,
+                requester_id=creator_user.id.value,
+                target_participant_id=other.participant_id.value,
+                handicap=20.0,
+            )
+        )
+
+        target_dto = next(
+            p for p in response.participants if p.participant_id == other.participant_id.value
+        )
+        assert target_dto.handicap == 20.0
+
+    async def test_non_creator_cannot_edit_handicap(self, qm_uow, user_uow):
+        creator_user = await create_user(user_uow, unique_email("creator"), handicap=10.0)
+        other_user = await create_user(user_uow, unique_email("other"), handicap=None)
+        qm, other = await _create_pending_match_with_participant(
+            qm_uow, creator_user.id, other_user.id
+        )
+
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        with pytest.raises(NotQuickMatchCreatorError):
+            await use_case.execute(
+                SetParticipantHandicapRequestDTO(
+                    quick_match_id=qm.id.value,
+                    requester_id=other_user.id.value,
+                    target_participant_id=other.participant_id.value,
+                    handicap=16.4,
+                )
+            )
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                SetParticipantHandicapRequestDTO(
+                    quick_match_id=uuid4(),
+                    requester_id=uuid4(),
+                    target_participant_id=uuid4(),
+                    handicap=10.0,
+                )
+            )
+
+    async def test_non_participant_raises(self, qm_uow, user_uow):
+        creator_user = await create_user(user_uow, unique_email("creator"), handicap=10.0)
+        other_user = await create_user(user_uow, unique_email("other"), handicap=None)
+        qm, _other = await _create_pending_match_with_participant(
+            qm_uow, creator_user.id, other_user.id
+        )
+
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            await use_case.execute(
+                SetParticipantHandicapRequestDTO(
+                    quick_match_id=qm.id.value,
+                    requester_id=creator_user.id.value,
+                    target_participant_id=uuid4(),
+                    handicap=10.0,
+                )
+            )
+
+    async def test_not_pending_raises(self, qm_uow, user_uow):
+        creator_user = await create_user(user_uow, unique_email("creator"), handicap=10.0)
+        other_user = await create_user(user_uow, unique_email("other"), handicap=None)
+        qm, other = await _create_pending_match_with_participant(
+            qm_uow, creator_user.id, other_user.id
+        )
+        qm.start([qm.creator_participant_id])
+
+        use_case = SetParticipantHandicapUseCase(qm_uow, user_uow)
+        with pytest.raises(InvalidQuickMatchStatusViolation):
+            await use_case.execute(
+                SetParticipantHandicapRequestDTO(
+                    quick_match_id=qm.id.value,
+                    requester_id=creator_user.id.value,
+                    target_participant_id=other.participant_id.value,
+                    handicap=10.0,
+                )
+            )

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -19,6 +19,9 @@ from src.modules.quick_match.domain.events.quick_match_created_event import (
 from src.modules.quick_match.domain.events.quick_match_participant_added_event import (
     QuickMatchParticipantAddedEvent,
 )
+from src.modules.quick_match.domain.events.quick_match_participant_handicap_updated_event import (
+    QuickMatchParticipantHandicapUpdatedEvent,
+)
 from src.modules.quick_match.domain.events.quick_match_participant_removed_event import (
     QuickMatchParticipantRemovedEvent,
 )
@@ -228,6 +231,73 @@ class TestQuickMatchRemoveParticipant:
         qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
             qm.remove_participant(other.participant_id)
+
+
+class TestQuickMatchSetParticipantHandicap:
+    def test_set_registered_participant_handicap_sets_override(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        qm.clear_domain_events()
+
+        qm.set_participant_handicap(other.participant_id, 12.3)
+
+        updated = qm.find_participant(other.participant_id)
+        assert updated.custom_handicap == 12.3
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchParticipantHandicapUpdatedEvent)
+
+    def test_set_guest_participant_handicap_sets_manual_handicap(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        guest = _guest()
+        qm.add_participant(guest)
+
+        qm.set_participant_handicap(guest.participant_id, 24.0)
+
+        assert qm.find_participant(guest.participant_id).handicap == 24.0
+
+    def test_set_participant_handicap_none_clears_it(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        guest = _guest()
+        qm.add_participant(guest)
+        qm.set_participant_handicap(guest.participant_id, 24.0)
+
+        qm.set_participant_handicap(guest.participant_id, None)
+
+        assert qm.find_participant(guest.participant_id).handicap is None
+
+    def test_set_handicap_preserves_other_participant_fields(self):
+        qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
+        other = _registered(team="B")
+        qm.add_participant(other)
+
+        qm.set_participant_handicap(other.participant_id, 5.0)
+
+        updated = qm.find_participant(other.participant_id)
+        assert updated.team == "B"
+        assert updated.user_id == other.user_id
+
+    def test_set_handicap_for_non_participant_raises(self):
+        qm = _make_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.set_participant_handicap(ParticipantId.generate(), 10.0)
+
+    def test_set_handicap_not_pending_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        qm.start([qm.creator_participant_id])
+
+        with pytest.raises(InvalidQuickMatchStatusViolation):
+            qm.set_participant_handicap(other.participant_id, 10.0)
+
+    def test_set_handicap_out_of_range_raises(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        with pytest.raises(ValueError, match="custom_handicap debe estar entre"):
+            qm.set_participant_handicap(other.participant_id, 99)
 
 
 class TestQuickMatchStart:

--- a/tests/unit/modules/quick_match/domain/value_objects/test_quick_match_participant.py
+++ b/tests/unit/modules/quick_match/domain/value_objects/test_quick_match_participant.py
@@ -52,6 +52,22 @@ class TestQuickMatchParticipantForUser:
         with pytest.raises(ValueError, match="tee_gender requiere tee_category"):
             QuickMatchParticipant.for_user(UserId(uuid4()), tee_gender=Gender.MALE)
 
+    def test_for_user_defaults_to_no_custom_handicap(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4()))
+        assert p.custom_handicap is None
+
+    def test_registered_rejects_custom_handicap_out_of_range(self):
+        user_id = UserId(uuid4())
+        with pytest.raises(ValueError, match="custom_handicap debe estar entre"):
+            QuickMatchParticipant(
+                participant_id=ParticipantId(user_id.value),
+                user_id=user_id,
+                first_name=None,
+                last_name=None,
+                handicap=None,
+                custom_handicap=99,
+            )
+
 
 class TestQuickMatchParticipantForGuest:
     def test_for_guest_creates_without_user_id(self):
@@ -92,6 +108,42 @@ class TestQuickMatchParticipantForGuest:
         )
         assert p.tee_category == TeeCategory.FORWARD
         assert p.tee_gender == Gender.FEMALE
+
+    def test_guest_rejects_custom_handicap(self):
+        with pytest.raises(ValueError, match="Un invitado no lleva custom_handicap"):
+            QuickMatchParticipant(
+                participant_id=ParticipantId.generate(),
+                user_id=None,
+                first_name="Jane",
+                last_name="Doe",
+                handicap=None,
+                custom_handicap=12.0,
+            )
+
+
+class TestQuickMatchParticipantWithHandicap:
+    def test_registered_with_handicap_sets_custom_handicap(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4()))
+        updated = p.with_handicap(15.5)
+        assert updated.custom_handicap == 15.5
+        assert updated.handicap is None
+        assert updated.participant_id == p.participant_id
+
+    def test_registered_with_handicap_none_clears_override(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4())).with_handicap(15.5)
+        cleared = p.with_handicap(None)
+        assert cleared.custom_handicap is None
+
+    def test_guest_with_handicap_sets_handicap(self):
+        p = QuickMatchParticipant.for_guest(first_name="Jane", last_name="Doe")
+        updated = p.with_handicap(9.2)
+        assert updated.handicap == 9.2
+        assert updated.custom_handicap is None
+
+    def test_with_handicap_rejects_out_of_range(self):
+        p = QuickMatchParticipant.for_user(UserId(uuid4()))
+        with pytest.raises(ValueError, match="custom_handicap debe estar entre"):
+            p.with_handicap(99)
 
 
 class TestQuickMatchParticipantEquality:


### PR DESCRIPTION
Closes #122

## Summary
- New `PATCH /api/v1/quick-matches/{id}/participants/{participant_id}/handicap` endpoint: the creator can set/override a participant's handicap while the match is `PENDING` — a manual value for guests, or a `custom_handicap` override for registered players (e.g. one without a handicap on their profile). Only allowed while `PENDING`; 403 for non-creators, 409 once started, 422 out of range.
- No Alembic migration needed — participants are stored as an embedded JSONB list, so the new `custom_handicap` field round-trips through the existing `QuickMatchParticipantsJsonType` decorator.
- **Bug fix found while testing this feature**: `QuickMatchParticipant.__eq__` only compares `participant_id` (by design, for list operations like `is_participant`/`find_participant`), so SQLAlchemy's default dirty-check on the `participants` JSONB column — a same-length list `==` comparison — couldn't see a change when only one entry's handicap differed, and silently skipped the `UPDATE`. Editing a second participant would then persist only that one, discarding the first one's already-"saved" (but never actually written) override. Fixed by forcing `flag_modified()` in `SQLAlchemyQuickMatchRepository.update()`.

## Test plan
- [x] 20 new unit tests (domain VO + entity + use case) — all passing
- [x] 6 integration tests against real Postgres, including a regression test (`test_editing_two_participants_handicaps_both_persist`) that reproduces the exact persistence bug — confirmed it fails without the `flag_modified()` fix and passes with it
- [x] Existing PATCH persistence assertions upgraded to re-fetch via a fresh `GET` request/session (not just the immediate response) to actually prove the write reached Postgres
- [x] `ruff` and `mypy` clean
- [x] Manually verified end-to-end in a real browser against a local Kind cluster (create match → add friend without profile handicap → summary step → edit handicap via keypad → confirm → start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `PATCH` endpoint for match creators to set, override, or clear participant handicaps while a Quick Match is pending.
  * Registered participants now support an optional handicap override; guest participants use a manual handicap.
  * Handicap updates are range-validated and reflected in match details.

* **Bug Fixes**
  * Fixed an issue where participant handicap edits were not consistently saved.

* **Tests**
  * Added unit and integration tests covering the endpoint, permissions, match state, validation, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
