### PR TITLE
fix(scoring): Expose own/marker submitted flags in scoring view

### DIFF
--- a/src/modules/competition/application/dto/scoring_dto.py
+++ b/src/modules/competition/application/dto/scoring_dto.py
@@ -61,7 +61,9 @@ class PlayerHoleScoreDTO(BaseModel):
 
     user_id: str
     own_score: int | None = None
+    own_submitted: bool = False
     marker_score: int | None = None
+    marker_submitted: bool = False
     validation_status: str
     net_score: int | None = None
     strokes_received_this_hole: int

--- a/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
+++ b/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
@@ -203,7 +203,9 @@ class GetScoringViewUseCase:
                 PlayerHoleScoreDTO(
                     user_id=str(hs.player_user_id),
                     own_score=hs.own_score,
+                    own_submitted=hs.own_submitted,
                     marker_score=hs.marker_score,
+                    marker_submitted=hs.marker_submitted,
                     validation_status=hs.validation_status.value.lower(),
                     net_score=hs.net_score,
                     strokes_received_this_hole=hs.strokes_received,

--- a/tests/integration/api/v1/test_scoring_endpoints.py
+++ b/tests/integration/api/v1/test_scoring_endpoints.py
@@ -206,6 +206,12 @@ class TestGetScoringView:
         assert data["match_standing"]["holes_remaining"] == 18
         assert data["scorecard_submitted_by"] == []
 
+        # No hole has been scored yet: own/marker_submitted must be False for every player
+        for hole in data["scores"]:
+            for ps in hole["player_scores"]:
+                assert ps["own_submitted"] is False
+                assert ps["marker_submitted"] is False
+
     @pytest.mark.asyncio
     async def test_get_scoring_view_not_found(self, client: AsyncClient):
         """Scoring view de partido inexistente retorna 404."""
@@ -254,10 +260,14 @@ class TestSubmitHoleScore:
         hole_1 = next(s for s in data["scores"] if s["hole_number"] == 1)
         a_score = next(ps for ps in hole_1["player_scores"] if ps["user_id"] == player_a_id)
         assert a_score["own_score"] == 4
+        assert a_score["own_submitted"] is True
 
         # Player B should have marker_score set by A
         b_score = next(ps for ps in hole_1["player_scores"] if ps["user_id"] == player_b_id)
         assert b_score["marker_score"] == 5
+        assert b_score["marker_submitted"] is True
+        # Player B hasn't submitted their own score yet
+        assert b_score["own_submitted"] is False
 
     @pytest.mark.asyncio
     async def test_cross_validation_produces_match(self, client: AsyncClient):

--- a/tests/unit/modules/competition/application/dto/test_scoring_dto.py
+++ b/tests/unit/modules/competition/application/dto/test_scoring_dto.py
@@ -128,12 +128,23 @@ class TestSubDTOs:
         dto = PlayerHoleScoreDTO(
             user_id="u1",
             own_score=5,
+            own_submitted=True,
             marker_score=5,
+            marker_submitted=True,
             validation_status="match",
             net_score=4,
             strokes_received_this_hole=1,
         )
         assert dto.net_score == 4
+
+    def test_player_hole_score_defaults_to_not_submitted(self):
+        dto = PlayerHoleScoreDTO(
+            user_id="u1",
+            validation_status="pending",
+            strokes_received_this_hole=1,
+        )
+        assert dto.own_submitted is False
+        assert dto.marker_submitted is False
 
     def test_hole_result(self):
         dto = HoleResultDTO(winner="A", standing="1UP", standing_team="A")


### PR DESCRIPTION
## Summary
- Adds `own_submitted`/`marker_submitted` to `PlayerHoleScoreDTO`, sourced from the already-persisted `HoleScore` flags.
- Lets the frontend distinguish "hole not touched yet" from "score explicitly picked up (null)", both of which currently look identical as `own_score: null`.
- No persistence or WHS calculation changes — purely additive API field.

Closes #101. Frontend companion issue: RyderCupWeb #232 (in progress, will stop auto-submitting `par` on hole navigation using this flag).

## Test plan
- [x] `pytest tests/unit/modules/competition/application/dto/test_scoring_dto.py` — new default/explicit assertions for the two flags
- [x] `pytest tests/integration/api/v1/test_scoring_endpoints.py` — asserts flags are `False` before any score, `True` after submission
- [x] `pytest tests/unit/` — 2274 passed
- [x] `ruff check` + `mypy` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added score submission status indicators for both a player’s own score and their marker’s score.
  * Submission statuses are shown for each hole and default to unsubmitted until recorded.

* **Tests**
  * Added coverage for initial submission states and updates after score submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->