### PR TITLE
feat(social): Send email notification when a friend request is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Email de notificación al enviar una solicitud de amistad (`ISocialEmailService`/`send_friend_request_email`), siguiendo el mismo patrón que las invitaciones a competición. Envío no bloqueante: un fallo de Mailgun no impide crear la solicitud.
+
+### Changed
+
+- Extraído `mask_email()` (enmascarado de emails para logs de seguridad) a `src/shared/infrastructure/security/email_masking.py`, reemplazando 3 copias idénticas/divergentes en los módulos Competition y Social.
+
 ## [2.3.1] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Extraído `mask_email()` (enmascarado de emails para logs de seguridad) a `src/shared/infrastructure/security/email_masking.py`, reemplazando 3 copias idénticas/divergentes en los módulos Competition y Social.
+- `EmailService`: los métodos async (`send_password_reset_email`, `send_password_changed_notification`, `send_invitation_email`, `send_friend_request_email`) ya no bloquean el event loop mientras esperan a Mailgun — el envío síncrono ahora se despacha vía `asyncio.to_thread`. Issue de deuda técnica para migrar a un cliente HTTP async de verdad: #148.
+
+### Fixed
+
+- `mask_email()` no enmascaraba correctamente emails con dominio vacío (ej. `"alice@"`), devolviendo `"a***@"` en vez de `"***"`.
 
 ## [2.3.1] - 2026-08-01
 

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -244,6 +244,9 @@ from src.modules.quick_match.domain.services.scoring_coverage_service import (
 from src.modules.quick_match.infrastructure.persistence.sqlalchemy.quick_match_unit_of_work import (
     SQLAlchemyQuickMatchUnitOfWork,
 )
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.social.application.use_cases.block_user_use_case import BlockUserUseCase
 from src.modules.social.application.use_cases.list_friends_use_case import ListFriendsUseCase
 from src.modules.social.application.use_cases.list_pending_requests_use_case import (
@@ -1065,12 +1068,18 @@ def get_social_uow(
     return SQLAlchemySocialUnitOfWork(session)
 
 
+def get_social_email_service() -> ISocialEmailService:
+    """Proveedor del servicio de email para el modulo Social (amistades)."""
+    return EmailService()
+
+
 def get_send_friend_request_use_case(
     uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    email_service: ISocialEmailService = Depends(get_social_email_service),
 ) -> SendFriendRequestUseCase:
     """Proveedor del caso de uso SendFriendRequestUseCase."""
-    return SendFriendRequestUseCase(uow, user_uow)
+    return SendFriendRequestUseCase(uow, user_uow, email_service)
 
 
 def get_respond_friend_request_use_case(

--- a/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
@@ -31,18 +31,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
 
 logger = logging.getLogger(__name__)
-
-
-def _mask_email(email: str) -> str:
-    """Enmascara un email para logging seguro (ej: t***@example.com)."""
-    parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
-        return "***"
-    local = parts[0]
-    masked_local = local[0] + "***" if len(local) > 1 else "***"
-    return f"{masked_local}@{parts[1]}"
 
 
 class SendInvitationByEmailUseCase:

--- a/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
@@ -31,18 +31,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
 
 logger = logging.getLogger(__name__)
-
-
-def _mask_email(email: str) -> str:
-    """Enmascara un email para logging seguro (ej: t***@example.com)."""
-    parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
-        return "***"
-    local = parts[0]
-    masked_local = local[0] + "***" if len(local) > 1 else "***"
-    return f"{masked_local}@{parts[1]}"
 
 
 class SendInvitationByUserIdUseCase:

--- a/src/modules/social/application/ports/social_email_service_interface.py
+++ b/src/modules/social/application/ports/social_email_service_interface.py
@@ -1,0 +1,38 @@
+"""
+Social Email Service Interface - Application Layer Port
+
+Define el contrato para envio de emails relacionados con el modulo Social
+(amistades). Vive en el Social module (Interface Segregation Principle).
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ISocialEmailService(ABC):
+    """
+    Puerto para envio de emails relacionados con amistades.
+
+    Separado de IEmailService (User module) e IInvitationEmailService
+    (Competition module) para respetar ISP. La implementacion concreta
+    (EmailService) puede implementar las tres interfaces.
+    """
+
+    @abstractmethod
+    async def send_friend_request_email(
+        self,
+        to_email: str,
+        addressee_name: str,
+        requester_name: str,
+    ) -> bool:
+        """
+        Envia un email notificando una nueva solicitud de amistad.
+
+        Args:
+            to_email: Email del destinatario de la solicitud
+            addressee_name: Nombre del destinatario de la solicitud
+            requester_name: Nombre de quien envia la solicitud
+
+        Returns:
+            True si se envio correctamente, False en caso contrario
+        """
+        pass

--- a/src/modules/social/application/use_cases/send_friend_request_use_case.py
+++ b/src/modules/social/application/use_cases/send_friend_request_use_case.py
@@ -1,10 +1,15 @@
 """Caso de Uso: Enviar una Solicitud de Amistad."""
 
+import logging
+
 from src.modules.social.application.dto.friendship_dto import (
     FriendshipResponseDTO,
     SendFriendRequestRequestDTO,
 )
 from src.modules.social.application.exceptions import AddresseeNotFoundError
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.social.domain.entities.friendship import Friendship
 from src.modules.social.domain.exceptions.social_violations import (
     BlockedUserViolation,
@@ -19,6 +24,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
+
+logger = logging.getLogger(__name__)
 
 
 class SendFriendRequestUseCase:
@@ -28,9 +36,11 @@ class SendFriendRequestUseCase:
         self,
         uow: SocialUnitOfWorkInterface,
         user_uow: UserUnitOfWorkInterface,
+        email_service: ISocialEmailService | None = None,
     ):
         self._uow = uow
         self._user_uow = user_uow
+        self._email_service = email_service
 
     async def execute(self, request: SendFriendRequestRequestDTO) -> FriendshipResponseDTO:
         requester_id = UserId(request.requester_id)
@@ -82,6 +92,22 @@ class SendFriendRequestUseCase:
             addressee_name = (
                 f"{addressee.first_name} {addressee.last_name}" if addressee else "Unknown"
             )
+
+        # Enviar email de notificacion (fuera de la transaccion, no bloquea la creacion)
+        if self._email_service and addressee and addressee.email:
+            addressee_email = str(addressee.email)
+            try:
+                await self._email_service.send_friend_request_email(
+                    to_email=addressee_email,
+                    addressee_name=addressee_name,
+                    requester_name=requester_name,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to send friend request email to %s: %s",
+                    _mask_email(addressee_email),
+                    str(e),
+                )
 
         return FriendshipResponseDTO(
             id=friendship.id.value,

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -4,6 +4,7 @@ Email Service - Infrastructure Layer
 Servicio para enviar emails usando Mailgun.
 """
 
+import asyncio
 import html
 import logging
 from datetime import datetime
@@ -370,7 +371,7 @@ The Ryder Cup Friends Team
 </html>
         """
 
-        return self._send_email(to_email, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, to_email, subject, text_body, html_body)
 
     async def send_password_changed_notification(self, to_email: str, user_name: str) -> bool:
         """
@@ -524,7 +525,7 @@ The Ryder Cup Friends Team
 </html>
         """
 
-        return self._send_email(to_email, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, to_email, subject, text_body, html_body)
 
     def _sanitize_name(self, name: str) -> str:
         """Sanitiza un nombre para prevenir inyeccion de headers (RFC 5322)."""
@@ -742,7 +743,7 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_invitee}" <{to_email}>' if safe_invitee else to_email
-        return self._send_email(recipient, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, recipient, subject, text_body, html_body)
 
     async def send_friend_request_email(
         self,
@@ -875,4 +876,4 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_addressee}" <{to_email}>'
-        return self._send_email(recipient, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, recipient, subject, text_body, html_body)

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -15,12 +15,15 @@ from src.config.settings import settings
 from src.modules.competition.application.ports.invitation_email_service_interface import (
     IInvitationEmailService,
 )
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.user.application.ports.email_service_interface import IEmailService
 
 logger = logging.getLogger(__name__)
 
 
-class EmailService(IEmailService, IInvitationEmailService):
+class EmailService(IEmailService, IInvitationEmailService, ISocialEmailService):
     """
     Implementación de IEmailService usando Mailgun.
 
@@ -739,4 +742,137 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_invitee}" <{to_email}>' if safe_invitee else to_email
+        return self._send_email(recipient, subject, text_body, html_body)
+
+    async def send_friend_request_email(
+        self,
+        to_email: str,
+        addressee_name: str,
+        requester_name: str,
+    ) -> bool:
+        """
+        Envia un email notificando una nueva solicitud de amistad.
+
+        Template bilingue (ES/EN) con diseno consistente con send_invitation_email.
+        """
+        safe_addressee = self._sanitize_name(addressee_name)
+        safe_requester = self._sanitize_name(requester_name)
+        html_addressee = html.escape(safe_addressee)
+        html_requester = html.escape(safe_requester)
+
+        friends_link = f"{settings.FRONTEND_URL}/friends"
+
+        subject = (
+            f"{safe_requester} quiere ser tu amigo | {safe_requester} wants to be your friend"
+        )
+
+        text_body = f"""
+Hola {safe_addressee},
+
+{safe_requester} te ha enviado una solicitud de amistad en Ryder Cup Friends.
+
+Para aceptarla o rechazarla, visita: {friends_link}
+
+Saludos,
+El equipo de Ryder Cup Friends
+
+---
+
+Hello {safe_addressee},
+
+{safe_requester} has sent you a friend request on Ryder Cup Friends.
+
+To accept or decline it, visit: {friends_link}
+
+Best regards,
+The Ryder Cup Friends Team
+        """
+
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }}
+        .container {{
+            background-color: #f9f9f9;
+            border-radius: 10px;
+            padding: 30px;
+        }}
+        .header {{
+            background-color: #0066cc;
+            color: white;
+            padding: 20px;
+            border-radius: 10px 10px 0 0;
+            text-align: center;
+        }}
+        .content {{
+            background-color: white;
+            padding: 30px;
+            border-radius: 0 0 10px 10px;
+        }}
+        .button {{
+            display: inline-block;
+            padding: 15px 30px;
+            background-color: #0066cc;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 20px 0;
+            font-weight: bold;
+        }}
+        .footer {{
+            margin-top: 30px;
+            font-size: 12px;
+            color: #666;
+            border-top: 1px solid #ddd;
+            padding-top: 20px;
+        }}
+        .divider {{
+            border-top: 2px solid #ddd;
+            margin: 30px 0;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Nueva Solicitud de Amistad</h1>
+            <h2>New Friend Request</h2>
+        </div>
+        <div class="content">
+            <!-- Spanish -->
+            <p>Hola <strong>{html_addressee}</strong>,</p>
+            <p><strong>{html_requester}</strong> te ha enviado una solicitud de amistad en Ryder Cup Friends.</p>
+            <center>
+                <a href="{friends_link}" class="button">Ver solicitud</a>
+            </center>
+
+            <div class="divider"></div>
+
+            <!-- English -->
+            <p>Hello <strong>{html_addressee}</strong>,</p>
+            <p><strong>{html_requester}</strong> has sent you a friend request on Ryder Cup Friends.</p>
+            <center>
+                <a href="{friends_link}" class="button">View request</a>
+            </center>
+
+            <div class="footer">
+                <p>Saludos | Best regards,<br>
+                <strong>El equipo de Ryder Cup Friends | The Ryder Cup Friends Team</strong></p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        recipient = f'"{safe_addressee}" <{to_email}>'
         return self._send_email(recipient, subject, text_body, html_body)

--- a/src/shared/infrastructure/security/email_masking.py
+++ b/src/shared/infrastructure/security/email_masking.py
@@ -1,0 +1,11 @@
+"""Utilidad compartida para enmascarar emails en logs de seguridad."""
+
+
+def mask_email(email: str) -> str:
+    """Enmascara un email para logging seguro (ej: t***@example.com)."""
+    parts = email.split("@")
+    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
+        return "***"
+    local = parts[0]
+    masked_local = local[0] + "***" if len(local) > 1 else "***"
+    return f"{masked_local}@{parts[1]}"

--- a/src/shared/infrastructure/security/email_masking.py
+++ b/src/shared/infrastructure/security/email_masking.py
@@ -4,7 +4,7 @@
 def mask_email(email: str) -> str:
     """Enmascara un email para logging seguro (ej: t***@example.com)."""
     parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
+    if len(parts) != 2 or not parts[0] or not parts[1]:  # noqa: PLR2004
         return "***"
     local = parts[0]
     masked_local = local[0] + "***" if len(local) > 1 else "***"

--- a/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
@@ -1,5 +1,7 @@
 """Tests para SendFriendRequestUseCase."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from src.modules.social.application.dto.friendship_dto import SendFriendRequestRequestDTO
@@ -133,3 +135,56 @@ class TestSendFriendRequestUseCase:
 
         assert response.status == "PENDING"
         assert response.id != declined.id.value
+
+    async def test_should_call_email_service_on_success(self, uow, user_uow):
+        """Email service se llama con los parametros correctos al enviar la solicitud."""
+        requester = await self._create_user(user_uow, "requester6@test.com")
+        addressee = await self._create_user(user_uow, "addressee6@test.com")
+
+        mock_email = AsyncMock()
+        mock_email.send_friend_request_email = AsyncMock(return_value=True)
+
+        use_case = SendFriendRequestUseCase(uow, user_uow, email_service=mock_email)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"
+        mock_email.send_friend_request_email.assert_called_once()
+        call_kwargs = mock_email.send_friend_request_email.call_args[1]
+        assert call_kwargs["to_email"] == "addressee6@test.com"
+        assert call_kwargs["addressee_name"] == "Test User"
+        assert call_kwargs["requester_name"] == "Test User"
+
+    async def test_should_create_friendship_even_if_email_fails(self, uow, user_uow):
+        """La solicitud se crea aunque el envio del email falle."""
+        requester = await self._create_user(user_uow, "requester7@test.com")
+        addressee = await self._create_user(user_uow, "addressee7@test.com")
+
+        mock_email = AsyncMock()
+        mock_email.send_friend_request_email = AsyncMock(side_effect=Exception("SMTP error"))
+
+        use_case = SendFriendRequestUseCase(uow, user_uow, email_service=mock_email)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"
+
+    async def test_no_email_sent_when_email_service_not_provided(self, uow, user_uow):
+        """Sin email_service inyectado (default None), no debe intentarse enviar nada."""
+        requester = await self._create_user(user_uow, "requester8@test.com")
+        addressee = await self._create_user(user_uow, "addressee8@test.com")
+
+        use_case = SendFriendRequestUseCase(uow, user_uow)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"

--- a/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
@@ -152,7 +152,7 @@ class TestSendFriendRequestUseCase:
         )
 
         assert response.status == "PENDING"
-        mock_email.send_friend_request_email.assert_called_once()
+        mock_email.send_friend_request_email.assert_awaited_once()
         call_kwargs = mock_email.send_friend_request_email.call_args[1]
         assert call_kwargs["to_email"] == "addressee6@test.com"
         assert call_kwargs["addressee_name"] == "Test User"

--- a/tests/unit/shared/infrastructure/security/test_email_masking.py
+++ b/tests/unit/shared/infrastructure/security/test_email_masking.py
@@ -1,0 +1,20 @@
+"""Tests para la utilidad compartida mask_email."""
+
+from src.shared.infrastructure.security.email_masking import mask_email
+
+
+class TestMaskEmail:
+    def test_masks_local_part_keeping_first_char(self):
+        assert mask_email("test@example.com") == "t***@example.com"
+
+    def test_single_char_local_part_fully_masked(self):
+        assert mask_email("a@test.com") == "***@test.com"
+
+    def test_no_at_sign_returns_fully_masked(self):
+        assert mask_email("not-an-email") == "***"
+
+    def test_multiple_at_signs_returns_fully_masked(self):
+        assert mask_email("a@b@c.com") == "***"
+
+    def test_empty_local_part_returns_fully_masked(self):
+        assert mask_email("@example.com") == "***"

--- a/tests/unit/shared/infrastructure/security/test_email_masking.py
+++ b/tests/unit/shared/infrastructure/security/test_email_masking.py
@@ -18,3 +18,6 @@ class TestMaskEmail:
 
     def test_empty_local_part_returns_fully_masked(self):
         assert mask_email("@example.com") == "***"
+
+    def test_empty_domain_part_returns_fully_masked(self):
+        assert mask_email("alice@") == "***"


### PR DESCRIPTION
## Summary
- New `ISocialEmailService` port (`src/modules/social/application/ports/`) + `EmailService.send_friend_request_email` (Mailgun adapter), following the exact same pattern as competition invitations (`IInvitationEmailService`).
- `SendFriendRequestUseCase` sends the notification email to the addressee right after the friendship is persisted — outside the transaction, guarded and non-blocking (a Mailgun failure never prevents the friend request from being created, same as invitations).
- Extracted `mask_email()` to `src/shared/infrastructure/security/email_masking.py`, replacing 3 copies across Competition (x2, identical) and Social (new, previously diverging) use cases — trivial, design-free helper, unlike the per-email HTML/CSS templates which stay duplicated per method (existing convention in `email_service.py`; extracting those is a separate, bigger refactor).

## Test plan
- [x] New unit tests for `SendFriendRequestUseCase`: email called with correct params on success, friendship still created if email send fails, no email attempted when service not injected
- [x] New unit tests for shared `mask_email()`
- [x] `pytest tests/unit/` — 2285 passed
- [x] `ruff check` + `mypy` clean on touched files
- [ ] Integration tests for friend endpoints — could not run locally (local Kind cluster/Postgres port-forward unavailable this session); CI spins its own Postgres and will cover this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Friend requests now trigger bilingual email notifications with a link to manage friendships.
  - Friend-request creation completes even if email delivery fails.

- **Security**
  - Email addresses are masked consistently in logs.
  - Notification content safely handles names and email data.

- **Tests**
  - Added coverage for successful and failed notifications, missing email services, and email masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->