### PR TITLE
refactor(quick-match): Use consistent row-locking (find_by_id_for_update) across quick-match mutating use cases

### DIFF
--- a/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
+++ b/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
@@ -38,7 +38,7 @@ class RemoveParticipantUseCase:
         target_participant_id = ParticipantId(request.target_participant_id)
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
                 QuickMatchId(request.quick_match_id)
             )
             if not quick_match:

--- a/src/modules/quick_match/application/use_cases/start_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/start_quick_match_use_case.py
@@ -39,7 +39,7 @@ class StartQuickMatchUseCase:
         scorer_ids = [ParticipantId(sid) for sid in request.scorer_ids]
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
                 QuickMatchId(request.quick_match_id)
             )
             if not quick_match:

--- a/src/modules/quick_match/application/use_cases/submit_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_hole_score_use_case.py
@@ -44,7 +44,7 @@ class SubmitQuickMatchHoleScoreUseCase:
         quick_match_id = QuickMatchId(request.quick_match_id)
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(quick_match_id)
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(quick_match_id)
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 


### PR DESCRIPTION
## Summary
- `start_quick_match_use_case.py`, `remove_participant_use_case.py`, and `submit_hole_score_use_case.py` fetched the `QuickMatch` aggregate with plain `find_by_id` before mutating/checking it, unlike `add_friend_to_quick_match_use_case.py`, `add_guest_to_quick_match_use_case.py`, and `set_participant_handicap_use_case.py`, which already lock the row via `find_by_id_for_update`.
- Switched all three to `find_by_id_for_update` for consistency with the rest of the module.

Closes #135

## Test plan
- [x] `pytest tests/unit/modules/quick_match/` — 165 passed
- [x] `ruff check` / `ruff format` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-match update reliability by preventing conflicting changes during participant removal, match start, and hole-score submission.
  * Reduced the risk of concurrent actions overwriting each other during match updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->