### PR TITLE
refactor(quick-match): Inject ScoringService/ScoringCoverageService via DI

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -237,6 +237,9 @@ from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_c
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
+)
 from src.modules.quick_match.infrastructure.persistence.sqlalchemy.quick_match_unit_of_work import (
     SQLAlchemyQuickMatchUnitOfWork,
 )
@@ -1197,19 +1200,32 @@ def get_submit_quick_match_hole_score_use_case(
     return SubmitQuickMatchHoleScoreUseCase(uow)
 
 
+def get_scoring_service() -> ScoringService:
+    """Proveedor del servicio de dominio ScoringService."""
+    return ScoringService()
+
+
+def get_scoring_coverage_service() -> ScoringCoverageService:
+    """Proveedor del servicio de dominio ScoringCoverageService."""
+    return ScoringCoverageService()
+
+
 def get_submit_quick_match_proxy_hole_score_use_case(
     uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    coverage_service: ScoringCoverageService = Depends(get_scoring_coverage_service),
 ) -> SubmitProxyHoleScoreUseCase:
     """Proveedor del caso de uso SubmitProxyHoleScoreUseCase."""
-    return SubmitProxyHoleScoreUseCase(uow)
+    return SubmitProxyHoleScoreUseCase(uow, coverage_service)
 
 
 def get_get_quick_match_use_case(
     uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    scoring_service: ScoringService = Depends(get_scoring_service),
+    coverage_service: ScoringCoverageService = Depends(get_scoring_coverage_service),
 ) -> GetQuickMatchUseCase:
     """Proveedor del caso de uso GetQuickMatchUseCase."""
-    return GetQuickMatchUseCase(uow, user_uow)
+    return GetQuickMatchUseCase(uow, user_uow, scoring_service, coverage_service)
 
 
 def get_list_my_quick_matches_use_case(
@@ -1578,11 +1594,6 @@ def get_assign_teams_use_case(
         user_repository=user_uow.users,
         snake_draft_service=SnakeDraftService(),
     )
-
-
-def get_scoring_service() -> ScoringService:
-    """Proveedor del servicio de dominio ScoringService."""
-    return ScoringService()
 
 
 def get_generate_matches_use_case(

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -31,11 +31,17 @@ TOTAL_HOLES = 18
 class GetQuickMatchUseCase:
     """Obtiene el detalle de una partida rapida: datos, scores, standing y reparto de anotacion."""
 
-    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+    def __init__(
+        self,
+        uow: QuickMatchUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        scoring_service: ScoringService,
+        coverage_service: ScoringCoverageService,
+    ):
         self._uow = uow
         self._user_uow = user_uow
-        self._scoring_service = ScoringService()
-        self._coverage_service = ScoringCoverageService()
+        self._scoring_service = scoring_service
+        self._coverage_service = coverage_service
 
     async def execute(
         self, quick_match_id_raw: str, current_user_id_raw: str
@@ -43,9 +49,7 @@ class GetQuickMatchUseCase:
         current_participant_id = ParticipantId(UserId(current_user_id_raw).value)
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(
-                QuickMatchId(quick_match_id_raw)
-            )
+            quick_match = await self._uow.quick_matches.find_by_id(QuickMatchId(quick_match_id_raw))
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {quick_match_id_raw}")
 

--- a/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
@@ -38,9 +38,11 @@ class SubmitProxyHoleScoreUseCase:
     (segun el reparto calculado por ScoringCoverageService).
     """
 
-    def __init__(self, uow: QuickMatchUnitOfWorkInterface):
+    def __init__(
+        self, uow: QuickMatchUnitOfWorkInterface, coverage_service: ScoringCoverageService
+    ):
         self._uow = uow
-        self._coverage_service = ScoringCoverageService()
+        self._coverage_service = coverage_service
 
     async def execute(self, request: SubmitProxyHoleScoreRequestDTO) -> HoleScoreResponseDTO:
         scorer_id = UserId(request.scorer_user_id)

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 
+from src.modules.competition.domain.services.scoring_service import ScoringService
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.quick_match.application.dto.quick_match_dto import (
@@ -24,6 +25,9 @@ from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_c
     SubmitProxyHoleScoreUseCase,
 )
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
+)
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
@@ -55,7 +59,9 @@ class TestGetQuickMatchUseCase:
         other = await create_user(user_uow, "other@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
-        use_case = GetQuickMatchUseCase(qm_uow, user_uow)
+        use_case = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+        )
         detail = await use_case.execute(str(qm.id.value), str(creator.id.value))
 
         assert detail.status == "IN_PROGRESS"
@@ -73,12 +79,16 @@ class TestGetQuickMatchUseCase:
         other = await create_user(user_uow, "other2@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
-        use_case = GetQuickMatchUseCase(qm_uow, user_uow)
+        use_case = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+        )
         with pytest.raises(NotQuickMatchParticipantError):
             await use_case.execute(str(qm.id.value), str(UserId(uuid4()).value))
 
     async def test_not_found_raises(self, qm_uow, user_uow):
-        use_case = GetQuickMatchUseCase(qm_uow, user_uow)
+        use_case = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+        )
         with pytest.raises(QuickMatchNotFoundError):
             await use_case.execute(str(uuid4()), str(uuid4()))
 
@@ -98,7 +108,7 @@ class TestGetQuickMatchUseCase:
                 score=4,
             )
         )
-        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow)
+        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
         await proxy_uc.execute(
             SubmitProxyHoleScoreRequestDTO(
                 quick_match_id=qm.id.value,
@@ -109,7 +119,7 @@ class TestGetQuickMatchUseCase:
             )
         )
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow)
+        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         assert len(detail.hole_scores) == 2
@@ -118,14 +128,12 @@ class TestGetQuickMatchUseCase:
         assert detail.standing.leading_team == "A"
         assert detail.standing.status == "1UP"
 
-    async def test_registered_participant_handicap_comes_from_user_profile(
-        self, qm_uow, user_uow
-    ):
+    async def test_registered_participant_handicap_comes_from_user_profile(self, qm_uow, user_uow):
         creator = await create_user(user_uow, "creator-hcp@test.com", handicap=12.4)
         other = await create_user(user_uow, "other-hcp@test.com", handicap=None)
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow)
+        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         creator_dto = next(p for p in detail.participants if p.user_id == creator.id.value)
@@ -157,7 +165,7 @@ class TestGetQuickMatchUseCase:
             )
         )
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow)
+        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         assert detail.match_format is None

--- a/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
@@ -20,6 +20,9 @@ from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     NotAssignedScorerViolation,
 )
+from src.modules.quick_match.domain.services.scoring_coverage_service import (
+    ScoringCoverageService,
+)
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
@@ -49,7 +52,7 @@ class TestSubmitProxyHoleScoreUseCase:
         creator = await create_user(user_uow, "creator@test.com")
         qm, guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
 
-        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
         response = await use_case.execute(
             SubmitProxyHoleScoreRequestDTO(
                 quick_match_id=qm.id.value,
@@ -68,7 +71,7 @@ class TestSubmitProxyHoleScoreUseCase:
         creator = await create_user(user_uow, "creator2@test.com")
         qm, guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
 
-        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
         with pytest.raises(NotAScorerError):
             await use_case.execute(
                 SubmitProxyHoleScoreRequestDTO(
@@ -84,7 +87,7 @@ class TestSubmitProxyHoleScoreUseCase:
         creator = await create_user(user_uow, "creator3@test.com")
         qm, _guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
 
-        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
         with pytest.raises(TargetParticipantNotFoundError):
             await use_case.execute(
                 SubmitProxyHoleScoreRequestDTO(
@@ -108,12 +111,8 @@ class TestSubmitProxyHoleScoreUseCase:
             match_format=MatchFormat.FOURBALL,
         )
         scorer_b = QuickMatchParticipant.for_user(other.id, team="A")
-        guest_a = QuickMatchParticipant.for_guest(
-            first_name="Guest", last_name="A", team="B"
-        )
-        guest_b = QuickMatchParticipant.for_guest(
-            first_name="Guest", last_name="B", team="B"
-        )
+        guest_a = QuickMatchParticipant.for_guest(first_name="Guest", last_name="A", team="B")
+        guest_b = QuickMatchParticipant.for_guest(first_name="Guest", last_name="B", team="B")
         qm.add_participant(scorer_b)
         qm.add_participant(guest_a)
         qm.add_participant(guest_b)
@@ -124,7 +123,7 @@ class TestSubmitProxyHoleScoreUseCase:
         # Con 2 anotadores y 2 no-anotadores, el reparto es 1 y 1: cada guest
         # queda asignado a un anotador distinto. Forzamos que "other" intente
         # anotar al invitado que NO le corresponde.
-        use_case = SubmitProxyHoleScoreUseCase(qm_uow)
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
         assignments = use_case._coverage_service.compute_assignments(
             participants=qm.participants,
             scorer_ids=qm.scorer_ids,


### PR DESCRIPTION
## Summary
- `GetQuickMatchUseCase` and `SubmitProxyHoleScoreUseCase` instantiated `ScoringService`/`ScoringCoverageService` directly instead of receiving them via DI, repeating the pattern already fixed as #111 for `LocationBuilder` in `competition`.
- Added `get_scoring_coverage_service()` provider and wired both services from `dependencies.py`, reusing the existing `get_scoring_service()` provider (moved earlier in the file so it's defined before the quick_match providers that now depend on it).
- Updated direct-construction test setups accordingly.

Closes #132

## Test plan
- [x] `pytest tests/unit/modules/quick_match/` — 165 passed
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` on touched files — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Quick Match scoring and coverage services are now consistently connected across match retrieval and score submission workflows.
  * Scoring behavior remains unchanged while improving reliability and consistency across Quick Match operations.
* **Tests**
  * Updated Quick Match coverage for scoring, handicap, standings, participant validation, and score-submission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->