### PR TITLE
fix(auth): Don't skip device registration when client IP can't be resolved

### DIFF
--- a/src/modules/user/application/dto/device_dto.py
+++ b/src/modules/user/application/dto/device_dto.py
@@ -12,6 +12,17 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Placeholder usado cuando get_trusted_client_ip() no puede resolver una IP real
+# (p.ej. tráfico vía kubectl port-forward, donde el peer siempre es 127.0.0.1 y
+# validate_ip_address() lo rechaza como sentinel). Sin esto, el registro de
+# dispositivo se saltaba por completo y la cookie device_id nunca se fijaba,
+# dejando al usuario sin ningún dispositivo "current" — lo que
+# useDeviceRevocationMonitor del frontend interpreta como revocación y fuerza
+# logout inmediato. DeviceFingerprint.create() exige una IP sintácticamente
+# válida, de ahí "0.0.0.0" (ya reconocida como sentinel en el resto del código)
+# en vez de un string arbitrario como "unknown".
+UNRESOLVED_IP_PLACEHOLDER = "0.0.0.0"
+
 # ======================================================================================
 # DTO para el Caso de Uso: Register/Update Device
 # ======================================================================================

--- a/src/modules/user/application/use_cases/google_login_use_case.py
+++ b/src/modules/user/application/use_cases/google_login_use_case.py
@@ -11,7 +11,10 @@ Soporta tres flujos:
 from datetime import datetime
 
 from src.config.csrf_config import generate_csrf_token
-from src.modules.user.application.dto.device_dto import RegisterDeviceRequestDTO
+from src.modules.user.application.dto.device_dto import (
+    UNRESOLVED_IP_PLACEHOLDER,
+    RegisterDeviceRequestDTO,
+)
 from src.modules.user.application.dto.oauth_dto import (
     GoogleLoginRequestDTO,
     GoogleLoginResponseDTO,
@@ -132,13 +135,13 @@ class GoogleLoginUseCase:
 
     async def _register_device(self, request: GoogleLoginRequestDTO, user_id_str: str):
         """Register device and return (device_id, device_id_str, should_set_cookie)."""
-        if not request.user_agent or not request.ip_address:
+        if not request.user_agent:
             return None, None, False
 
         device_request = RegisterDeviceRequestDTO(
             user_id=user_id_str,
             user_agent=request.user_agent,
-            ip_address=request.ip_address,
+            ip_address=request.ip_address or UNRESOLVED_IP_PLACEHOLDER,
             device_id_from_cookie=request.device_id_from_cookie,
         )
         device_response = await self._register_device_use_case.execute(device_request)

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -12,7 +12,10 @@ import logging
 from datetime import UTC, datetime
 
 from src.config.csrf_config import generate_csrf_token
-from src.modules.user.application.dto.device_dto import RegisterDeviceRequestDTO
+from src.modules.user.application.dto.device_dto import (
+    UNRESOLVED_IP_PLACEHOLDER,
+    RegisterDeviceRequestDTO,
+)
 from src.modules.user.application.dto.user_dto import (
     LoginRequestDTO,
     LoginResponseDTO,
@@ -206,11 +209,11 @@ class LoginUserUseCase:
         device_id = None
         should_set_device_cookie = False
         device_id_str = None
-        if request.user_agent and request.ip_address:
+        if request.user_agent:
             device_request = RegisterDeviceRequestDTO(
                 user_id=str(user.id.value),
                 user_agent=request.user_agent,
-                ip_address=request.ip_address,
+                ip_address=request.ip_address or UNRESOLVED_IP_PLACEHOLDER,
                 device_id_from_cookie=request.device_id_from_cookie,  # v2.0.4
             )
             # Registrar dispositivo (crea nuevo o actualiza last_used_at + ip_address)

--- a/src/modules/user/application/use_cases/refresh_access_token_use_case.py
+++ b/src/modules/user/application/use_cases/refresh_access_token_use_case.py
@@ -9,7 +9,10 @@ Device Fingerprinting (v1.13.0): Registra/actualiza dispositivo en cada refresh.
 """
 
 from src.config.csrf_config import generate_csrf_token
-from src.modules.user.application.dto.device_dto import RegisterDeviceRequestDTO
+from src.modules.user.application.dto.device_dto import (
+    UNRESOLVED_IP_PLACEHOLDER,
+    RegisterDeviceRequestDTO,
+)
 from src.modules.user.application.dto.user_dto import (
     RefreshAccessTokenRequestDTO,
     RefreshAccessTokenResponseDTO,
@@ -150,11 +153,11 @@ class RefreshAccessTokenUseCase:
         # Cookie-based identification: device_id_from_cookie tiene prioridad
         device_id: str | None = None
         should_set_device_cookie = False
-        if request.user_agent and request.ip_address:
+        if request.user_agent:
             device_request = RegisterDeviceRequestDTO(
                 user_id=str(user.id.value),
                 user_agent=request.user_agent,
-                ip_address=request.ip_address,
+                ip_address=request.ip_address or UNRESOLVED_IP_PLACEHOLDER,
                 device_id_from_cookie=request.device_id_from_cookie,  # v2.0.4
             )
             # Registrar dispositivo (crea nuevo o actualiza last_used_at + ip_address)

--- a/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_google_login_use_case.py
@@ -401,3 +401,29 @@ class TestGoogleLoginUseCaseTokenGeneration:
         assert response.device_id is None
         assert response.should_set_device_cookie is False
         register_device_use_case.execute.assert_not_called()
+
+    async def test_registers_device_with_placeholder_ip_when_ip_unresolved(
+        self, use_case, google_oauth_service, google_user_info, register_device_use_case
+    ):
+        """
+        Debe seguir registrando el dispositivo (con IP placeholder) cuando
+        ip_address es None pero hay user_agent — ver test equivalente en
+        test_login_user_use_case.py para el porqué (device_id cookie nunca se
+        fijaba, causando logout inmediato por falsa revocación).
+        """
+        from src.modules.user.application.dto.device_dto import UNRESOLVED_IP_PLACEHOLDER
+
+        google_oauth_service.exchange_code_for_user_info.return_value = google_user_info
+
+        request = GoogleLoginRequestDTO(
+            authorization_code="valid-code",
+            ip_address=None,
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        )
+
+        response = await use_case.execute(request)
+
+        assert response.should_set_device_cookie is True
+        register_device_use_case.execute.assert_awaited_once()
+        call_kwargs = register_device_use_case.execute.call_args.args[0]
+        assert call_kwargs.ip_address == UNRESOLVED_IP_PLACEHOLDER

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -187,6 +187,41 @@ class TestLoginUserUseCase:
         assert payload["sub"] == str(existing_user.id.value)
         assert "exp" in payload  # Debe tener tiempo de expiración
 
+    async def test_registers_device_with_placeholder_ip_when_ip_unresolved(
+        self, uow, token_service, register_device_use_case, existing_user
+    ):
+        """
+        Debe seguir registrando el dispositivo (con IP placeholder) cuando
+        ip_address es None pero hay user_agent.
+
+        Antes de este fix, el registro de dispositivo (y por tanto la cookie
+        device_id) se saltaba por completo si no había IP resuelta — lo que
+        ocurre siempre que get_trusted_client_ip() rechaza el peer como
+        sentinel (p.ej. 127.0.0.1 vía kubectl port-forward). Sin cookie
+        device_id, ningún dispositivo se marca is_current_device=True y el
+        frontend fuerza un logout inmediato interpretándolo como revocación.
+        """
+        from src.modules.user.application.dto.device_dto import UNRESOLVED_IP_PLACEHOLDER
+
+        register_device_use_case.execute.return_value = AsyncMock(
+            device_id="7c9e6679-7425-40de-944b-e07fc1f90ae7",
+            set_device_cookie=True,
+        )
+        use_case = LoginUserUseCase(uow, token_service, register_device_use_case)
+        request = LoginRequestDTO(
+            email="test@example.com",
+            password="V@l1dP@ss123!",
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            ip_address=None,
+        )
+
+        response = await use_case.execute(request)
+
+        assert response is not None
+        register_device_use_case.execute.assert_awaited_once()
+        call_kwargs = register_device_use_case.execute.call_args.args[0]
+        assert call_kwargs.ip_address == UNRESOLVED_IP_PLACEHOLDER
+
 
 @pytest.mark.asyncio
 class TestLoginUserUseCaseHandicapRFEG:

--- a/tests/unit/modules/user/application/use_cases/test_refresh_access_token_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_refresh_access_token_use_case.py
@@ -139,6 +139,46 @@ class TestRefreshAccessTokenUseCase:
         token_service.verify_refresh_token.assert_called_once_with(valid_refresh_token_jwt)
         token_service.create_access_token.assert_called_once()
 
+    async def test_registers_device_with_placeholder_ip_when_ip_unresolved(
+        self,
+        use_case,
+        uow,
+        token_service,
+        register_device_use_case,
+        sample_user,
+        valid_refresh_token_jwt,
+        refresh_token_entity,
+    ):
+        """
+        Debe seguir registrando/actualizando el dispositivo (con IP placeholder)
+        cuando ip_address es None pero hay user_agent — ver test equivalente en
+        test_login_user_use_case.py para el porqué (device_id cookie nunca se
+        fijaba, causando logout inmediato por falsa revocación).
+        """
+        from src.modules.user.application.dto.device_dto import UNRESOLVED_IP_PLACEHOLDER
+
+        register_device_use_case.execute.return_value = AsyncMock(
+            device_id="7c9e6679-7425-40de-944b-e07fc1f90ae7",
+            set_device_cookie=True,
+        )
+        request = RefreshAccessTokenRequestDTO(
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            ip_address=None,
+        )
+        token_service.verify_refresh_token.return_value = {
+            "sub": str(sample_user.id.value),
+            "type": "refresh",
+        }
+        await uow.users.save(sample_user)
+        await uow.refresh_tokens.save(refresh_token_entity)
+
+        result = await use_case.execute(request, valid_refresh_token_jwt)
+
+        assert result is not None
+        register_device_use_case.execute.assert_awaited_once()
+        call_kwargs = register_device_use_case.execute.call_args.args[0]
+        assert call_kwargs.ip_address == UNRESOLVED_IP_PLACEHOLDER
+
     async def test_execute_with_invalid_jwt_returns_none(
         self,
         use_case,


### PR DESCRIPTION
## Summary
- `login_user_use_case.py` / `refresh_access_token_use_case.py` / `google_login_use_case.py` used to require **both** `user_agent` and `ip_address` before registering the device / setting the `device_id` cookie. If `ip_address` resolved to `None` (which `get_trusted_client_ip()` correctly does for sentinel values like `127.0.0.1`), device registration was skipped entirely — no error, just silently skipped.
- Without the `device_id` cookie, `GET /users/me/devices` can never mark any device `is_current_device: true`. The frontend's `useDeviceRevocationMonitor` treats "no current device" as an explicit revocation and forces an immediate logout right after a successful login.
- Reproduced reliably via `kubectl port-forward` to the API (peer IP is always `127.0.0.1` in that path) — confirmed with curl and in the browser, and confirmed fixed after rebuilding the image with this change and rolling it out locally (new device row gets `ip_address: "0.0.0.0"` and `is_current_device: true`, login no longer bounces back).
- Not a recent regression — this code path hasn't changed since v2.0.4/v2.0.6. It's an edge case nobody had exercised end-to-end (real traffic goes through Cloudflare/ingress, both of which supply a resolvable IP).

## Fix
Keep requiring `user_agent`; fall back to a fixed placeholder (`UNRESOLVED_IP_PLACEHOLDER = "0.0.0.0"`, already a recognized IP sentinel elsewhere in the codebase) for `ip_address` instead of skipping registration outright.

**Scope / security note:** this only touches the device-registration call sites. `validate_ip_address()`, `get_trusted_client_ip()`, trusted-proxy validation, and Cloudflare header trust are untouched — no change to IP-spoofing defenses. Rate limiting / account lockout use SlowAPI's own `get_remote_address()`, a separate code path, also untouched.

## Test plan
- [x] New unit tests in the 3 affected use cases: registration proceeds with the placeholder IP when `ip_address` is `None` but `user_agent` is present
- [x] `pytest tests/unit/` — 2276 passed
- [x] `pytest tests/integration/` — 318 passed, 1 skipped (pre-existing)
- [x] `ruff check` + `mypy` clean on touched files
- [x] Manually verified end-to-end: rebuilt image, rolled out to local Kind cluster, confirmed `device_id` cookie is set and `is_current_device: true` on next login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device registration now works when a user agent is available but the client IP address cannot be determined.
  * Unresolved IP addresses are recorded as `0.0.0.0` during login, Google login, and access-token refresh flows.
  * Device cookies are set correctly in these scenarios.

* **Tests**
  * Added coverage for device registration without a resolved IP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->