### PR TITLE
refactor(competition): De-duplicate max_playing_handicap cap between domain service and use case

### DIFF
--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -253,7 +253,9 @@ class GenerateMatchesUseCase:
             for pid, user in zip(all_player_ids, users, strict=True):
                 if user:
                     enrollment = enrollment_map.get(str(pid.value))
-                    has_custom_handicap = enrollment is not None and enrollment.custom_handicap is not None
+                    has_custom_handicap = (
+                        enrollment is not None and enrollment.custom_handicap is not None
+                    )
                     if not has_custom_handicap:
                         await self._maybe_refresh_rfeg_handicap(user)
                     if user.handicap is not None:
@@ -572,7 +574,9 @@ class GenerateMatchesUseCase:
                 f"(gender: {tee_gender}) en el campo de golf"
             )
 
-        playing_handicap = calculator.calculate(handicap_index, tee_rating, allowance, max_playing_handicap)
+        playing_handicap = calculator.calculate(
+            handicap_index, tee_rating, allowance, max_playing_handicap
+        )
         strokes_received = calculator.compute_strokes_received(
             playing_handicap, holes_by_stroke_index
         )
@@ -663,11 +667,10 @@ class GenerateMatchesUseCase:
             course_handicaps.append((str(uid.value), ch))
 
         # 2. Método diferencial: aplica allowance% a diferencias respecto al menor CH
-        differential_phs = calculator.calculate_fourball_differential(course_handicaps, allowance)
-
-        # Aplicar cap de max_playing_handicap si está definido
-        if max_playing_handicap is not None:
-            differential_phs = {k: min(v, max_playing_handicap) for k, v in differential_phs.items()}
+        # (calculate_fourball_differential aplica el cap de max_playing_handicap internamente)
+        differential_phs = calculator.calculate_fourball_differential(
+            course_handicaps, allowance, max_playing_handicap
+        )
 
         # 3. Construir MatchPlayers con PH diferencial
         def build_player(uid):
@@ -723,12 +726,20 @@ class GenerateMatchesUseCase:
         if is_scratch:
             return (
                 MatchPlayer.create(
-                    user_id=a_player_id, playing_handicap=0, tee_category=tee_cat_a,
-                    strokes_received=[], tee_gender=tee_gen_a, player_handicap=hi_a,
+                    user_id=a_player_id,
+                    playing_handicap=0,
+                    tee_category=tee_cat_a,
+                    strokes_received=[],
+                    tee_gender=tee_gen_a,
+                    player_handicap=hi_a,
                 ),
                 MatchPlayer.create(
-                    user_id=b_player_id, playing_handicap=0, tee_category=tee_cat_b,
-                    strokes_received=[], tee_gender=tee_gen_b, player_handicap=hi_b,
+                    user_id=b_player_id,
+                    playing_handicap=0,
+                    tee_category=tee_cat_b,
+                    strokes_received=[],
+                    tee_gender=tee_gen_b,
+                    player_handicap=hi_b,
                 ),
             )
 
@@ -759,12 +770,20 @@ class GenerateMatchesUseCase:
 
         return (
             MatchPlayer.create(
-                user_id=a_player_id, playing_handicap=ph_a, tee_category=tee_cat_a,
-                strokes_received=strokes_a, tee_gender=tee_gen_a, player_handicap=hi_a,
+                user_id=a_player_id,
+                playing_handicap=ph_a,
+                tee_category=tee_cat_a,
+                strokes_received=strokes_a,
+                tee_gender=tee_gen_a,
+                player_handicap=hi_a,
             ),
             MatchPlayer.create(
-                user_id=b_player_id, playing_handicap=ph_b, tee_category=tee_cat_b,
-                strokes_received=strokes_b, tee_gender=tee_gen_b, player_handicap=hi_b,
+                user_id=b_player_id,
+                playing_handicap=ph_b,
+                tee_category=tee_cat_b,
+                strokes_received=strokes_b,
+                tee_gender=tee_gen_b,
+                player_handicap=hi_b,
             ),
         )
 
@@ -852,14 +871,10 @@ class GenerateMatchesUseCase:
                 team_b_chs.append(ch)
 
         # 2. Método diferencial por equipos: allowance% se aplica a la diferencia de promedios
+        # (calculate_foursomes_differential aplica el cap de max_playing_handicap internamente)
         team_a_ph, team_b_ph = calculator.calculate_foursomes_differential(
-            team_a_chs, team_b_chs, allowance
+            team_a_chs, team_b_chs, allowance, max_playing_handicap
         )
-
-        # Aplicar cap de max_playing_handicap si está definido
-        if max_playing_handicap is not None:
-            team_a_ph = min(team_a_ph, max_playing_handicap)
-            team_b_ph = min(team_b_ph, max_playing_handicap)
 
         # 3. Ambos jugadores del equipo comparten los mismos strokes (una bola)
         team_a_strokes = calculator.compute_strokes_received(team_a_ph, holes_by_stroke_index)

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -215,6 +215,7 @@ class PlayingHandicapCalculator:
     def calculate_fourball_differential(
         player_course_handicaps: list[tuple[str, int]],
         allowance_percentage: int,
+        max_playing_handicap: int | None = None,
     ) -> dict[str, int]:
         """
         Método diferencial WHS para Fourball (Match Play).
@@ -227,13 +228,15 @@ class PlayingHandicapCalculator:
         1. Encontrar el menor course handicap entre los 4 jugadores
         2. Para cada jugador: diferencia = CH - menor_CH
         3. Playing Handicap = diferencia x allowance_percentage / 100
+        4. Si se indica max_playing_handicap, se acota a ese límite
 
         Args:
             player_course_handicaps: Lista de (user_id, course_handicap) para los 4 jugadores
             allowance_percentage: Porcentaje de allowance de la ronda (50-100)
+            max_playing_handicap: Límite superior opcional (cap WHS de la competición)
 
         Returns:
-            dict de user_id → playing_handicap diferencial
+            dict de user_id → playing_handicap diferencial (acotado si se indica el cap)
         """
         if not player_course_handicaps:
             return {}
@@ -247,6 +250,8 @@ class PlayingHandicapCalculator:
             ph = int(
                 (Decimal(str(diff)) * allowance).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
             )
+            if max_playing_handicap is not None:
+                ph = min(ph, max_playing_handicap)
             result[user_id] = ph
         return result
 
@@ -255,6 +260,7 @@ class PlayingHandicapCalculator:
         team_a_course_handicaps: list[int],
         team_b_course_handicaps: list[int],
         allowance_percentage: int,
+        max_playing_handicap: int | None = None,
     ) -> tuple[int, int]:
         """
         Método diferencial WHS para Foursomes (Golpe Alterno).
@@ -264,6 +270,7 @@ class PlayingHandicapCalculator:
         2. Calcular diferencia entre promedios
         3. Aplicar allowance_percentage a la diferencia
         4. El equipo con mayor promedio CH recibe los strokes; el otro recibe 0
+        5. Si se indica max_playing_handicap, se acota a ese límite
 
         Ambos jugadores del equipo reciben los mismos strokes porque
         comparten una bola (golpe alterno).
@@ -272,10 +279,11 @@ class PlayingHandicapCalculator:
             team_a_course_handicaps: CHs de los jugadores del equipo A
             team_b_course_handicaps: CHs de los jugadores del equipo B
             allowance_percentage: Porcentaje de allowance de la ronda (50-100)
+            max_playing_handicap: Límite superior opcional (cap WHS de la competición)
 
         Returns:
-            (team_a_ph, team_b_ph) — Playing Handicap por equipo.
-            Solo un equipo recibe strokes (el de mayor CH promedio).
+            (team_a_ph, team_b_ph) — Playing Handicap por equipo (acotado si se indica
+            el cap). Solo un equipo recibe strokes (el de mayor CH promedio).
         """
         if not team_a_course_handicaps or not team_b_course_handicaps:
             return 0, 0
@@ -290,6 +298,8 @@ class PlayingHandicapCalculator:
         difference = abs(team_a_avg - team_b_avg)
         allowance = Decimal(str(allowance_percentage)) / Decimal("100")
         strokes = int((difference * allowance).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+        if max_playing_handicap is not None:
+            strokes = min(strokes, max_playing_handicap)
 
         if team_a_avg > team_b_avg:
             return strokes, 0

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -755,9 +755,7 @@ class TestGenerateMatchesUseCase:
             total_strokes = sum(
                 len(p.strokes_received) for p in (*m.team_a_players, *m.team_b_players)
             )
-            assert total_strokes == 0, (
-                "Equal PHs → differential = 0 → no strokes for either player"
-            )
+            assert total_strokes == 0, "Equal PHs → differential = 0 → no strokes for either player"
 
     async def test_singles_differential_strokes_only_higher_ph_receives(
         self,
@@ -1221,6 +1219,76 @@ class TestGenerateMatchesUseCase:
 
         high_hi_player = next(p for p in all_players if p.user_id == high_hi_uid)
         assert high_hi_player.playing_handicap == 3
+
+    async def test_max_playing_handicap_is_applied_in_foursomes(
+        self,
+        uow: InMemoryUnitOfWork,
+        creator_id: UserId,
+        golf_course_id: GolfCourseId,
+        gc_repo: AsyncMock,
+        user_repo: AsyncMock,
+    ):
+        """
+        Verifica que max_playing_handicap se aplica al generar partidos FOURSOMES.
+
+        Given: Competicion HANDICAP con max_playing_handicap=3, equipo A con HI=36
+               en ambos jugadores y equipo B con HI=0, de forma que el metodo
+               diferencial WHS por equipos produzca un PH > 3 para el equipo A
+               antes de aplicar el cap
+        When: Se generan partidos FOURSOMES
+        Then: playing_handicap de todos los jugadores <= 3, y el equipo A (mayor CH
+              promedio) queda exactamente en 3 (confirma que el cap realmente actuo)
+        """
+        competition = Competition.create(
+            id=CompetitionId(uuid4()),
+            creator_id=creator_id,
+            name=CompetitionName("Cap Foursomes"),
+            dates=DateRange(start_date=date(2026, 6, 1), end_date=date(2026, 6, 3)),
+            location=Location(main_country=CountryCode("ES")),
+            play_mode=PlayMode.HANDICAP,
+            max_players=24,
+            team_assignment=TeamAssignment.MANUAL,
+            team_1_name="Team A",
+            team_2_name="Team B",
+            max_playing_handicap=3,
+        )
+        competition.activate()
+        competition.close_enrollments()
+        async with uow:
+            await uow.competitions.add(competition)
+
+        round_entity = await self._create_round_pending_matches(
+            uow, competition, golf_course_id, MatchFormat.FOURSOMES
+        )
+        team_a_ids, _team_b_ids = await self._create_teams_and_enrollments_with_tees(
+            uow, competition, 2, 2
+        )
+        high_hi_uids = set(team_a_ids)
+
+        mock_gc = self._build_mock_golf_course([(TeeCategory.AMATEUR, Gender.MALE)])
+        gc_repo.find_by_id = AsyncMock(return_value=mock_gc)
+
+        async def mock_find_user(uid):
+            hi = 36.0 if uid in high_hi_uids else 0.0
+            return self._build_mock_user(uid, hi, Gender.MALE)
+
+        user_repo.find_by_id = AsyncMock(side_effect=mock_find_user)
+
+        use_case = GenerateMatchesUseCase(
+            uow=uow, golf_course_repository=gc_repo, user_repository=user_repo
+        )
+        request = GenerateMatchesRequestDTO(round_id=round_entity.id.value)
+
+        await use_case.execute(request, creator_id)
+
+        matches = await uow.matches.find_by_round(round_entity.id)
+        assert len(matches) == 1
+        all_players = (*matches[0].team_a_players, *matches[0].team_b_players)
+        for p in all_players:
+            assert p.playing_handicap <= 3
+
+        high_hi_players = [p for p in all_players if p.user_id in high_hi_uids]
+        assert all(p.playing_handicap == 3 for p in high_hi_players)
 
     # =========================================================================
     # HM-1b: PLAYER_HANDICAP SNAPSHOT TESTS

--- a/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
@@ -483,3 +483,49 @@ class TestPlayingHandicapCalculatorMaxHandicap:
         )
 
         assert result == 18
+
+    def test_fourball_differential_caps_result_when_above_limit(self):
+        """calculate_fourball_differential aplica el mismo cap que calculate()."""
+        result = PlayingHandicapCalculator.calculate_fourball_differential(
+            player_course_handicaps=[("p1", 10), ("p2", 30)],
+            allowance_percentage=100,
+            max_playing_handicap=15,
+        )
+
+        # p1: diff=0 → ph=0 (sin cap). p2: diff=20 → ph=20 → acotado a 15
+        assert result["p1"] == 0
+        assert result["p2"] == 15
+
+    def test_fourball_differential_no_cap_when_none(self):
+        """Sin cap (None), calculate_fourball_differential no acota el resultado."""
+        result = PlayingHandicapCalculator.calculate_fourball_differential(
+            player_course_handicaps=[("p1", 10), ("p2", 30)],
+            allowance_percentage=100,
+            max_playing_handicap=None,
+        )
+
+        assert result["p2"] == 20
+
+    def test_foursomes_differential_caps_result_when_above_limit(self):
+        """calculate_foursomes_differential aplica el mismo cap que calculate()."""
+        team_a_ph, team_b_ph = PlayingHandicapCalculator.calculate_foursomes_differential(
+            team_a_course_handicaps=[10, 10],
+            team_b_course_handicaps=[30, 30],
+            allowance_percentage=100,
+            max_playing_handicap=15,
+        )
+
+        # Equipo B tiene mayor CH promedio: diff=20 → 20 strokes → acotado a 15
+        assert team_a_ph == 0
+        assert team_b_ph == 15
+
+    def test_foursomes_differential_no_cap_when_none(self):
+        """Sin cap (None), calculate_foursomes_differential no acota el resultado."""
+        _team_a_ph, team_b_ph = PlayingHandicapCalculator.calculate_foursomes_differential(
+            team_a_course_handicaps=[10, 10],
+            team_b_course_handicaps=[30, 30],
+            allowance_percentage=100,
+            max_playing_handicap=None,
+        )
+
+        assert team_b_ph == 20


### PR DESCRIPTION
## Summary
- `PlayingHandicapCalculator.calculate()` already applies the `max_playing_handicap` cap internally for the individual/SINGLES path. But `GenerateMatchesUseCase` reimplemented the same capping rule manually via dict comprehension / `min()` calls after calling `calculate_fourball_differential()` and `calculate_foursomes_differential()` — two sources of truth for one business rule.
- Added an optional `max_playing_handicap` parameter to both `calculate_fourball_differential()` and `calculate_foursomes_differential()`, applying the cap internally (same as `calculate()`).
- `_build_fourball_match_players` and `_build_foursomes_match_players` now pass `max_playing_handicap` straight through to the calculator instead of re-capping the result themselves.
- Added direct unit tests for the cap on both differential methods (capped vs. uncapped) — previously untested in isolation.
- Added `test_max_playing_handicap_is_applied_in_foursomes`, mirroring the existing FOURBALL end-to-end test (which already covered this path and required no changes) — FOURSOMES had no equivalent coverage before.

Closes #112

## Test plan
- [x] `pytest tests/unit/modules/competition/` — 1087 passed (1082 baseline + 5 new)
- [x] `pytest tests/unit/` — 2265 passed (full suite)
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Playing handicaps in FOURBALL and FOURSOMES matches now consistently respect the configured maximum handicap.
  - Ensures generated match handicaps do not exceed the specified cap.

- **Tests**
  - Added coverage for capped and uncapped handicap calculations.
  - Added validation for maximum handicaps in FOURSOMES match generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->