### PR TITLE
refactor(competition): Inject LocationBuilder via DI instead of instantiating it inside use case constructors

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -149,6 +149,7 @@ from src.modules.competition.application.use_cases.withdraw_enrollment_use_case 
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.services.playing_handicap_calculator import (
     PlayingHandicapCalculator,
 )
@@ -1236,18 +1237,33 @@ def get_list_my_quick_matches_use_case(
     return ListMyQuickMatchesUseCase(uow, user_uow)
 
 
+def get_location_builder(
+    uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+) -> LocationBuilder:
+    """
+    Proveedor del domain service LocationBuilder.
+
+    Reutiliza el mismo `uow` (y por tanto el mismo `uow.countries`) que reciben
+    los use cases que lo consumen, ya que FastAPI cachea `Depends(get_competition_uow)`
+    dentro de una misma request.
+    """
+    return LocationBuilder(uow.countries)
+
+
 def get_create_competition_use_case(
     uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    location_builder: LocationBuilder = Depends(get_location_builder),
 ) -> CreateCompetitionUseCase:
     """
     Proveedor del caso de uso CreateCompetitionUseCase.
 
     Esta función:
     1. Depende de `get_competition_uow` para obtener una Unit of Work.
-    2. Crea una instancia de `CreateCompetitionUseCase` con esa dependencia.
-    3. Devuelve la instancia lista para ser usada por el endpoint de la API.
+    2. Depende de `get_location_builder` para el domain service de ubicación.
+    3. Crea una instancia de `CreateCompetitionUseCase` con esas dependencias.
+    4. Devuelve la instancia lista para ser usada por el endpoint de la API.
     """
-    return CreateCompetitionUseCase(uow)
+    return CreateCompetitionUseCase(uow, location_builder)
 
 
 def get_list_competitions_use_case(
@@ -1266,16 +1282,18 @@ def get_list_competitions_use_case(
 
 def get_update_competition_use_case(
     uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    location_builder: LocationBuilder = Depends(get_location_builder),
 ) -> UpdateCompetitionUseCase:
     """
     Proveedor del caso de uso UpdateCompetitionUseCase.
 
     Esta función:
     1. Depende de `get_competition_uow` para obtener una Unit of Work.
-    2. Crea una instancia de `UpdateCompetitionUseCase` con esa dependencia.
-    3. Devuelve la instancia lista para ser usada por el endpoint de la API.
+    2. Depende de `get_location_builder` para el domain service de ubicación.
+    3. Crea una instancia de `UpdateCompetitionUseCase` con esas dependencias.
+    4. Devuelve la instancia lista para ser usada por el endpoint de la API.
     """
-    return UpdateCompetitionUseCase(uow)
+    return UpdateCompetitionUseCase(uow, location_builder)
 
 
 def get_get_competition_use_case(

--- a/src/modules/competition/application/use_cases/create_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/create_competition_use_case.py
@@ -50,16 +50,16 @@ class CreateCompetitionUseCase:
     - Persistir mediante repositorio
     """
 
-    def __init__(self, uow: CompetitionUnitOfWorkInterface):
+    def __init__(self, uow: CompetitionUnitOfWorkInterface, location_builder: LocationBuilder):
         """
         Constructor.
 
         Args:
             uow: Unit of Work para gestionar transacciones
+            location_builder: Domain Service para construir Location (patrón UserFinder)
         """
         self._uow = uow
-        # Domain Service para construir Location (patrón UserFinder)
-        self._location_builder = LocationBuilder(self._uow.countries)
+        self._location_builder = location_builder
 
     async def execute(
         self, request: CreateCompetitionRequestDTO, creator_id: UserId

--- a/src/modules/competition/application/use_cases/update_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/update_competition_use_case.py
@@ -49,15 +49,16 @@ class UpdateCompetitionUseCase:
     5. Persistir cambios
     """
 
-    def __init__(self, uow: CompetitionUnitOfWorkInterface):
+    def __init__(self, uow: CompetitionUnitOfWorkInterface, location_builder: LocationBuilder):
         """
         Constructor.
 
         Args:
             uow: Unit of Work para gestionar transacciones
+            location_builder: Domain Service para construir Location
         """
         self._uow = uow
-        self._location_builder = LocationBuilder(self._uow.countries)
+        self._location_builder = location_builder
 
     async def execute(
         self,

--- a/tests/unit/modules/competition/application/use_cases/helpers.py
+++ b/tests/unit/modules/competition/application/use_cases/helpers.py
@@ -10,6 +10,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CreateCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
@@ -20,7 +21,7 @@ from src.modules.user.domain.value_objects.user_id import UserId
 
 async def create_competition(uow: InMemoryUnitOfWork, creator_id: UserId):
     """Crea una competición en DRAFT."""
-    create_uc = CreateCompetitionUseCase(uow)
+    create_uc = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
     request = CreateCompetitionRequestDTO(
         name="Test Cup",
         start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_activate_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_activate_competition_use_case.py
@@ -18,6 +18,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CreateCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.competition import CompetitionStateError
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -57,7 +58,7 @@ class TestActivateCompetitionUseCase:
         Then: Se activa correctamente y cambia a estado ACTIVE
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -115,7 +116,7 @@ class TestActivateCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -146,7 +147,7 @@ class TestActivateCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -179,7 +180,7 @@ class TestActivateCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear competición y llevarla a COMPLETED
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -220,7 +221,7 @@ class TestActivateCompetitionUseCase:
         Then: Se emite el evento de dominio
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_cancel_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_cancel_competition_use_case.py
@@ -18,6 +18,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CreateCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.competition import CompetitionStateError
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -57,7 +58,7 @@ class TestCancelCompetitionUseCase:
         Then: Se cancela correctamente y cambia a estado CANCELLED
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -95,7 +96,7 @@ class TestCancelCompetitionUseCase:
         Then: Se cancela correctamente
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -134,7 +135,7 @@ class TestCancelCompetitionUseCase:
         Then: Se cancela correctamente
         """
         # Arrange: Crear y llevar a IN_PROGRESS
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -172,7 +173,7 @@ class TestCancelCompetitionUseCase:
         Then: Se cancela correctamente con reason=None
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -223,7 +224,7 @@ class TestCancelCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -254,7 +255,7 @@ class TestCancelCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear y completar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -295,7 +296,7 @@ class TestCancelCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear y cancelar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -328,7 +329,7 @@ class TestCancelCompetitionUseCase:
         Then: Se emite el evento de dominio con la razón
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_close_enrollments_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_close_enrollments_use_case.py
@@ -18,6 +18,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CreateCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.competition import CompetitionStateError
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -57,7 +58,7 @@ class TestCloseEnrollmentsUseCase:
         Then: Se cierran correctamente y cambia a estado CLOSED
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -122,7 +123,7 @@ class TestCloseEnrollmentsUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -160,7 +161,7 @@ class TestCloseEnrollmentsUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear competición (queda en DRAFT)
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -191,7 +192,7 @@ class TestCloseEnrollmentsUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear, activar y cerrar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -230,7 +231,7 @@ class TestCloseEnrollmentsUseCase:
         Then: Se emite el evento de dominio
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_complete_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_complete_competition_use_case.py
@@ -20,6 +20,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CreateCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.competition import CompetitionStateError
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -59,7 +60,7 @@ class TestCompleteCompetitionUseCase:
         Then: Se completa correctamente y cambia a estado COMPLETED
         """
         # Arrange: Crear y llevar a IN_PROGRESS
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -126,7 +127,7 @@ class TestCompleteCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear y llevar a IN_PROGRESS
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -166,7 +167,7 @@ class TestCompleteCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear competición (queda en DRAFT)
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -197,7 +198,7 @@ class TestCompleteCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear, activar y cerrar
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -236,7 +237,7 @@ class TestCompleteCompetitionUseCase:
         Then: Se emite el evento de dominio
         """
         # Arrange: Crear y llevar a IN_PROGRESS
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_create_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_create_competition_use_case.py
@@ -12,7 +12,10 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
     CompetitionAlreadyExistsError,
     CreateCompetitionUseCase,
 )
-from src.modules.competition.domain.services.location_builder import InvalidCountryError
+from src.modules.competition.domain.services.location_builder import (
+    InvalidCountryError,
+    LocationBuilder,
+)
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -46,7 +49,7 @@ class TestCreateCompetitionUseCase:
         Then: La competición se crea en estado DRAFT y se persiste
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -91,7 +94,7 @@ class TestCreateCompetitionUseCase:
         Then: La competición se crea con los 3 países correctamente
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Iberian Cup 2025",
             start_date=date(2025, 7, 1),
@@ -127,7 +130,7 @@ class TestCreateCompetitionUseCase:
         Then: Se lanza CompetitionAlreadyExistsError
         """
         # Arrange: Crear competición existente
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         existing_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -162,7 +165,7 @@ class TestCreateCompetitionUseCase:
         Then: Se lanza InvalidCountryError
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Invalid Cup",
             start_date=date(2025, 6, 1),
@@ -188,7 +191,7 @@ class TestCreateCompetitionUseCase:
         Then: Se lanza InvalidCountryError
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Invalid Adjacency Cup",
             start_date=date(2025, 6, 1),
@@ -215,7 +218,7 @@ class TestCreateCompetitionUseCase:
         Then: La competición se crea con play_mode configurado
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Handicap Cup",
             start_date=date(2025, 6, 1),
@@ -243,7 +246,7 @@ class TestCreateCompetitionUseCase:
         Then: Se crea un enrollment APPROVED para el creador
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Auto Enroll Cup",
             start_date=date(2025, 6, 1),
@@ -272,7 +275,7 @@ class TestCreateCompetitionUseCase:
         Then: Se llama a commit() en el UoW
         """
         # Arrange
-        use_case = CreateCompetitionUseCase(uow)
+        use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request_dto = CreateCompetitionRequestDTO(
             name="Commit Test Cup",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_delete_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_delete_competition_use_case.py
@@ -20,6 +20,7 @@ from src.modules.competition.application.use_cases.delete_competition_use_case i
     CompetitionNotDeletableError,
     DeleteCompetitionUseCase,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -59,7 +60,7 @@ class TestDeleteCompetitionUseCase:
         Then: Se elimina correctamente y retorna confirmación
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -117,7 +118,7 @@ class TestDeleteCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -148,7 +149,7 @@ class TestDeleteCompetitionUseCase:
         Then: Se lanza CompetitionNotDeletableError
         """
         # Arrange: Crear competición y activarla
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -187,7 +188,7 @@ class TestDeleteCompetitionUseCase:
         Then: Se lanza CompetitionNotDeletableError
         """
         # Arrange: Crear competición y llevarla a IN_PROGRESS
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -228,7 +229,7 @@ class TestDeleteCompetitionUseCase:
         Then: Se lanza CompetitionNotDeletableError
         """
         # Arrange: Crear competición y llevarla a COMPLETED
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_get_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_get_competition_use_case.py
@@ -15,6 +15,7 @@ from src.modules.competition.application.use_cases.create_competition_use_case i
 from src.modules.competition.application.use_cases.get_competition_use_case import (
     GetCompetitionUseCase,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -49,7 +50,7 @@ class TestGetCompetitionUseCase:
         Then: Se retorna el DTO completo
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -86,7 +87,7 @@ class TestGetCompetitionUseCase:
         Then: El DTO muestra play_mode como SCRATCH
         """
         # Arrange
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Scratch Cup",
             start_date=date(2025, 6, 1),
@@ -132,7 +133,7 @@ class TestGetCompetitionUseCase:
         Then: Los países adyacentes son None en el DTO
         """
         # Arrange
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Single Country Cup",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_handle_enrollment_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_handle_enrollment_use_case.py
@@ -24,6 +24,7 @@ from src.modules.competition.domain.entities.enrollment import Enrollment
 from src.modules.competition.domain.exceptions.competition_violations import (
     CompetitionFullViolation,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
@@ -57,7 +58,7 @@ class TestHandleEnrollmentUseCase:
         self, uow: InMemoryUnitOfWork, creator_id: UserId, max_players: int = 24
     ):
         """Helper: crea y activa una competición."""
-        create_uc = CreateCompetitionUseCase(uow)
+        create_uc = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         request = CreateCompetitionRequestDTO(
             name="Test Cup",
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_list_competition_invitations_use_case.py
@@ -19,6 +19,7 @@ from src.modules.competition.application.use_cases.list_competition_invitations_
     ListCompetitionInvitationsUseCase,
 )
 from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.invitation_id import InvitationId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
@@ -57,7 +58,7 @@ class TestListCompetitionInvitationsUseCase:
         return user
 
     async def _create_active_competition(self, comp_uow, creator_id, name="Test Cup"):
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name=name,
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_list_my_invitations_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_list_my_invitations_use_case.py
@@ -14,6 +14,7 @@ from src.modules.competition.application.use_cases.list_my_invitations_use_case 
     ListMyInvitationsUseCase,
 )
 from src.modules.competition.domain.entities.invitation import Invitation
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.invitation_id import InvitationId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
@@ -52,7 +53,7 @@ class TestListMyInvitationsUseCase:
         return user
 
     async def _create_active_competition(self, comp_uow, creator_id, name="Test Cup"):
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name=name,
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_reopen_enrollments_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_reopen_enrollments_use_case.py
@@ -23,6 +23,7 @@ from src.modules.competition.domain.entities.competition import CompetitionState
 from src.modules.competition.domain.events.competition_enrollments_reopened_event import (
     CompetitionEnrollmentsReopenedEvent,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -52,7 +53,7 @@ class TestReopenEnrollmentsUseCase:
 
     async def _create_closed_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
         """Helper: crea una competición en estado CLOSED."""
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -134,7 +135,7 @@ class TestReopenEnrollmentsUseCase:
         When: Se intenta reabrir inscripciones
         Then: Se lanza CompetitionStateError (ya está en ACTIVE)
         """
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_respond_to_invitation_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_respond_to_invitation_use_case.py
@@ -25,6 +25,7 @@ from src.modules.competition.domain.entities.invitation import Invitation
 from src.modules.competition.domain.exceptions.competition_violations import (
     InvalidInvitationStatusViolation,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.invitation_id import InvitationId
 from src.modules.competition.domain.value_objects.invitation_status import (
@@ -66,7 +67,7 @@ class TestRespondToInvitationUseCase:
         return user
 
     async def _create_active_competition(self, comp_uow, creator_id, max_players=24):
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name="Test Cup",
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_revert_competition_status_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_revert_competition_status_use_case.py
@@ -23,6 +23,7 @@ from src.modules.competition.domain.entities.competition import CompetitionState
 from src.modules.competition.domain.events.competition_reverted_to_closed_event import (
     CompetitionRevertedToClosedEvent,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -52,7 +53,7 @@ class TestRevertCompetitionStatusUseCase:
 
     async def _create_in_progress_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
         """Helper: crea una competición en estado IN_PROGRESS."""
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -134,7 +135,7 @@ class TestRevertCompetitionStatusUseCase:
         When: Se intenta revertir
         Then: Se lanza CompetitionStateError (ya está en CLOSED)
         """
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_revert_competition_to_in_progress_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_revert_competition_to_in_progress_use_case.py
@@ -23,6 +23,7 @@ from src.modules.competition.domain.entities.competition import CompetitionState
 from src.modules.competition.domain.events.competition_reverted_to_in_progress_event import (
     CompetitionRevertedToInProgressEvent,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -52,7 +53,7 @@ class TestRevertCompetitionToInProgressUseCase:
 
     async def _create_completed_competition(self, uow: InMemoryUnitOfWork, creator_id: UserId):
         """Helper: crea una competición en estado COMPLETED."""
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -135,7 +136,7 @@ class TestRevertCompetitionToInProgressUseCase:
         When: Se intenta revertir
         Then: Se lanza CompetitionStateError
         """
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_email_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_email_use_case.py
@@ -30,6 +30,7 @@ from src.modules.competition.domain.exceptions.competition_violations import (
     InvitationRateLimitViolation,
     SelfInvitationViolation,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.competition.domain.value_objects.invitation_id import InvitationId
@@ -69,7 +70,7 @@ class TestSendInvitationByEmailUseCase:
         return user
 
     async def _create_active_competition(self, comp_uow, creator_id):
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name="Test Cup",
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_send_invitation_by_user_id_use_case.py
@@ -32,6 +32,7 @@ from src.modules.competition.domain.exceptions.competition_violations import (
     InvitationRateLimitViolation,
     SelfInvitationViolation,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
 from src.modules.competition.domain.value_objects.invitation_id import InvitationId
@@ -73,7 +74,7 @@ class TestSendInvitationByUserIdUseCase:
 
     async def _create_active_competition(self, comp_uow, creator_id):
         """Helper: crea y activa una competicion."""
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name="Test Cup",
             start_date=date(2026, 6, 1),
@@ -250,7 +251,7 @@ class TestSendInvitationByUserIdUseCase:
         invitee = await self._create_user(user_uow, email="invitee@test.com")
 
         # Crear competition sin activar (queda en DRAFT)
-        create_uc = CreateCompetitionUseCase(comp_uow)
+        create_uc = CreateCompetitionUseCase(comp_uow, LocationBuilder(comp_uow.countries))
         request = CreateCompetitionRequestDTO(
             name="Draft Cup",
             start_date=date(2026, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_start_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_start_competition_use_case.py
@@ -18,6 +18,7 @@ from src.modules.competition.application.use_cases.start_competition_use_case im
     StartCompetitionUseCase,
 )
 from src.modules.competition.domain.entities.competition import CompetitionStateError
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -57,7 +58,7 @@ class TestStartCompetitionUseCase:
         Then: Se inicia correctamente y cambia a estado IN_PROGRESS
         """
         # Arrange: Crear, activar y cerrar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -123,7 +124,7 @@ class TestStartCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear, activar y cerrar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -162,7 +163,7 @@ class TestStartCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear competición (queda en DRAFT)
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -193,7 +194,7 @@ class TestStartCompetitionUseCase:
         Then: Se lanza CompetitionStateError
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),
@@ -231,7 +232,7 @@ class TestStartCompetitionUseCase:
         Then: Se emite el evento de dominio
         """
         # Arrange: Crear, activar y cerrar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Ryder Cup 2025",
             start_date=date(2025, 6, 1),

--- a/tests/unit/modules/competition/application/use_cases/test_update_competition_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_update_competition_use_case.py
@@ -18,6 +18,7 @@ from src.modules.competition.application.use_cases.update_competition_use_case i
     NotCompetitionCreatorError,
     UpdateCompetitionUseCase,
 )
+from src.modules.competition.domain.services.location_builder import LocationBuilder
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -52,7 +53,7 @@ class TestUpdateCompetitionUseCase:
         Then: El nombre se actualiza correctamente
         """
         # Arrange: Crear competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Original Name",
             start_date=date(2025, 6, 1),
@@ -63,7 +64,7 @@ class TestUpdateCompetitionUseCase:
         created = await create_use_case.execute(create_request, creator_id)
 
         # Act: Actualizar nombre
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         update_request = UpdateCompetitionRequestDTO(name="Updated Name")
 
         response = await update_use_case.execute(
@@ -87,7 +88,7 @@ class TestUpdateCompetitionUseCase:
         Then: Todos los campos se actualizan correctamente
         """
         # Arrange
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Original",
             start_date=date(2025, 6, 1),
@@ -98,7 +99,7 @@ class TestUpdateCompetitionUseCase:
         created = await create_use_case.execute(create_request, creator_id)
 
         # Act
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         update_request = UpdateCompetitionRequestDTO(
             name="Updated",
             start_date=date(2025, 7, 1),
@@ -126,7 +127,7 @@ class TestUpdateCompetitionUseCase:
         Then: El play_mode se actualiza correctamente
         """
         # Arrange
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Test",
             start_date=date(2025, 6, 1),
@@ -137,7 +138,7 @@ class TestUpdateCompetitionUseCase:
         created = await create_use_case.execute(create_request, creator_id)
 
         # Act
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         update_request = UpdateCompetitionRequestDTO(play_mode="HANDICAP")
 
         await update_use_case.execute(CompetitionId(created.id), update_request, creator_id)
@@ -157,7 +158,7 @@ class TestUpdateCompetitionUseCase:
         Then: Se lanza CompetitionNotFoundError
         """
         # Arrange
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         fake_id = CompetitionId(uuid4())
         update_request = UpdateCompetitionRequestDTO(name="Test")
 
@@ -178,7 +179,7 @@ class TestUpdateCompetitionUseCase:
         Then: Se lanza NotCompetitionCreatorError
         """
         # Arrange: Crear con creator_id
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Test",
             start_date=date(2025, 6, 1),
@@ -189,7 +190,7 @@ class TestUpdateCompetitionUseCase:
         created = await create_use_case.execute(create_request, creator_id)
 
         # Act & Assert: Intentar actualizar con otro usuario
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         other_user = UserId(uuid4())
         update_request = UpdateCompetitionRequestDTO(name="Hacked")
 
@@ -209,7 +210,7 @@ class TestUpdateCompetitionUseCase:
         Then: Se lanza CompetitionNotEditableError
         """
         # Arrange: Crear y activar competición
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Test",
             start_date=date(2025, 6, 1),
@@ -227,7 +228,7 @@ class TestUpdateCompetitionUseCase:
             await uow.commit()
 
         # Act & Assert: Intentar actualizar
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         update_request = UpdateCompetitionRequestDTO(name="Cannot Update")
 
         with pytest.raises(CompetitionNotEditableError) as exc_info:
@@ -244,7 +245,7 @@ class TestUpdateCompetitionUseCase:
         Then: Se llama a commit() en el UoW
         """
         # Arrange
-        create_use_case = CreateCompetitionUseCase(uow)
+        create_use_case = CreateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         create_request = CreateCompetitionRequestDTO(
             name="Test",
             start_date=date(2025, 6, 1),
@@ -255,7 +256,7 @@ class TestUpdateCompetitionUseCase:
         created = await create_use_case.execute(create_request, creator_id)
 
         # Act
-        update_use_case = UpdateCompetitionUseCase(uow)
+        update_use_case = UpdateCompetitionUseCase(uow, LocationBuilder(uow.countries))
         update_request = UpdateCompetitionRequestDTO(name="Updated")
 
         await update_use_case.execute(CompetitionId(created.id), update_request, creator_id)


### PR DESCRIPTION
## Summary
- `CreateCompetitionUseCase` and `UpdateCompetitionUseCase` instantiated the `LocationBuilder` domain service directly inside their constructors (`LocationBuilder(self._uow.countries)`) instead of receiving it via DI — the two call sites that predated (or were missed by) the Nov 2025 "Dependency Injection Refactoring" documented in CLAUDE.md.
- Added `get_location_builder()` provider in `dependencies.py`, wired from the same `get_competition_uow` the use cases already depend on (FastAPI caches `Depends` results within a request, so this reuses the same UoW instance, not a second one).
- Both use cases now receive `location_builder: LocationBuilder` as a constructor parameter.
- Updated all direct-construction test call sites (helpers.py + 18 test files) to pass `LocationBuilder(uow.countries)` explicitly.

Closes #111

## Test plan
- [x] `pytest tests/unit/modules/competition/` — 1082 passed
- [x] `pytest tests/unit/` — 2260 passed (full suite)
- [x] `ruff check` / `ruff format` — clean (scoped to touched files only, no unrelated formatting noise)
- [x] `mypy` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved competition creation and updates by consistently handling location information.
  - Competition workflows now share country data more reliably, supporting consistent location validation and processing.

- **Tests**
  - Updated competition workflow test coverage to reflect the revised location handling.
  - Existing competition behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->