### PR TITLE
refactor(competition): Extract SINGLES WHS differential handicap logic into PlayingHandicapCalculator

### DIFF
--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -253,7 +253,9 @@ class GenerateMatchesUseCase:
             for pid, user in zip(all_player_ids, users, strict=True):
                 if user:
                     enrollment = enrollment_map.get(str(pid.value))
-                    has_custom_handicap = enrollment is not None and enrollment.custom_handicap is not None
+                    has_custom_handicap = (
+                        enrollment is not None and enrollment.custom_handicap is not None
+                    )
                     if not has_custom_handicap:
                         await self._maybe_refresh_rfeg_handicap(user)
                     if user.handicap is not None:
@@ -572,7 +574,9 @@ class GenerateMatchesUseCase:
                 f"(gender: {tee_gender}) en el campo de golf"
             )
 
-        playing_handicap = calculator.calculate(handicap_index, tee_rating, allowance, max_playing_handicap)
+        playing_handicap = calculator.calculate(
+            handicap_index, tee_rating, allowance, max_playing_handicap
+        )
         strokes_received = calculator.compute_strokes_received(
             playing_handicap, holes_by_stroke_index
         )
@@ -667,7 +671,9 @@ class GenerateMatchesUseCase:
 
         # Aplicar cap de max_playing_handicap si está definido
         if max_playing_handicap is not None:
-            differential_phs = {k: min(v, max_playing_handicap) for k, v in differential_phs.items()}
+            differential_phs = {
+                k: min(v, max_playing_handicap) for k, v in differential_phs.items()
+            }
 
         # 3. Construir MatchPlayers con PH diferencial
         def build_player(uid):
@@ -723,12 +729,20 @@ class GenerateMatchesUseCase:
         if is_scratch:
             return (
                 MatchPlayer.create(
-                    user_id=a_player_id, playing_handicap=0, tee_category=tee_cat_a,
-                    strokes_received=[], tee_gender=tee_gen_a, player_handicap=hi_a,
+                    user_id=a_player_id,
+                    playing_handicap=0,
+                    tee_category=tee_cat_a,
+                    strokes_received=[],
+                    tee_gender=tee_gen_a,
+                    player_handicap=hi_a,
                 ),
                 MatchPlayer.create(
-                    user_id=b_player_id, playing_handicap=0, tee_category=tee_cat_b,
-                    strokes_received=[], tee_gender=tee_gen_b, player_handicap=hi_b,
+                    user_id=b_player_id,
+                    playing_handicap=0,
+                    tee_category=tee_cat_b,
+                    strokes_received=[],
+                    tee_gender=tee_gen_b,
+                    player_handicap=hi_b,
                 ),
             )
 
@@ -746,25 +760,26 @@ class GenerateMatchesUseCase:
         ph_a = calculator.calculate(hi_a, tee_rating_a, allowance, max_playing_handicap)
         ph_b = calculator.calculate(hi_b, tee_rating_b, allowance, max_playing_handicap)
 
-        diff = ph_a - ph_b
-        if diff > 0:
-            strokes_a = calculator.compute_strokes_received(diff, holes_by_stroke_index)
-            strokes_b: list[int] = []
-        elif diff < 0:
-            strokes_a = []
-            strokes_b = calculator.compute_strokes_received(-diff, holes_by_stroke_index)
-        else:
-            strokes_a = []
-            strokes_b = []
+        strokes_a, strokes_b = calculator.calculate_singles_differential(
+            ph_a, ph_b, holes_by_stroke_index
+        )
 
         return (
             MatchPlayer.create(
-                user_id=a_player_id, playing_handicap=ph_a, tee_category=tee_cat_a,
-                strokes_received=strokes_a, tee_gender=tee_gen_a, player_handicap=hi_a,
+                user_id=a_player_id,
+                playing_handicap=ph_a,
+                tee_category=tee_cat_a,
+                strokes_received=strokes_a,
+                tee_gender=tee_gen_a,
+                player_handicap=hi_a,
             ),
             MatchPlayer.create(
-                user_id=b_player_id, playing_handicap=ph_b, tee_category=tee_cat_b,
-                strokes_received=strokes_b, tee_gender=tee_gen_b, player_handicap=hi_b,
+                user_id=b_player_id,
+                playing_handicap=ph_b,
+                tee_category=tee_cat_b,
+                strokes_received=strokes_b,
+                tee_gender=tee_gen_b,
+                player_handicap=hi_b,
             ),
         )
 

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -251,6 +251,40 @@ class PlayingHandicapCalculator:
         return result
 
     @staticmethod
+    def calculate_singles_differential(
+        ph_a: int,
+        ph_b: int,
+        holes_by_stroke_index: list[int],
+    ) -> tuple[list[int], list[int]]:
+        """
+        Método diferencial WHS para Singles (Match Play).
+
+        Solo el jugador con mayor Playing Handicap recibe golpes, en los hoyos
+        más difíciles (menor Stroke Index). El jugador de menor PH juega off
+        scratch (0 golpes recibidos). Si ambos PH son iguales, ninguno recibe.
+
+        Args:
+            ph_a: Playing Handicap del jugador A (ya con allowance aplicado)
+            ph_b: Playing Handicap del jugador B (ya con allowance aplicado)
+            holes_by_stroke_index: Números de hoyo ordenados por stroke index
+
+        Returns:
+            (strokes_a, strokes_b) — hoyos donde cada jugador recibe golpe.
+            Exactamente una de las dos listas tendrá elementos (o ninguna, si
+            ph_a == ph_b).
+        """
+        diff = ph_a - ph_b
+        if diff > 0:
+            return PlayingHandicapCalculator.compute_strokes_received(
+                diff, holes_by_stroke_index
+            ), []
+        if diff < 0:
+            return [], PlayingHandicapCalculator.compute_strokes_received(
+                -diff, holes_by_stroke_index
+            )
+        return [], []
+
+    @staticmethod
     def calculate_foursomes_differential(
         team_a_course_handicaps: list[int],
         team_b_course_handicaps: list[int],

--- a/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
@@ -1,6 +1,7 @@
 """Tests para PlayingHandicapCalculator domain service."""
 
 from decimal import Decimal
+from typing import ClassVar
 
 import pytest
 
@@ -206,6 +207,46 @@ class TestPlayingHandicapCalculatorSingles:
         # HI=10 × 90% = 9
         assert player_ph == 18
         assert opponent_ph == 9
+
+
+class TestPlayingHandicapCalculatorSinglesDifferential:
+    """Tests para calculate_singles_differential (método diferencial WHS Match Play)."""
+
+    HOLES_BY_STROKE_INDEX: ClassVar[list[int]] = list(range(1, 19))  # hoyo 1 = mas dificil (SI 1)
+
+    def test_higher_ph_player_receives_strokes(self):
+        strokes_a, strokes_b = PlayingHandicapCalculator.calculate_singles_differential(
+            ph_a=16, ph_b=11, holes_by_stroke_index=self.HOLES_BY_STROKE_INDEX
+        )
+
+        assert strokes_a == [1, 2, 3, 4, 5]
+        assert strokes_b == []
+
+    def test_lower_ph_player_plays_off_scratch(self):
+        strokes_a, strokes_b = PlayingHandicapCalculator.calculate_singles_differential(
+            ph_a=11, ph_b=16, holes_by_stroke_index=self.HOLES_BY_STROKE_INDEX
+        )
+
+        assert strokes_a == []
+        assert strokes_b == [1, 2, 3, 4, 5]
+
+    def test_equal_ph_nobody_receives_strokes(self):
+        strokes_a, strokes_b = PlayingHandicapCalculator.calculate_singles_differential(
+            ph_a=12, ph_b=12, holes_by_stroke_index=self.HOLES_BY_STROKE_INDEX
+        )
+
+        assert strokes_a == []
+        assert strokes_b == []
+
+    def test_diff_over_18_wraps_around_hardest_holes(self):
+        strokes_a, strokes_b = PlayingHandicapCalculator.calculate_singles_differential(
+            ph_a=20, ph_b=0, holes_by_stroke_index=self.HOLES_BY_STROKE_INDEX
+        )
+
+        assert len(strokes_a) == 20
+        assert strokes_a.count(1) == 2  # hoyo mas dificil recibe 2 golpes
+        assert strokes_a.count(18) == 1
+        assert strokes_b == []
 
 
 class TestPlayingHandicapCalculatorFourball:


### PR DESCRIPTION
## Summary
- `GenerateMatchesUseCase._build_singles_match_players` computed `diff = ph_a - ph_b` and branched inline to decide which player receives strokes, then called `calculator.compute_strokes_received()` — a WHS Match Play business rule living in the application layer instead of the domain, unlike the equivalent FOURBALL path which already delegates to `calculator.calculate_fourball_differential()`.
- Added `PlayingHandicapCalculator.calculate_singles_differential(ph_a, ph_b, holes_by_stroke_index) -> tuple[list[int], list[int]]`, mirroring the fourball/foursomes differential methods.
- `_build_singles_match_players` now calls it instead of the inline diff/branch logic.
- Added a dedicated test class (`TestPlayingHandicapCalculatorSinglesDifferential`) exercising the new method directly — higher/lower PH, equal PH, and PH diff > 18 (wrap-around) — independent of `GenerateMatchesUseCase`'s DTO/UoW plumbing (this and the fourball/foursomes differential methods had no direct unit tests before).

Closes #110

## Test plan
- [x] `pytest tests/unit/modules/competition/` — 1086 passed (includes the two prior SINGLES WHS-differential regression tests from CHANGELOG 2.0.16/2.0.17, unchanged)
- [x] `pytest tests/unit/` — 2264 passed (full suite)
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved singles match-play handicap calculations so strokes are awarded only to the player with the higher Playing Handicap.
  - Correctly distributes handicap differences across hole stroke indexes, including differences greater than 18.
  - Ensures players with equal handicaps receive no strokes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->