### PR TITLE
chore(merge): Sync develop with main after v2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-29
+
 ### Added
 
 **Social — Friends System (BE #103)**


### PR DESCRIPTION
## Summary
- Merge-back of `main` into `develop` after the v2.2.0 release (PR #123), per GitFlow.

## Test plan
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog section for version 2.2.0, dated July 29, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->