### PR TITLE
refactor(quick-match): Extract quick-match team-standing derivation logic out of GetQuickMatchUseCase into the domain

### DIFF
--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -43,9 +43,7 @@ class GetQuickMatchUseCase:
         current_participant_id = ParticipantId(UserId(current_user_id_raw).value)
 
         async with self._uow:
-            quick_match = await self._uow.quick_matches.find_by_id(
-                QuickMatchId(quick_match_id_raw)
-            )
+            quick_match = await self._uow.quick_matches.find_by_id(QuickMatchId(quick_match_id_raw))
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {quick_match_id_raw}")
 
@@ -118,15 +116,10 @@ class GetQuickMatchUseCase:
             # La clasificacion individual se calcula en el frontend a partir de hole_scores.
             return None
 
-        participants = quick_match.participants
-        if len(participants) < 2:  # noqa: PLR2004
+        rosters = quick_match.team_rosters()
+        if rosters is None:
             return None
-
-        team_a_ids = {p.participant_id for p in participants if (p.team or "A") == "A"}
-        team_b_ids = {p.participant_id for p in participants if p.team == "B"}
-        if not team_b_ids and len(participants) == 2:  # noqa: PLR2004 - SINGLES: no team field
-            team_a_ids = {participants[0].participant_id}
-            team_b_ids = {participants[1].participant_id}
+        team_a_ids, team_b_ids = rosters
 
         scores_by_hole: dict[int, dict] = {}
         for hs in hole_scores:

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -349,6 +349,32 @@ class QuickMatch:
     def registered_participants(self) -> list[QuickMatchParticipant]:
         return [p for p in self._participants if not p.is_guest]
 
+    def team_rosters(self) -> tuple[set[ParticipantId], set[ParticipantId]] | None:
+        """
+        Deriva los dos bandos (A y B) de participantes para el calculo de standing.
+
+        Reutiliza la misma convencion de asignacion de equipo que `add_participant()`:
+        en formatos que usan equipos (FOURBALL/FOURSOMES), el campo `team` de cada
+        participante decide el bando. En SINGLES (que no usa el campo `team`, ver
+        `add_participant`) los dos unicos participantes son cada bando por convencion.
+
+        Devuelve `None` si no hay exactamente dos bandos no vacios resolubles (por
+        ejemplo, con menos de 2 participantes).
+        """
+        if len(self._participants) < 2:  # noqa: PLR2004
+            return None
+
+        team_a_ids = {p.participant_id for p in self._participants if (p.team or "A") == "A"}
+        team_b_ids = {p.participant_id for p in self._participants if p.team == "B"}
+        if not team_b_ids and len(self._participants) == 2:  # noqa: PLR2004 - SINGLES: no team field
+            team_a_ids = {self._participants[0].participant_id}
+            team_b_ids = {self._participants[1].participant_id}
+
+        if not team_a_ids or not team_b_ids:
+            return None
+
+        return team_a_ids, team_b_ids
+
     def _team_count(self, team: str) -> int:
         return sum(1 for p in self._participants if p.team == team)
 
@@ -377,9 +403,7 @@ class QuickMatch:
         uses_teams = self._match_format is not None and self._match_format != MatchFormat.SINGLES
         if not uses_teams:
             if team is not None:
-                raise InvalidTeamAssignmentViolation(
-                    "This quick match format does not use teams."
-                )
+                raise InvalidTeamAssignmentViolation("This quick match format does not use teams.")
         else:
             if team not in ("A", "B"):
                 raise InvalidTeamAssignmentViolation("team must be 'A' or 'B' for this format.")
@@ -427,7 +451,9 @@ class QuickMatch:
             )
         )
 
-    def set_participant_handicap(self, participant_id: ParticipantId, handicap: float | None) -> None:
+    def set_participant_handicap(
+        self, participant_id: ParticipantId, handicap: float | None
+    ) -> None:
         """
         Edita el handicap de un participante mientras la partida esta PENDING.
 
@@ -559,7 +585,9 @@ class QuickMatch:
     # ===========================================
 
     def __str__(self) -> str:
-        format_value = self._match_format.value if self._match_format else self._scoring_format.value
+        format_value = (
+            self._match_format.value if self._match_format else self._scoring_format.value
+        )
         return f"QuickMatch({format_value}, {self._status.value})"
 
     def __eq__(self, other) -> bool:

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -359,16 +359,22 @@ class QuickMatch:
         `add_participant`) los dos unicos participantes son cada bando por convencion.
 
         Devuelve `None` si no hay exactamente dos bandos no vacios resolubles (por
-        ejemplo, con menos de 2 participantes).
+        ejemplo, con menos de 2 participantes, o un FOURBALL/FOURSOMES incompleto
+        con ambos participantes aun en el mismo equipo).
         """
-        if len(self._participants) < 2:  # noqa: PLR2004
+        if self._match_format == MatchFormat.SINGLES:
+            if len(self._participants) != 2:  # noqa: PLR2004
+                return None
+            return (
+                {self._participants[0].participant_id},
+                {self._participants[1].participant_id},
+            )
+
+        if self._match_format is None:
             return None
 
-        team_a_ids = {p.participant_id for p in self._participants if (p.team or "A") == "A"}
+        team_a_ids = {p.participant_id for p in self._participants if p.team == "A"}
         team_b_ids = {p.participant_id for p in self._participants if p.team == "B"}
-        if not team_b_ids and len(self._participants) == 2:  # noqa: PLR2004 - SINGLES: no team field
-            team_a_ids = {self._participants[0].participant_id}
-            team_b_ids = {self._participants[1].participant_id}
 
         if not team_a_ids or not team_b_ids:
             return None

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -228,6 +228,12 @@ class TestQuickMatchTeamRosters:
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         assert qm.team_rosters() is None
 
+    def test_incomplete_fourball_with_two_participants_on_same_team_returns_none(self):
+        qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
+        qm.add_participant(_registered(team="A"))
+
+        assert qm.team_rosters() is None
+
 
 class TestQuickMatchRemoveParticipant:
     def test_remove_participant_succeeds(self):

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -200,6 +200,35 @@ class TestQuickMatchAddParticipant:
             qm.add_participant(_registered())
 
 
+class TestQuickMatchTeamRosters:
+    def test_singles_falls_back_to_each_participant_as_a_side(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+
+        rosters = qm.team_rosters()
+
+        assert rosters == ({qm.creator_participant_id}, {other.participant_id})
+
+    def test_fourball_derives_rosters_from_team_field(self):
+        qm = _make_quick_match(match_format=MatchFormat.FOURBALL)
+        partner_a = _registered(team="A")
+        opponent_b1 = _registered(team="B")
+        opponent_b2 = _guest(team="B")
+        qm.add_participant(partner_a)
+        qm.add_participant(opponent_b1)
+        qm.add_participant(opponent_b2)
+
+        team_a_ids, team_b_ids = qm.team_rosters()
+
+        assert team_a_ids == {qm.creator_participant_id, partner_a.participant_id}
+        assert team_b_ids == {opponent_b1.participant_id, opponent_b2.participant_id}
+
+    def test_returns_none_with_fewer_than_two_participants(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        assert qm.team_rosters() is None
+
+
 class TestQuickMatchRemoveParticipant:
     def test_remove_participant_succeeds(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
@@ -345,8 +374,12 @@ class TestQuickMatchStart:
     def test_start_with_non_registered_scorer_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)
         qm.add_participant(_registered())
-        with pytest.raises(InvalidScorerConfigurationViolation, match="not a registered participant"):
-            qm.start([qm.creator_participant_id, ParticipantId.generate(), ParticipantId.generate()])
+        with pytest.raises(
+            InvalidScorerConfigurationViolation, match="not a registered participant"
+        ):
+            qm.start(
+                [qm.creator_participant_id, ParticipantId.generate(), ParticipantId.generate()]
+            )
 
     def test_start_with_duplicate_scorers_raises(self):
         qm = _make_quick_match(match_format=MatchFormat.SINGLES)


### PR DESCRIPTION
## Summary
- `GetQuickMatchUseCase._compute_standing` reconstructed "team A vs team B" rosters from `QuickMatchParticipant.team` directly inside the use case, including a SINGLES-specific fallback — duplicating knowledge already encoded once in `QuickMatch.add_participant()`'s team-assignment logic.
- Added `QuickMatch.team_rosters() -> tuple[set[ParticipantId], set[ParticipantId]] | None`, mirroring the existing team-assignment convention (team field for FOURBALL/FOURSOMES, 2-participant fallback for SINGLES).
- `_compute_standing` now calls `quick_match.team_rosters()` instead of recomputing team membership inline.
- Added direct unit tests for `team_rosters()` on the domain entity (SINGLES fallback, FOURBALL from `team` field, <2 participants → `None`), independent of `GetQuickMatchUseCase`'s DTO/UoW plumbing.

Closes #133

## Test plan
- [x] `pytest tests/unit/modules/quick_match/` — 168 passed (165 + 3 new)
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-match standings by reliably identifying team rosters across singles and fourball matches.
  * Added support for two-player singles matches when determining opposing teams.
  * Prevented standings from appearing when valid team rosters cannot be determined, including incomplete team configurations.

* **Tests**
  * Added coverage for singles, fourball, missing-participant, and incomplete-roster scenarios to help ensure accurate standings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->