### PR TITLE
refactor(social): Translate SQLAlchemy IntegrityError into a domain exception in BlockUserUseCase

### DIFF
--- a/src/modules/social/application/use_cases/block_user_use_case.py
+++ b/src/modules/social/application/use_cases/block_user_use_case.py
@@ -1,11 +1,12 @@
 """Caso de Uso: Bloquear a un usuario."""
 
-from sqlalchemy.exc import IntegrityError
-
 from src.modules.social.application.dto.friendship_dto import FriendshipResponseDTO
 from src.modules.social.application.exceptions import AddresseeNotFoundError
 from src.modules.social.domain.entities.friendship import Friendship
-from src.modules.social.domain.exceptions.social_violations import SelfFriendRequestViolation
+from src.modules.social.domain.exceptions.social_violations import (
+    DuplicateFriendshipViolation,
+    SelfFriendRequestViolation,
+)
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
 )
@@ -57,10 +58,10 @@ class BlockUserUseCase:
                 try:
                     await self._uow.friendships.add(friendship)
                     await self._uow.flush()
-                except IntegrityError:
+                except DuplicateFriendshipViolation:
                     # Concurrent block on the same pair: another request already
-                    # won the uq_friendship_pair race. Idempotent: reload and return it.
-                    await self._uow.rollback()
+                    # won the uq_friendship_pair race (translated by the UoW
+                    # adapter). Idempotent: reload and return it.
                     friendship = await self._uow.friendships.find_by_pair(blocker_id, blocked_id)
             elif not friendship.is_blocked():
                 friendship.block(blocker_id)

--- a/src/modules/social/domain/exceptions/social_violations.py
+++ b/src/modules/social/domain/exceptions/social_violations.py
@@ -38,3 +38,14 @@ class BlockedUserViolation(BusinessRuleViolation):
     """La accion no es posible porque existe un bloqueo entre ambos usuarios."""
 
     pass
+
+
+class DuplicateFriendshipViolation(BusinessRuleViolation):
+    """Ya existe una relacion (de cualquier estado) para esta pareja de usuarios.
+
+    Traduce la violacion del indice unico `uq_friendship_pair` (o su equivalente
+    en el repositorio en memoria) a una excepcion de dominio, para que la capa
+    de aplicacion no dependa de la jerarquia de excepciones de SQLAlchemy.
+    """
+
+    pass

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_friendship_repository.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_friendship_repository.py
@@ -1,6 +1,9 @@
 """In-Memory Friendship Repository para testing."""
 
 from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.exceptions.social_violations import (
+    DuplicateFriendshipViolation,
+)
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
@@ -16,6 +19,16 @@ class InMemoryFriendshipRepository(FriendshipRepositoryInterface):
         self._friendships: dict[FriendshipId, Friendship] = {}
 
     async def add(self, friendship: Friendship) -> None:
+        # Mismo invariante que el indice unico `uq_friendship_pair` de la BD real:
+        # una unica relacion (en cualquier estado) por pareja de usuarios, en
+        # cualquier direccion. Permite simular en tests la misma race que
+        # traduce SQLAlchemySocialUnitOfWork.flush() a DuplicateFriendshipViolation.
+        pair = {friendship.requester_id, friendship.addressee_id}
+        for existing in self._friendships.values():
+            if {existing.requester_id, existing.addressee_id} == pair:
+                raise DuplicateFriendshipViolation(
+                    "A friendship between these users already exists."
+                )
         self._friendships[friendship.id] = friendship
 
     async def update(self, friendship: Friendship) -> None:

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
@@ -1,7 +1,11 @@
 """Social Unit of Work - SQLAlchemy Implementation."""
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.modules.social.domain.exceptions.social_violations import (
+    DuplicateFriendshipViolation,
+)
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
@@ -11,6 +15,8 @@ from src.modules.social.domain.repositories.social_unit_of_work_interface import
 from src.modules.social.infrastructure.persistence.sqlalchemy.friendship_repository import (
     SQLAlchemyFriendshipRepository,
 )
+
+UQ_FRIENDSHIP_PAIR_CONSTRAINT = "uq_friendship_pair"
 
 
 class SQLAlchemySocialUnitOfWork(SocialUnitOfWorkInterface):
@@ -40,7 +46,16 @@ class SQLAlchemySocialUnitOfWork(SocialUnitOfWorkInterface):
         await self._session.rollback()
 
     async def flush(self) -> None:
-        await self._session.flush()
+        try:
+            await self._session.flush()
+        except IntegrityError as e:
+            await self._session.rollback()
+            if UQ_FRIENDSHIP_PAIR_CONSTRAINT in str(e.orig):
+                raise DuplicateFriendshipViolation(
+                    "A friendship or block relationship between these users "
+                    "was just created concurrently."
+                ) from e
+            raise
 
     def is_active(self) -> bool:
         return self._session.is_active

--- a/tests/unit/modules/social/application/use_cases/test_block_user_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_block_user_use_case.py
@@ -1,7 +1,6 @@
 """Tests para BlockUserUseCase."""
 
 import pytest
-from sqlalchemy.exc import IntegrityError
 
 from src.modules.social.application.exceptions import AddresseeNotFoundError
 from src.modules.social.application.use_cases.block_user_use_case import BlockUserUseCase
@@ -92,7 +91,16 @@ class TestBlockUserUseCase:
         assert second.status == "BLOCKED"
 
     async def test_block_handles_concurrent_insert_race_idempotently(self, uow, user_uow):
-        """Simula dos bloqueos concurrentes chocando contra uq_friendship_pair."""
+        """Simula dos bloqueos concurrentes chocando contra uq_friendship_pair.
+
+        A diferencia de un mock que fuerce directamente la excepcion, aqui la
+        fila "ganadora" se inserta con el `add()` real del repositorio en
+        memoria (que ahora aplica el mismo invariante de pareja unica que el
+        indice `uq_friendship_pair` de la BD) — solo se parchea `find_by_pair`
+        para simular la ventana de carrera (lectura antes del commit
+        concurrente). La excepcion `DuplicateFriendshipViolation` la produce
+        el propio adaptador, no el test.
+        """
         blocker = await self._create_user(user_uow, "blocker5@test.com")
         blocked = await self._create_user(user_uow, "blocked5@test.com")
         use_case = BlockUserUseCase(uow, user_uow)
@@ -100,16 +108,22 @@ class TestBlockUserUseCase:
         winning_friendship = Friendship.create_blocked(
             id=FriendshipId.generate(), blocker_id=blocker.id, blocked_id=blocked.id
         )
-        original_add = uow.friendships.add
+        async with uow:
+            await uow.friendships.add(winning_friendship)
 
-        async def add_with_race(friendship):
-            # La primera llamada simula que otra request concurrente ya gano
-            # la carrera e inserto la fila; la BD real respondería con
-            # IntegrityError por uq_friendship_pair.
-            await original_add(winning_friendship)
-            raise IntegrityError("uq_friendship_pair", params=None, orig=Exception("duplicate"))
+        original_find_by_pair = uow.friendships.find_by_pair
+        call_count = 0
 
-        uow.friendships.add = add_with_race
+        async def find_by_pair_with_race(user_id_a, user_id_b):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Simula que la lectura ocurrio antes de que la request
+                # concurrente ganara la carrera e insertara la fila.
+                return None
+            return await original_find_by_pair(user_id_a, user_id_b)
+
+        uow.friendships.find_by_pair = find_by_pair_with_race
 
         response = await use_case.execute(str(blocker.id.value), str(blocked.id.value))
 


### PR DESCRIPTION
## Summary
- `BlockUserUseCase` imported and caught `sqlalchemy.exc.IntegrityError` directly to handle a concurrent-block race on `uq_friendship_pair`, breaking the Port/Adapter boundary the Unit-of-Work exists to provide. It was also the only occurrence of `IntegrityError` in `src/`.
- Added `DuplicateFriendshipViolation` domain exception (`social_violations.py`).
- `SQLAlchemySocialUnitOfWork.flush()` now catches `IntegrityError`, rolls back, and translates it to `DuplicateFriendshipViolation` when the `uq_friendship_pair` constraint is involved (other integrity errors are re-raised unchanged).
- `InMemoryFriendshipRepository.add()` now enforces the same "one relationship per pair, any status/direction" invariant as the real unique index, raising the same domain exception — matching the DB adapter's behavior for tests.
- `BlockUserUseCase` now catches `DuplicateFriendshipViolation` instead of the SQLAlchemy exception.
- Rewrote `test_block_handles_concurrent_insert_race_idempotently` so the race is exercised through the real (now duplicate-checking) in-memory `add()`, only patching `find_by_pair` to simulate the read-before-concurrent-commit race window — previously the test had to directly force-raise `IntegrityError` via a monkeypatched `add()`, since the in-memory double had no way to produce it.

Closes #134

## Test plan
- [x] `pytest tests/unit/modules/social/` — 77 passed
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of simultaneous attempts to block the same person.
  * Prevented duplicate friendship records in both in-memory and database-backed storage.
  * Preserved idempotent behavior when a block request races with another request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->