### PR TITLE
feat(admin): Add admin panel backend — user management and platform stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `PUT /admin/users/{id}`: editar nombre, email, hándicap, país y rol de administrador.
   - `PUT /admin/users/{id}/active`: desactivar/reactivar una cuenta (bloquea el login, reversible, no toca ningún dato).
   - `DELETE /admin/users/{id}`: borrado definitivo, bloqueado (409) si la cuenta ha creado torneos/partidas rápidas, solicitado campos de golf, o tiene scores registrados — evita borrar en cascada datos de otros usuarios o romper una restricción de base de datos.
+  - Un admin no puede desactivar (400) ni borrar (400) su propia cuenta, evitando quedarse sin acceso al panel si es el único administrador.
   - Nuevo campo `User.is_active` (migración `f3a9c2e7b1d4`), con eventos de dominio `AccountDeactivatedEvent`/`AccountReactivatedEvent`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Email de notificación al enviar una solicitud de amistad (`ISocialEmailService`/`send_friend_request_email`), siguiendo el mismo patrón que las invitaciones a competición. Envío no bloqueante: un fallo de Mailgun no impide crear la solicitud.
+- **Panel de administración — gestión de usuarios y estadísticas** (issue FE #233, mitad backend): nuevos endpoints `/api/v1/admin/*` (solo Admin, vía `require_admin()`):
+  - `GET /admin/stats`: usuarios registrados, torneos creados, partidas rápidas y campos de golf (aprobados/pendientes).
+  - `GET /admin/users`: listado paginado con búsqueda (nombre/apellidos/email) y filtros por rol, estado y verificación.
+  - `PUT /admin/users/{id}`: editar nombre, email, hándicap, país y rol de administrador.
+  - `PUT /admin/users/{id}/active`: desactivar/reactivar una cuenta (bloquea el login, reversible, no toca ningún dato).
+  - `DELETE /admin/users/{id}`: borrado definitivo, bloqueado (409) si la cuenta ha creado torneos/partidas rápidas, solicitado campos de golf, o tiene scores registrados — evita borrar en cascada datos de otros usuarios o romper una restricción de base de datos.
+  - Nuevo campo `User.is_active` (migración `f3a9c2e7b1d4`), con eventos de dominio `AccountDeactivatedEvent`/`AccountReactivatedEvent`.
 
 ### Changed
 

--- a/alembic/versions/f3a9c2e7b1d4_add_is_active_field_to_users_table.py
+++ b/alembic/versions/f3a9c2e7b1d4_add_is_active_field_to_users_table.py
@@ -1,0 +1,56 @@
+"""add is_active field to users table
+
+Revision ID: f3a9c2e7b1d4
+Revises: 5e13a3225101
+Create Date: 2026-08-02 10:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'f3a9c2e7b1d4'
+down_revision: str | None = '5e13a3225101'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Añade campo is_active a la tabla users para el panel de administración.
+
+    Campo añadido:
+    - is_active: Flag booleano que indica si la cuenta está activa. Un admin
+      puede desactivar una cuenta (bloquea login, conserva todos los datos)
+      desde el panel de administración.
+
+    Default: TRUE (todos los usuarios existentes quedan activos).
+    """
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+            comment="Cuenta activa (FALSE si un admin la desactivó desde el panel)",
+        ),
+    )
+
+    # Partial index: solo indexar cuentas desactivadas (caso poco frecuente)
+    # para acelerar el listado "usuarios desactivados" en el panel de admin.
+    op.create_index(
+        "ix_users_is_active_false",
+        "users",
+        ["is_active"],
+        postgresql_where=sa.text("is_active = FALSE"),
+    )
+
+
+def downgrade() -> None:
+    """Elimina el campo is_active de la tabla users."""
+    op.drop_index("ix_users_is_active_false", table_name="users")
+    op.drop_column("users", "is_active")

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ from src.modules.user.application.use_cases.upload_avatar_use_case import (  # n
     MAX_UPLOAD_BYTES,
 )
 from src.modules.user.infrastructure.api.v1 import (  # noqa: E402
+    admin_routes,
     auth_routes,
     avatar_routes,
     device_routes,
@@ -344,6 +345,12 @@ app.include_router(
     user_routes.router,
     prefix="/api/v1/users",
     tags=["Users"],
+)
+
+app.include_router(
+    admin_routes.router,
+    prefix="/api/v1/admin",
+    tags=["Admin"],
 )
 
 app.include_router(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -284,7 +284,22 @@ from src.modules.user.application.ports.token_service_interface import ITokenSer
 from src.modules.user.application.use_cases.activate_uploaded_avatar_use_case import (
     ActivateUploadedAvatarUseCase,
 )
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
 from src.modules.user.application.use_cases.find_user_use_case import FindUserUseCase
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
 from src.modules.user.application.use_cases.get_avatar_image_use_case import (
     GetAvatarImageUseCase,
 )
@@ -1133,6 +1148,52 @@ def get_quick_match_uow(
     3. Devuelve la instancia, cumpliendo con la interfaz `QuickMatchUnitOfWorkInterface`.
     """
     return SQLAlchemyQuickMatchUnitOfWork(session)
+
+
+# ======================================================================================
+# ADMIN PANEL USE CASE PROVIDERS
+# ======================================================================================
+
+
+def get_admin_list_users_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminListUsersUseCase:
+    """Proveedor del caso de uso AdminListUsersUseCase."""
+    return AdminListUsersUseCase(uow)
+
+
+def get_admin_update_user_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminUpdateUserUseCase:
+    """Proveedor del caso de uso AdminUpdateUserUseCase."""
+    return AdminUpdateUserUseCase(uow)
+
+
+def get_admin_set_user_active_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminSetUserActiveUseCase:
+    """Proveedor del caso de uso AdminSetUserActiveUseCase."""
+    return AdminSetUserActiveUseCase(uow)
+
+
+def get_admin_delete_user_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> AdminDeleteUserUseCase:
+    """Proveedor del caso de uso AdminDeleteUserUseCase."""
+    return AdminDeleteUserUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+
+def get_get_admin_stats_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> GetAdminStatsUseCase:
+    """Proveedor del caso de uso GetAdminStatsUseCase."""
+    return GetAdminStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
 
 
 def get_create_quick_match_use_case(

--- a/src/modules/competition/domain/repositories/competition_repository_interface.py
+++ b/src/modules/competition/domain/repositories/competition_repository_interface.py
@@ -209,6 +209,21 @@ class CompetitionRepositoryInterface(ABC):
         pass
 
     @abstractmethod
+    async def count_all(self) -> int:
+        """
+        Cuenta el total de competiciones en el sistema.
+
+        Útil para: Estadísticas del panel de administración.
+
+        Returns:
+            int: Número total de competiciones
+
+        Raises:
+            RepositoryError: Si ocurre un error de consulta
+        """
+        pass
+
+    @abstractmethod
     async def count_by_creator(self, creator_id: UserId) -> int:
         """
         Cuenta el total de competiciones creadas por un usuario.

--- a/src/modules/competition/domain/repositories/hole_score_repository_interface.py
+++ b/src/modules/competition/domain/repositories/hole_score_repository_interface.py
@@ -54,3 +54,14 @@ class HoleScoreRepositoryInterface(ABC):
     async def delete_by_match(self, match_id: MatchId) -> int:
         """Elimina todos los hole scores de un partido. Retorna la cantidad eliminada."""
         pass
+
+    @abstractmethod
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        """
+        True si el jugador tiene algun hole score registrado (en cualquier partido).
+
+        Util para bloquear el borrado definitivo de una cuenta: hole_scores.player_user_id
+        no tiene ON DELETE definido (RESTRICT por defecto en Postgres), asi que borrar a
+        un jugador con historial de scores fallaria con un IntegrityError si no se bloquea antes.
+        """
+        pass

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_competition_repository.py
@@ -88,6 +88,10 @@ class InMemoryCompetitionRepository(CompetitionRepositoryInterface):
         """Retorna todas las competiciones."""
         return list(self._competitions.values())
 
+    async def count_all(self) -> int:
+        """Cuenta el total de competiciones en el sistema."""
+        return len(self._competitions)
+
     async def count_by_creator(self, creator_id: UserId) -> int:
         """Cuenta el total de competiciones creadas por un usuario."""
         return sum(1 for comp in self._competitions.values() if comp.creator_id == creator_id)

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_hole_score_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_hole_score_repository.py
@@ -62,3 +62,6 @@ class InMemoryHoleScoreRepository(HoleScoreRepositoryInterface):
         for hs_id in to_delete:
             del self._scores[hs_id]
         return len(to_delete)
+
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        return any(hs.player_user_id == player_user_id for hs in self._scores.values())

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -268,6 +268,12 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
         result = await self._session.execute(statement)
         return list(result.scalars().all())
 
+    async def count_all(self) -> int:
+        """Cuenta el total de competiciones en el sistema."""
+        statement = select(func.count()).select_from(Competition)
+        result = await self._session.execute(statement)
+        return result.scalar_one()
+
     async def count_by_creator(self, creator_id: UserId) -> int:
         """
         Cuenta el total de competiciones creadas por un usuario.

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
@@ -1,6 +1,6 @@
 """HoleScore Repository - SQLAlchemy Implementation."""
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.competition.domain.entities.hole_score import HoleScore
 from src.modules.competition.domain.repositories.hole_score_repository_interface import (
@@ -71,3 +71,12 @@ class SQLAlchemyHoleScoreRepository(HoleScoreRepositoryInterface):
         statement = delete(HoleScore).where(HoleScore._match_id == match_id)
         result = await self._session.execute(statement)
         return result.rowcount
+
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        statement = (
+            select(func.count())
+            .select_from(HoleScore)
+            .where(HoleScore._player_user_id == player_user_id)
+        )
+        result = await self._session.execute(statement)
+        return result.scalar_one() > 0

--- a/src/modules/golf_course/domain/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/domain/repositories/golf_course_repository.py
@@ -91,6 +91,32 @@ class IGolfCourseRepository(ABC):
         pass
 
     @abstractmethod
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos de golf por estado de aprobación, sin materializarlos.
+
+        Args:
+            approval_status: Estado a contar (PENDING_APPROVAL, APPROVED, REJECTED)
+
+        Returns:
+            Número de campos con ese estado
+        """
+        pass
+
+    @abstractmethod
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico, sin materializarlos.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        pass
+
+    @abstractmethod
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """
         Elimina un campo de golf (hard delete).

--- a/src/modules/golf_course/infrastructure/persistence/in_memory/in_memory_golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/in_memory/in_memory_golf_course_repository.py
@@ -97,6 +97,30 @@ class InMemoryGolfCourseRepository(IGolfCourseRepository):
         """
         return [gc for gc in self._golf_courses.values() if gc.requested_by == creator_id]
 
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos por estado de aprobación.
+
+        Args:
+            approval_status: Estado a contar
+
+        Returns:
+            Número de campos con ese estado
+        """
+        return len(await self.find_by_approval_status(approval_status))
+
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        return len(await self.find_by_creator(creator_id))
+
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """
         Elimina un campo de golf (hard delete).

--- a/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
@@ -2,7 +2,7 @@
 GolfCourseRepository - Implementación SQLAlchemy del repositorio de campos de golf.
 """
 
-from sqlalchemy import delete, inspect, select
+from sqlalchemy import delete, func, inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -183,6 +183,42 @@ class GolfCourseRepository(IGolfCourseRepository):
         result = await self._session.execute(stmt)
         result = result.unique()
         return list(result.scalars().all())
+
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos de golf por estado de aprobación, sin materializarlos.
+
+        Args:
+            approval_status: Estado a contar (PENDING_APPROVAL, APPROVED, REJECTED)
+
+        Returns:
+            Número de campos con ese estado
+        """
+        stmt = (
+            select(func.count())
+            .select_from(golf_courses_table)
+            .where(golf_courses_table.c.approval_status == approval_status)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
+
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico, sin materializarlos.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        stmt = (
+            select(func.count())
+            .select_from(golf_courses_table)
+            .where(golf_courses_table.c.creator_id == creator_id)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
 
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """

--- a/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
+++ b/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
@@ -52,3 +52,19 @@ class QuickMatchRepositoryInterface(ABC):
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
         pass
+
+    @abstractmethod
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema (estadisticas de admin)."""
+        pass
+
+    @abstractmethod
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """
+        True si el usuario ha creado alguna partida rapida.
+
+        Util para bloquear el borrado definitivo de una cuenta: quick_matches.creator_id
+        tiene ON DELETE CASCADE, asi que borrar al creador borraria la partida entera
+        (incluyendo a otros participantes) si no se bloquea antes.
+        """
+        pass

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -52,3 +52,11 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
             for qm in self._quick_matches.values()
             if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
         )
+
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema."""
+        return len(self._quick_matches)
+
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """True si el usuario ha creado alguna partida rapida."""
+        return any(qm.creator_id == creator_id for qm in self._quick_matches.values())

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -79,3 +79,19 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
         stmt = select(func.count()).select_from(QuickMatch).where(and_(*conditions))
         result = await self._session.execute(stmt)
         return result.scalar() or 0
+
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema."""
+        stmt = select(func.count()).select_from(QuickMatch)
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0
+
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """True si el usuario ha creado alguna partida rapida."""
+        stmt = (
+            select(func.count())
+            .select_from(QuickMatch)
+            .where(QuickMatch._creator_id == creator_id)
+        )
+        result = await self._session.execute(stmt)
+        return (result.scalar() or 0) > 0

--- a/src/modules/user/application/dto/admin_dto.py
+++ b/src/modules/user/application/dto/admin_dto.py
@@ -1,0 +1,79 @@
+"""DTOs para el panel de administración (gestión de usuarios y estadísticas)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class AdminListUsersRequestDTO(BaseModel):
+    """DTO de entrada para listar usuarios (admin)."""
+
+    search: str | None = Field(
+        default=None, description="Filtro por nombre, apellidos o email (opcional)."
+    )
+    is_admin: bool | None = Field(
+        default=None, description="Filtra por rol: True=admins, False=jugadores."
+    )
+    is_active: bool | None = Field(
+        default=None, description="Filtra por estado: True=activas, False=desactivadas."
+    )
+    email_verified: bool | None = Field(
+        default=None, description="Filtra por verificación de email."
+    )
+    limit: int = Field(default=20, ge=1, le=100, description="Tamaño de página.")
+    offset: int = Field(default=0, ge=0, description="Desplazamiento de paginación.")
+
+
+class AdminUserSummaryDTO(BaseModel):
+    """Fila de la tabla de usuarios del panel de administración."""
+
+    id: UUID
+    first_name: str
+    last_name: str
+    email: EmailStr
+    handicap: float | None = None
+    is_admin: bool
+    is_active: bool
+    email_verified: bool
+    created_at: datetime
+
+
+class AdminListUsersResponseDTO(BaseModel):
+    """Respuesta paginada del listado de usuarios."""
+
+    users: list[AdminUserSummaryDTO]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class AdminUpdateUserRequestDTO(BaseModel):
+    """
+    DTO de entrada para editar un usuario desde el panel de administración.
+
+    Todos los campos son opcionales: solo se actualizan los que vengan informados.
+    """
+
+    first_name: str | None = None
+    last_name: str | None = None
+    email: EmailStr | None = None
+    handicap: float | None = None
+    country_code: str | None = None
+    is_admin: bool | None = None
+
+
+class AdminSetUserActiveRequestDTO(BaseModel):
+    """DTO de entrada para (des)activar una cuenta."""
+
+    is_active: bool = Field(..., description="True para reactivar, False para desactivar.")
+
+
+class AdminStatsResponseDTO(BaseModel):
+    """Estadísticas globales de la plataforma para el panel de administración."""
+
+    total_users: int
+    total_competitions: int
+    total_quick_matches: int
+    total_golf_courses_approved: int
+    total_golf_courses_pending: int

--- a/src/modules/user/application/use_cases/admin_delete_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_delete_user_use_case.py
@@ -79,8 +79,10 @@ class AdminDeleteUserUseCase:
                 reasons.append("has created one or more quick matches")
 
         async with self._golf_course_uow:
-            golf_courses = await self._golf_course_uow.golf_courses.find_by_creator(user_id)
-            if golf_courses:
-                reasons.append(f"has requested {len(golf_courses)} golf course(s)")
+            golf_courses_requested = await self._golf_course_uow.golf_courses.count_by_creator(
+                user_id
+            )
+            if golf_courses_requested > 0:
+                reasons.append(f"has requested {golf_courses_requested} golf course(s)")
 
         return reasons

--- a/src/modules/user/application/use_cases/admin_delete_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_delete_user_use_case.py
@@ -1,0 +1,86 @@
+"""Caso de Uso: Borrado definitivo de una cuenta de usuario (panel de administración)."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminDeleteUserUseCase:
+    """
+    Borra definitivamente la cuenta de un usuario (solo Admin).
+
+    Bloquea el borrado si la cuenta tiene actividad de la que dependen otros
+    usuarios o que rompería una restriccion de la base de datos:
+    - Ha creado alguna competicion (competitions.creator_id es ON DELETE CASCADE:
+      borraria el torneo entero para todos sus participantes).
+    - Ha creado alguna partida rapida (mismo motivo, quick_matches.creator_id CASCADE).
+    - Ha solicitado algun campo de golf (golf_courses.creator_id sin ON DELETE: fallaria).
+    - Tiene algun hole score registrado (hole_scores.player_user_id sin ON DELETE: fallaria).
+
+    En esos casos, el panel de administracion debe ofrecer "Desactivar" en su lugar
+    (ver AdminSetUserActiveUseCase).
+    """
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+
+    async def execute(self, user_id_str: str) -> None:
+        user_id = UserId(user_id_str)
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+        reasons = await self._collect_activity_reasons(user_id)
+        if reasons:
+            raise UserHasActivityException(reasons)
+
+        async with self._user_uow:
+            await self._user_uow.users.delete_by_id(user_id)
+
+    async def _collect_activity_reasons(self, user_id: UserId) -> list[str]:
+        reasons: list[str] = []
+
+        async with self._competition_uow:
+            competitions_created = await self._competition_uow.competitions.count_by_creator(
+                user_id
+            )
+            if competitions_created > 0:
+                reasons.append(f"has created {competitions_created} competition(s)")
+
+            has_scores = await self._competition_uow.hole_scores.exists_by_player(user_id)
+            if has_scores:
+                reasons.append("has recorded hole scores in one or more matches")
+
+        async with self._quick_match_uow:
+            if await self._quick_match_uow.quick_matches.exists_created_by(user_id):
+                reasons.append("has created one or more quick matches")
+
+        async with self._golf_course_uow:
+            golf_courses = await self._golf_course_uow.golf_courses.find_by_creator(user_id)
+            if golf_courses:
+                reasons.append(f"has requested {len(golf_courses)} golf course(s)")
+
+        return reasons

--- a/src/modules/user/application/use_cases/admin_list_users_use_case.py
+++ b/src/modules/user/application/use_cases/admin_list_users_use_case.py
@@ -1,0 +1,54 @@
+"""Caso de Uso: Listar usuarios (panel de administración)."""
+
+from src.modules.user.application.dto.admin_dto import (
+    AdminListUsersRequestDTO,
+    AdminListUsersResponseDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+
+
+class AdminListUsersUseCase:
+    """Lista usuarios paginados, opcionalmente filtrados por búsqueda (solo Admin)."""
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(self, request: AdminListUsersRequestDTO) -> AdminListUsersResponseDTO:
+        async with self._uow:
+            users = await self._uow.users.find_all(
+                limit=request.limit,
+                offset=request.offset,
+                search=request.search,
+                is_admin=request.is_admin,
+                is_active=request.is_active,
+                email_verified=request.email_verified,
+            )
+            total_count = await self._uow.users.count_all(
+                search=request.search,
+                is_admin=request.is_admin,
+                is_active=request.is_active,
+                email_verified=request.email_verified,
+            )
+
+        return AdminListUsersResponseDTO(
+            users=[
+                AdminUserSummaryDTO(
+                    id=user.id.value,
+                    first_name=user.first_name,
+                    last_name=user.last_name,
+                    email=str(user.email),
+                    handicap=float(user.handicap) if user.handicap is not None else None,
+                    is_admin=user.is_admin,
+                    is_active=user.is_active,
+                    email_verified=user.email_verified,
+                    created_at=user.created_at,
+                )
+                for user in users
+            ],
+            total_count=total_count,
+            limit=request.limit,
+            offset=request.offset,
+        )

--- a/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
+++ b/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
@@ -19,6 +19,9 @@ class AdminSetUserActiveUseCase:
         self._uow = uow
 
     async def execute(self, user_id_str: str, is_active: bool, actor_user_id: str) -> None:
+        if not is_active and user_id_str == actor_user_id:
+            raise ValueError("Admins cannot deactivate their own account")
+
         user_id = UserId(user_id_str)
 
         async with self._uow:

--- a/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
+++ b/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
@@ -1,0 +1,35 @@
+"""Caso de Uso: (Des)activar una cuenta de usuario (panel de administración)."""
+
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminSetUserActiveUseCase:
+    """
+    Desactiva o reactiva la cuenta de un usuario (solo Admin).
+
+    Una cuenta desactivada no puede iniciar sesión pero conserva todos sus
+    datos (torneos, partidas, amistades) intactos — acción reversible.
+    """
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(self, user_id_str: str, is_active: bool, actor_user_id: str) -> None:
+        user_id = UserId(user_id_str)
+
+        async with self._uow:
+            user = await self._uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+            if is_active:
+                if not user.is_active:
+                    user.reactivate(reactivated_by_user_id=actor_user_id)
+            elif user.is_active:
+                user.deactivate(deactivated_by_user_id=actor_user_id)
+
+            await self._uow.users.save(user)

--- a/src/modules/user/application/use_cases/admin_update_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_update_user_use_case.py
@@ -1,0 +1,67 @@
+"""Caso de Uso: Editar un usuario (panel de administración)."""
+
+from src.modules.user.application.dto.admin_dto import (
+    AdminUpdateUserRequestDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.email import Email
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminUpdateUserUseCase:
+    """Edita los datos de un usuario desde el panel de administración (solo Admin)."""
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(
+        self, user_id_str: str, request: AdminUpdateUserRequestDTO
+    ) -> AdminUserSummaryDTO:
+        user_id = UserId(user_id_str)
+
+        async with self._uow:
+            user = await self._uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+            if (
+                request.first_name is not None
+                or request.last_name is not None
+                or request.country_code is not None
+            ):
+                user.update_profile(
+                    first_name=request.first_name,
+                    last_name=request.last_name,
+                    country_code_str=request.country_code,
+                )
+
+            if request.email is not None and str(request.email) != str(user.email):
+                new_email_str = str(request.email)
+                existing = await self._uow.users.find_by_email(Email(new_email_str))
+                if existing and existing.id != user.id:
+                    raise DuplicateEmailError(f"Email {new_email_str} is already in use")
+                user.change_email(new_email_str)
+
+            if request.handicap is not None:
+                user.update_handicap(request.handicap)
+
+            if request.is_admin is not None and request.is_admin != user.is_admin:
+                user.set_is_admin(request.is_admin)
+
+            await self._uow.users.save(user)
+
+        return AdminUserSummaryDTO(
+            id=user.id.value,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=str(user.email),
+            handicap=float(user.handicap) if user.handicap is not None else None,
+            is_admin=user.is_admin,
+            is_active=user.is_active,
+            email_verified=user.email_verified,
+            created_at=user.created_at,
+        )

--- a/src/modules/user/application/use_cases/get_admin_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_admin_stats_use_case.py
@@ -42,10 +42,10 @@ class GetAdminStatsUseCase:
             total_quick_matches = await self._quick_match_uow.quick_matches.count_all()
 
         async with self._golf_course_uow:
-            approved = await self._golf_course_uow.golf_courses.find_by_approval_status(
+            approved_count = await self._golf_course_uow.golf_courses.count_by_approval_status(
                 ApprovalStatus.APPROVED
             )
-            pending = await self._golf_course_uow.golf_courses.find_by_approval_status(
+            pending_count = await self._golf_course_uow.golf_courses.count_by_approval_status(
                 ApprovalStatus.PENDING_APPROVAL
             )
 
@@ -53,6 +53,6 @@ class GetAdminStatsUseCase:
             total_users=total_users,
             total_competitions=total_competitions,
             total_quick_matches=total_quick_matches,
-            total_golf_courses_approved=len(approved),
-            total_golf_courses_pending=len(pending),
+            total_golf_courses_approved=approved_count,
+            total_golf_courses_pending=pending_count,
         )

--- a/src/modules/user/application/use_cases/get_admin_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_admin_stats_use_case.py
@@ -1,0 +1,58 @@
+"""Caso de Uso: Estadísticas globales de la plataforma (panel de administración)."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.user.application.dto.admin_dto import AdminStatsResponseDTO
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+
+
+class GetAdminStatsUseCase:
+    """Agrega contadores globales de los distintos módulos para el panel de admin."""
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+
+    async def execute(self) -> AdminStatsResponseDTO:
+        async with self._user_uow:
+            total_users = await self._user_uow.users.count_all()
+
+        async with self._competition_uow:
+            total_competitions = await self._competition_uow.competitions.count_all()
+
+        async with self._quick_match_uow:
+            total_quick_matches = await self._quick_match_uow.quick_matches.count_all()
+
+        async with self._golf_course_uow:
+            approved = await self._golf_course_uow.golf_courses.find_by_approval_status(
+                ApprovalStatus.APPROVED
+            )
+            pending = await self._golf_course_uow.golf_courses.find_by_approval_status(
+                ApprovalStatus.PENDING_APPROVAL
+            )
+
+        return AdminStatsResponseDTO(
+            total_users=total_users,
+            total_competitions=total_competitions,
+            total_quick_matches=total_quick_matches,
+            total_golf_courses_approved=len(approved),
+            total_golf_courses_pending=len(pending),
+        )

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -27,7 +27,7 @@ from src.modules.user.application.use_cases.register_device_use_case import (
 )
 from src.modules.user.domain.entities.refresh_token import RefreshToken
 from src.modules.user.domain.entities.user import User
-from src.modules.user.domain.exceptions import AccountLockedException
+from src.modules.user.domain.exceptions import AccountDeactivatedException, AccountLockedException
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
@@ -145,6 +145,18 @@ class LoginUserUseCase:
                 locked_until=user.locked_until,
                 message=f"Account is locked due to too many failed login attempts. Try again after {user.locked_until.isoformat()}",
             )
+
+        # Admin Panel (v2.4.0): Verificar si la cuenta fue desactivada por un admin
+        if not user.is_active:
+            security_logger.log_login_attempt(
+                user_id=str(user.id.value),
+                email=request.email,
+                success=False,
+                failure_reason="Account deactivated by admin",
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+            raise AccountDeactivatedException()
 
         # Verificar contraseña
         if not user.verify_password(request.password):

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -146,18 +146,6 @@ class LoginUserUseCase:
                 message=f"Account is locked due to too many failed login attempts. Try again after {user.locked_until.isoformat()}",
             )
 
-        # Admin Panel (v2.4.0): Verificar si la cuenta fue desactivada por un admin
-        if not user.is_active:
-            security_logger.log_login_attempt(
-                user_id=str(user.id.value),
-                email=request.email,
-                success=False,
-                failure_reason="Account deactivated by admin",
-                ip_address=ip_address,
-                user_agent=user_agent,
-            )
-            raise AccountDeactivatedException()
-
         # Verificar contraseña
         if not user.verify_password(request.password):
             # Account Lockout (v1.13.0): Registrar intento fallido
@@ -196,6 +184,20 @@ class LoginUserUseCase:
 
         # Account Lockout (v1.13.0): Resetear intentos fallidos tras login exitoso
         user.reset_failed_attempts()
+
+        # Admin Panel (v2.4.0): Verificar si la cuenta fue desactivada por un admin.
+        # Se comprueba DESPUES de validar la contraseña para no filtrar el estado
+        # de la cuenta (activa/desactivada) a quien no conoce las credenciales.
+        if not user.is_active:
+            security_logger.log_login_attempt(
+                user_id=str(user.id.value),
+                email=request.email,
+                success=False,
+                failure_reason="Account deactivated by admin",
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+            raise AccountDeactivatedException()
 
         # Registrar evento de login exitoso (Clean Architecture)
         # UTC-aware: handicap_updated_at ahora es timezone-aware, y la comparación

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -6,7 +6,9 @@ from src.shared.domain.value_objects.country_code import CountryCode
 from src.shared.domain.value_objects.gender import Gender
 
 from ..errors.user_errors import InvalidAvatarPresetError
+from ..events.account_deactivated_event import AccountDeactivatedEvent
 from ..events.account_locked_event import AccountLockedEvent
+from ..events.account_reactivated_event import AccountReactivatedEvent
 from ..events.account_unlocked_event import AccountUnlockedEvent
 from ..events.email_verified_event import EmailVerifiedEvent
 from ..events.google_account_unlinked_event import GoogleAccountUnlinkedEvent
@@ -101,6 +103,7 @@ class User:
         failed_login_attempts: int = 0,
         locked_until: datetime | None = None,
         is_admin: bool = False,
+        is_active: bool = True,
         gender: Gender | None = None,
         avatar_source: AvatarSource = AvatarSource.NONE,
         avatar_preset_id: int | None = None,
@@ -125,6 +128,7 @@ class User:
         self._failed_login_attempts = failed_login_attempts
         self._locked_until = locked_until
         self._is_admin = is_admin
+        self._is_active = is_active
         self._gender = gender
         self._avatar_source = avatar_source
         self._avatar_preset_id = avatar_preset_id
@@ -202,6 +206,10 @@ class User:
     @property
     def is_admin(self) -> bool:
         return self._is_admin
+
+    @property
+    def is_active(self) -> bool:
+        return self._is_active
 
     @property
     def gender(self) -> Gender | None:
@@ -1079,6 +1087,71 @@ class User:
         if self.failed_login_attempts > 0:
             self._failed_login_attempts = 0
             self._updated_at = datetime.now()
+
+    def set_is_admin(self, is_admin: bool) -> None:
+        """Concede o revoca privilegios de administrador (solo desde el panel de admin)."""
+        self._is_admin = is_admin
+        self._updated_at = datetime.now()
+
+    # === Account Deactivation Methods (Admin) ===
+
+    def deactivate(self, deactivated_by_user_id: str) -> None:
+        """
+        Desactiva la cuenta del usuario (solo Admin, desde el panel de administración).
+
+        Una cuenta desactivada no puede iniciar sesión (ver LoginUserUseCase),
+        pero conserva todos sus datos (torneos, partidas, amistades) intactos.
+        Es una acción reversible mediante reactivate().
+
+        Emite AccountDeactivatedEvent para auditoría.
+
+        Args:
+            deactivated_by_user_id: ID del admin que realiza la desactivación
+
+        Raises:
+            ValueError: Si la cuenta ya está desactivada
+        """
+        if not self._is_active:
+            raise ValueError("Account is already deactivated")
+
+        now = datetime.now()
+        self._is_active = False
+        self._updated_at = now
+
+        self._add_domain_event(
+            AccountDeactivatedEvent(
+                user_id=str(self.id.value),
+                deactivated_by_user_id=deactivated_by_user_id,
+                deactivated_at=now,
+            )
+        )
+
+    def reactivate(self, reactivated_by_user_id: str) -> None:
+        """
+        Reactiva una cuenta previamente desactivada por un admin.
+
+        Emite AccountReactivatedEvent para auditoría.
+
+        Args:
+            reactivated_by_user_id: ID del admin que realiza la reactivación
+
+        Raises:
+            ValueError: Si la cuenta ya está activa
+        """
+        if self._is_active:
+            raise ValueError("Account is already active")
+
+        now = datetime.now()
+        self._is_active = True
+        self._updated_at = now
+
+        self._add_domain_event(
+            AccountReactivatedEvent(
+                user_id=str(self.id.value),
+                reactivated_by_user_id=reactivated_by_user_id,
+                reactivated_at=now,
+            )
+        )
 
     def __str__(self) -> str:
         """Representación string del usuario (sin mostrar password)."""

--- a/src/modules/user/domain/events/account_deactivated_event.py
+++ b/src/modules/user/domain/events/account_deactivated_event.py
@@ -1,0 +1,32 @@
+"""Account Deactivated Event - Emitido cuando un admin desactiva una cuenta."""
+
+from datetime import datetime
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+class AccountDeactivatedEvent(DomainEvent):
+    """
+    Evento de dominio emitido cuando un administrador desactiva la cuenta
+    de un usuario desde el panel de administración.
+
+    Security (OWASP A09):
+        - Evento de auditoría: registra quién desactivó y cuándo
+        - La cuenta desactivada no puede iniciar sesión (ver User.deactivate())
+
+    Attributes:
+        user_id: ID del usuario cuya cuenta fue desactivada
+        deactivated_by_user_id: ID del admin que realizó la desactivación
+        deactivated_at: Timestamp de la desactivación
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        deactivated_by_user_id: str,
+        deactivated_at: datetime,
+    ):
+        super().__init__()
+        self.user_id = user_id
+        self.deactivated_by_user_id = deactivated_by_user_id
+        self.deactivated_at = deactivated_at

--- a/src/modules/user/domain/events/account_deactivated_event.py
+++ b/src/modules/user/domain/events/account_deactivated_event.py
@@ -1,10 +1,12 @@
 """Account Deactivated Event - Emitido cuando un admin desactiva una cuenta."""
 
+from dataclasses import dataclass
 from datetime import datetime
 
 from src.shared.domain.events.domain_event import DomainEvent
 
 
+@dataclass(frozen=True)
 class AccountDeactivatedEvent(DomainEvent):
     """
     Evento de dominio emitido cuando un administrador desactiva la cuenta
@@ -20,13 +22,11 @@ class AccountDeactivatedEvent(DomainEvent):
         deactivated_at: Timestamp de la desactivación
     """
 
-    def __init__(
-        self,
-        user_id: str,
-        deactivated_by_user_id: str,
-        deactivated_at: datetime,
-    ):
-        super().__init__()
-        self.user_id = user_id
-        self.deactivated_by_user_id = deactivated_by_user_id
-        self.deactivated_at = deactivated_at
+    user_id: str
+    deactivated_by_user_id: str
+    deactivated_at: datetime
+
+    @property
+    def aggregate_id(self) -> str:
+        """El ID del agregado es el ID del usuario."""
+        return self.user_id

--- a/src/modules/user/domain/events/account_reactivated_event.py
+++ b/src/modules/user/domain/events/account_reactivated_event.py
@@ -1,0 +1,28 @@
+"""Account Reactivated Event - Emitido cuando un admin reactiva una cuenta."""
+
+from datetime import datetime
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+class AccountReactivatedEvent(DomainEvent):
+    """
+    Evento de dominio emitido cuando un administrador reactiva la cuenta
+    de un usuario previamente desactivada.
+
+    Attributes:
+        user_id: ID del usuario cuya cuenta fue reactivada
+        reactivated_by_user_id: ID del admin que realizó la reactivación
+        reactivated_at: Timestamp de la reactivación
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        reactivated_by_user_id: str,
+        reactivated_at: datetime,
+    ):
+        super().__init__()
+        self.user_id = user_id
+        self.reactivated_by_user_id = reactivated_by_user_id
+        self.reactivated_at = reactivated_at

--- a/src/modules/user/domain/events/account_reactivated_event.py
+++ b/src/modules/user/domain/events/account_reactivated_event.py
@@ -1,10 +1,12 @@
 """Account Reactivated Event - Emitido cuando un admin reactiva una cuenta."""
 
+from dataclasses import dataclass
 from datetime import datetime
 
 from src.shared.domain.events.domain_event import DomainEvent
 
 
+@dataclass(frozen=True)
 class AccountReactivatedEvent(DomainEvent):
     """
     Evento de dominio emitido cuando un administrador reactiva la cuenta
@@ -16,13 +18,11 @@ class AccountReactivatedEvent(DomainEvent):
         reactivated_at: Timestamp de la reactivación
     """
 
-    def __init__(
-        self,
-        user_id: str,
-        reactivated_by_user_id: str,
-        reactivated_at: datetime,
-    ):
-        super().__init__()
-        self.user_id = user_id
-        self.reactivated_by_user_id = reactivated_by_user_id
-        self.reactivated_at = reactivated_at
+    user_id: str
+    reactivated_by_user_id: str
+    reactivated_at: datetime
+
+    @property
+    def aggregate_id(self) -> str:
+        """El ID del agregado es el ID del usuario."""
+        return self.user_id

--- a/src/modules/user/domain/exceptions/__init__.py
+++ b/src/modules/user/domain/exceptions/__init__.py
@@ -1,6 +1,13 @@
 """User Domain Exceptions."""
 
+from .account_deactivated_exception import AccountDeactivatedException
 from .account_locked_exception import AccountLockedException
 from .current_device_revocation_exception import CurrentDeviceRevocationException
+from .user_has_activity_exception import UserHasActivityException
 
-__all__ = ["AccountLockedException", "CurrentDeviceRevocationException"]
+__all__ = [
+    "AccountDeactivatedException",
+    "AccountLockedException",
+    "CurrentDeviceRevocationException",
+    "UserHasActivityException",
+]

--- a/src/modules/user/domain/exceptions/account_deactivated_exception.py
+++ b/src/modules/user/domain/exceptions/account_deactivated_exception.py
@@ -1,0 +1,19 @@
+"""Account Deactivated Exception - Lanzada cuando se intenta login en cuenta desactivada."""
+
+
+class AccountDeactivatedException(Exception):  # noqa: N818 - Exception is intentional naming
+    """
+    Excepción lanzada cuando un usuario intenta hacer login en una cuenta
+    desactivada por un administrador.
+
+    Esta excepción se lanza en el Application Layer (LoginUserUseCase) cuando:
+    - user.is_active es False
+
+    Security (OWASP A07):
+        - Impide el acceso a cuentas desactivadas por un admin
+        - NO revela si la cuenta existe/está bloqueada por otro motivo
+    """
+
+    def __init__(self, message: str | None = None):
+        self.message = message or "Account has been deactivated"
+        super().__init__(self.message)

--- a/src/modules/user/domain/exceptions/user_has_activity_exception.py
+++ b/src/modules/user/domain/exceptions/user_has_activity_exception.py
@@ -1,0 +1,23 @@
+"""User Has Activity Exception - Bloquea el borrado definitivo de cuentas con datos."""
+
+
+class UserHasActivityException(Exception):  # noqa: N818 - Exception is intentional naming
+    """
+    Lanzada al intentar borrar definitivamente una cuenta que tiene datos
+    de los que depende otra gente (torneos creados, partidas rápidas creadas,
+    campos de golf solicitados, o historial de scores).
+
+    Borrar sin este chequeo podría:
+    - Borrar en cascada torneos/partidas rápidas de OTROS participantes
+      (competitions.creator_id y quick_matches.creator_id son ON DELETE CASCADE).
+    - Fallar con un IntegrityError de base de datos (hole_scores.player_user_id
+      no tiene ON DELETE definido).
+
+    Attributes:
+        reasons: Lista de motivos legibles por los que se bloquea el borrado.
+    """
+
+    def __init__(self, reasons: list[str]):
+        self.reasons = reasons
+        message = "Cannot permanently delete this account: " + "; ".join(reasons)
+        super().__init__(message)

--- a/src/modules/user/domain/repositories/user_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_repository_interface.py
@@ -181,13 +181,26 @@ class UserRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    async def find_all(self, limit: int = 100, offset: int = 0) -> list[User]:
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
         """
-        Obtiene una lista paginada de usuarios.
+        Obtiene una lista paginada de usuarios, opcionalmente filtrada.
 
         Args:
             limit (int): Número máximo de usuarios a retornar (default: 100)
             offset (int): Número de usuarios a saltar (default: 0)
+            search (str | None): Si se indica, filtra por coincidencia parcial
+                (case-insensitive) en nombre, apellidos o email
+            is_admin (bool | None): Si se indica, filtra por rol (admin/jugador)
+            is_active (bool | None): Si se indica, filtra por cuentas activas/desactivadas
+            email_verified (bool | None): Si se indica, filtra por email verificado o no
 
         Returns:
             List[User]: Lista de usuarios encontrados
@@ -198,12 +211,18 @@ class UserRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    async def count_all(self) -> int:
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
         """
-        Cuenta el total de usuarios en el repositorio.
+        Cuenta usuarios, opcionalmente filtrados (ver find_all).
 
         Returns:
-            int: Número total de usuarios
+            int: Número total de usuarios que coinciden con el filtro
 
         Raises:
             RepositoryError: Si ocurre un error de consulta

--- a/src/modules/user/infrastructure/api/v1/admin_routes.py
+++ b/src/modules/user/infrastructure/api/v1/admin_routes.py
@@ -128,6 +128,8 @@ async def set_user_active(
         await use_case.execute(user_id, body.is_active, actor_user_id=str(current_user.id))
     except UserNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.delete(
@@ -146,6 +148,11 @@ async def delete_user(
     use_case: AdminDeleteUserUseCase = Depends(get_admin_delete_user_use_case),
 ):
     require_admin(current_user)
+    if user_id == str(current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Admins cannot delete their own account",
+        )
     try:
         await use_case.execute(user_id)
     except UserNotFoundError as e:

--- a/src/modules/user/infrastructure/api/v1/admin_routes.py
+++ b/src/modules/user/infrastructure/api/v1/admin_routes.py
@@ -1,0 +1,154 @@
+"""
+Admin Panel Routes - API Layer.
+
+Endpoints exclusivos de administrador para gestionar usuarios y consultar
+estadisticas globales de la plataforma. Todos los endpoints requieren
+autenticacion + require_admin().
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.config.dependencies import (
+    get_admin_delete_user_use_case,
+    get_admin_list_users_use_case,
+    get_admin_set_user_active_use_case,
+    get_admin_update_user_use_case,
+    get_current_user,
+    get_get_admin_stats_use_case,
+)
+from src.modules.user.application.dto.admin_dto import (
+    AdminListUsersRequestDTO,
+    AdminListUsersResponseDTO,
+    AdminSetUserActiveRequestDTO,
+    AdminStatsResponseDTO,
+    AdminUpdateUserRequestDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.application.dto.user_dto import UserResponseDTO
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.shared.infrastructure.security.authorization import require_admin
+
+router = APIRouter()
+
+
+@router.get(
+    "/stats",
+    response_model=AdminStatsResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Estadisticas globales de la plataforma (Admin)",
+)
+async def get_admin_stats(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetAdminStatsUseCase = Depends(get_get_admin_stats_use_case),
+):
+    require_admin(current_user)
+    return await use_case.execute()
+
+
+@router.get(
+    "/users",
+    response_model=AdminListUsersResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Listar usuarios (Admin)",
+)
+async def list_users(
+    search: str | None = Query(default=None),
+    is_admin_filter: bool | None = Query(default=None, alias="is_admin"),
+    is_active: bool | None = Query(default=None),
+    email_verified: bool | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminListUsersUseCase = Depends(get_admin_list_users_use_case),
+):
+    require_admin(current_user)
+    request = AdminListUsersRequestDTO(
+        search=search,
+        is_admin=is_admin_filter,
+        is_active=is_active,
+        email_verified=email_verified,
+        limit=limit,
+        offset=offset,
+    )
+    return await use_case.execute(request)
+
+
+@router.put(
+    "/users/{user_id}",
+    response_model=AdminUserSummaryDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Editar un usuario (Admin)",
+)
+async def update_user(
+    user_id: str,
+    body: AdminUpdateUserRequestDTO,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminUpdateUserUseCase = Depends(get_admin_update_user_use_case),
+):
+    require_admin(current_user)
+    try:
+        return await use_case.execute(user_id, body)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except DuplicateEmailError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+@router.put(
+    "/users/{user_id}/active",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Activar o desactivar una cuenta (Admin)",
+)
+async def set_user_active(
+    user_id: str,
+    body: AdminSetUserActiveRequestDTO,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminSetUserActiveUseCase = Depends(get_admin_set_user_active_use_case),
+):
+    require_admin(current_user)
+    try:
+        await use_case.execute(user_id, body.is_active, actor_user_id=str(current_user.id))
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.delete(
+    "/users/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Borrado definitivo de una cuenta (Admin)",
+    description=(
+        "Borra la cuenta permanentemente. Bloqueado (409) si el usuario ha creado "
+        "competiciones/partidas rapidas, solicitado campos de golf, o tiene scores "
+        "registrados - en ese caso, usar /active para desactivar en su lugar."
+    ),
+)
+async def delete_user(
+    user_id: str,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminDeleteUserUseCase = Depends(get_admin_delete_user_use_case),
+):
+    require_admin(current_user)
+    try:
+        await use_case.execute(user_id)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except UserHasActivityException as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e

--- a/src/modules/user/infrastructure/api/v1/auth_routes.py
+++ b/src/modules/user/infrastructure/api/v1/auth_routes.py
@@ -71,7 +71,7 @@ from src.modules.user.application.use_cases.verify_email_use_case import (
     VerifyEmailUseCase,
 )
 from src.modules.user.domain.errors.user_errors import UserAlreadyExistsError
-from src.modules.user.domain.exceptions import AccountLockedException
+from src.modules.user.domain.exceptions import AccountDeactivatedException, AccountLockedException
 from src.shared.infrastructure.http.http_context_validator import (
     get_trusted_client_ip,
     get_user_agent,
@@ -249,6 +249,12 @@ async def login_user(
         raise HTTPException(
             status_code=status.HTTP_423_LOCKED,
             detail=f"Account locked until {e.locked_until.isoformat()}. Too many failed login attempts.",
+        ) from e
+    except AccountDeactivatedException as e:
+        # Admin Panel (v2.4.0): Cuenta desactivada por un administrador
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This account has been deactivated. Contact an administrator.",
         ) from e
 
     if not login_response:

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
@@ -39,7 +39,12 @@ class InMemoryUserRepository(UserRepositoryInterface):
         q = search.strip().lower()
         full_name = f"{user.first_name} {user.last_name}".lower()
         email = str(user.email).lower() if user.email else ""
-        return q in user.first_name.lower() or q in user.last_name.lower() or q in full_name or q in email
+        return (
+            q in user.first_name.lower()
+            or q in user.last_name.lower()
+            or q in full_name
+            or q in email
+        )
 
     def _matches_filters(
         self,
@@ -85,7 +90,7 @@ class InMemoryUserRepository(UserRepositoryInterface):
             for u in self._users.values()
             if self._matches_filters(u, search, is_admin, is_active, email_verified)
         ]
-        matching.sort(key=lambda u: u.created_at, reverse=True)
+        matching.sort(key=lambda u: (u.created_at, str(u.id)), reverse=True)
         return matching[offset : offset + limit]
 
     async def delete_by_id(self, user_id: UserId) -> bool:

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
@@ -33,23 +33,66 @@ class InMemoryUserRepository(UserRepositoryInterface):
                 return user
         return None
 
-    async def find_all(self, limit: int = 100, offset: int = 0) -> list[User]:
+    def _matches_search(self, user: User, search: str | None) -> bool:
+        if not search or not search.strip():
+            return True
+        q = search.strip().lower()
+        full_name = f"{user.first_name} {user.last_name}".lower()
+        email = str(user.email).lower() if user.email else ""
+        return q in user.first_name.lower() or q in user.last_name.lower() or q in full_name or q in email
+
+    def _matches_filters(
+        self,
+        user: User,
+        search: str | None,
+        is_admin: bool | None,
+        is_active: bool | None,
+        email_verified: bool | None,
+    ) -> bool:
+        if not self._matches_search(user, search):
+            return False
+        if is_admin is not None and user.is_admin != is_admin:
+            return False
+        if is_active is not None and user.is_active != is_active:
+            return False
+        return email_verified is None or user.email_verified == email_verified
+
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
         """
-        Obtiene una lista paginada de usuarios.
+        Obtiene una lista paginada de usuarios, opcionalmente filtrada.
 
         Args:
             limit: Número máximo de usuarios a retornar
             offset: Número de usuarios a saltar
+            search: Filtro opcional por nombre/apellidos/email
+            is_admin: Filtro opcional por rol
+            is_active: Filtro opcional por cuentas activas/desactivadas
+            email_verified: Filtro opcional por verificación de email
 
         Returns:
             Lista de usuarios paginada
         """
-        all_users = list(self._users.values())
-        return all_users[offset : offset + limit]
+        matching = [
+            u
+            for u in self._users.values()
+            if self._matches_filters(u, search, is_admin, is_active, email_verified)
+        ]
+        matching.sort(key=lambda u: u.created_at, reverse=True)
+        return matching[offset : offset + limit]
 
-    async def delete_by_id(self, user_id: UserId) -> None:
+    async def delete_by_id(self, user_id: UserId) -> bool:
         if user_id in self._users:
             del self._users[user_id]
+            return True
+        return False
 
     async def update(self, user: User) -> None:
         if user.id in self._users:
@@ -86,8 +129,20 @@ class InMemoryUserRepository(UserRepositoryInterface):
     async def exists_by_email(self, email: Email) -> bool:
         return any(user.email == email for user in self._users.values())
 
-    async def count_all(self) -> int:
-        return len(self._users)
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
+        return len(
+            [
+                u
+                for u in self._users.values()
+                if self._matches_filters(u, search, is_admin, is_active, email_verified)
+            ]
+        )
 
     async def find_by_verification_token(self, token: str) -> User | None:
         """Busca un usuario por su token de verificación."""

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -168,6 +168,8 @@ users_table = Table(
     Column("locked_until", DateTime, nullable=True),
     # RBAC field (v2.0.0)
     Column("is_admin", Boolean, nullable=False, default=False),
+    # Admin panel: deactivation (v2.4.0)
+    Column("is_active", Boolean, nullable=False, default=True, server_default="true"),
     # Gender field (tee system refactor)
     Column("gender", GenderDecorator(), nullable=True),
     # Avatar fields (v2.3.0)
@@ -222,6 +224,7 @@ def start_mappers():
                 "_failed_login_attempts": users_table.c.failed_login_attempts,
                 "_locked_until": users_table.c.locked_until,
                 "_is_admin": users_table.c.is_admin,
+                "_is_active": users_table.c.is_active,
                 "_gender": users_table.c.gender,
                 "_avatar_source": users_table.c.avatar_source,
                 "_avatar_preset_id": users_table.c.avatar_preset_id,

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -93,7 +93,7 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         email_verified: bool | None = None,
     ) -> list[User]:
         """Devuelve una página de usuarios, opcionalmente filtrada."""
-        statement = select(User).order_by(User._created_at.desc())
+        statement = select(User).order_by(User._created_at.desc(), User._id.desc())  # type: ignore[union-attr]
         for condition in self._build_filters(search, is_admin, is_active, email_verified):
             statement = statement.where(condition)
         statement = statement.limit(limit).offset(offset)

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -52,17 +52,61 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
-    async def find_all(self) -> list[User]:
-        """Devuelve todos los usuarios."""
-        statement = select(User)
+    def _search_filter(self, search: str | None):
+        """Construye la condición ILIKE compartida por find_all/count_all."""
+        if not search or not search.strip():
+            return None
+        q = search.strip().lower()
+        return or_(
+            func.lower(User._first_name).contains(q, autoescape=True),
+            func.lower(User._last_name).contains(q, autoescape=True),
+            func.lower(User._first_name + " " + User._last_name).contains(q, autoescape=True),
+            func.lower(User._email_value).contains(q, autoescape=True),
+        )
+
+    def _build_filters(
+        self,
+        search: str | None,
+        is_admin: bool | None,
+        is_active: bool | None,
+        email_verified: bool | None,
+    ) -> list:
+        conditions = []
+        search_condition = self._search_filter(search)
+        if search_condition is not None:
+            conditions.append(search_condition)
+        if is_admin is not None:
+            conditions.append(User._is_admin == is_admin)
+        if is_active is not None:
+            conditions.append(User._is_active == is_active)
+        if email_verified is not None:
+            conditions.append(User._email_verified == email_verified)
+        return conditions
+
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
+        """Devuelve una página de usuarios, opcionalmente filtrada."""
+        statement = select(User).order_by(User._created_at.desc())
+        for condition in self._build_filters(search, is_admin, is_active, email_verified):
+            statement = statement.where(condition)
+        statement = statement.limit(limit).offset(offset)
         result = await self._session.execute(statement)
         return list(result.scalars().all())
 
-    async def delete_by_id(self, user_id: UserId) -> None:
-        """Elimina un usuario por su ID."""
+    async def delete_by_id(self, user_id: UserId) -> bool:
+        """Elimina un usuario por su ID. Devuelve True si existía y se eliminó."""
         user = await self.find_by_id(user_id)
-        if user:
-            await self._session.delete(user)
+        if not user:
+            return False
+        await self._session.delete(user)
+        return True
 
     async def update(self, user: User) -> None:
         """
@@ -125,9 +169,17 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         result = await self._session.execute(statement)
         return result.scalar_one() > 0
 
-    async def count_all(self) -> int:
-        """Cuenta todos los usuarios."""
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
+        """Cuenta usuarios, opcionalmente filtrados (ver find_all)."""
         statement = select(func.count()).select_from(User)
+        for condition in self._build_filters(search, is_admin, is_active, email_verified):
+            statement = statement.where(condition)
         result = await self._session.execute(statement)
         return result.scalar_one()
 

--- a/tests/integration/api/v1/test_admin_endpoints.py
+++ b/tests/integration/api/v1/test_admin_endpoints.py
@@ -1,0 +1,225 @@
+"""Tests de integración para /api/v1/admin/* (panel de administración)."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from tests.conftest import create_authenticated_user
+
+
+async def _make_admin(email: str) -> None:
+    from main import app as fastapi_app
+    from src.config.dependencies import get_db_session
+
+    db_session_override = fastapi_app.dependency_overrides.get(get_db_session)
+    async for session in db_session_override():
+        try:
+            await session.execute(
+                text("UPDATE users SET is_admin = true WHERE email = :email"),
+                {"email": email},
+            )
+            await session.commit()
+            break
+        finally:
+            await session.close()
+
+
+class TestAdminStats:
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_get_stats_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_stats@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        response = await client.get("/api/v1/admin/stats", cookies=user["cookies"])
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_gets_stats(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_stats@test.com", "AdminPass123!", "Admin", "Stats"
+        )
+        await _make_admin("admin_stats@test.com")
+
+        response = await client.get("/api/v1/admin/stats", cookies=admin["cookies"])
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_users" in data
+        assert data["total_users"] >= 1
+        assert "total_competitions" in data
+        assert "total_quick_matches" in data
+        assert "total_golf_courses_approved" in data
+        assert "total_golf_courses_pending" in data
+
+
+class TestAdminListUsers:
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_list_users_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_list@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        response = await client.get("/api/v1/admin/users", cookies=user["cookies"])
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_lists_and_searches_users(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_list@test.com", "AdminPass123!", "Admin", "List"
+        )
+        await _make_admin("admin_list@test.com")
+        await create_authenticated_user(
+            client, "findable_target@test.com", "P@ssw0rd123!", "Findable", "Target"
+        )
+
+        response = await client.get(
+            "/api/v1/admin/users", params={"search": "findable_target"}, cookies=admin["cookies"]
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        assert data["users"][0]["email"] == "findable_target@test.com"
+
+
+class TestAdminUpdateUser:
+    @pytest.mark.asyncio
+    async def test_admin_updates_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_update@test.com", "AdminPass123!", "Admin", "Update"
+        )
+        await _make_admin("admin_update@test.com")
+        target = await create_authenticated_user(
+            client, "target_update@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"first_name": "Renamed", "handicap": 15.3},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["first_name"] == "Renamed"
+        assert data["handicap"] == 15.3
+
+    @pytest.mark.asyncio
+    async def test_admin_update_duplicate_email_returns_409(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_dup@test.com", "AdminPass123!", "Admin", "Dup"
+        )
+        await _make_admin("admin_dup@test.com")
+        await create_authenticated_user(
+            client, "already_taken@test.com", "P@ssw0rd123!", "Taken", "User"
+        )
+        target = await create_authenticated_user(
+            client, "target_dup@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"email": "already_taken@test.com"},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update_user_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_update@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        target = await create_authenticated_user(
+            client, "target_notadmin@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"first_name": "Hacked"},
+            cookies=user["cookies"],
+        )
+        assert response.status_code == 403
+
+
+class TestAdminSetUserActive:
+    @pytest.mark.asyncio
+    async def test_admin_deactivates_and_blocks_login(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_deact@test.com", "AdminPass123!", "Admin", "Deact"
+        )
+        await _make_admin("admin_deact@test.com")
+        target = await create_authenticated_user(
+            client, "target_deact@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_deact@test.com", "password": "P@ssw0rd123!"},
+        )
+        assert login_response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_reactivates_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_react@test.com", "AdminPass123!", "Admin", "React"
+        )
+        await _make_admin("admin_react@test.com")
+        target = await create_authenticated_user(
+            client, "target_react@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": True},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_react@test.com", "password": "P@ssw0rd123!"},
+        )
+        assert login_response.status_code == 200
+
+
+class TestAdminDeleteUser:
+    @pytest.mark.asyncio
+    async def test_admin_deletes_clean_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_delete@test.com", "AdminPass123!", "Admin", "Delete"
+        )
+        await _make_admin("admin_delete@test.com")
+        target = await create_authenticated_user(
+            client, "target_delete@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.delete(
+            f"/api/v1/admin/users/{target['user']['id']}", cookies=admin["cookies"]
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_delete@test.com", "password": "P@ssw0rd123!"},
+        )
+        assert login_response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_delete_user_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_delete@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        target = await create_authenticated_user(
+            client, "target_notadmin_delete@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+        response = await client.delete(
+            f"/api/v1/admin/users/{target['user']['id']}", cookies=user["cookies"]
+        )
+        assert response.status_code == 403

--- a/tests/integration/api/v1/test_admin_endpoints.py
+++ b/tests/integration/api/v1/test_admin_endpoints.py
@@ -1,17 +1,23 @@
 """Tests de integración para /api/v1/admin/* (panel de administración)."""
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 
-from tests.conftest import create_authenticated_user
+from tests.conftest import (
+    create_authenticated_user,
+    create_golf_course,
+    set_auth_cookies,
+)
 
 
 async def _make_admin(email: str) -> None:
     from main import app as fastapi_app
     from src.config.dependencies import get_db_session
 
-    db_session_override = fastapi_app.dependency_overrides.get(get_db_session)
+    db_session_override = fastapi_app.dependency_overrides[get_db_session]
     async for session in db_session_override():
         try:
             await session.execute(
@@ -157,6 +163,7 @@ class TestAdminSetUserActive:
         login_response = await client.post(
             "/api/v1/auth/login",
             json={"email": "target_deact@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
         )
         assert login_response.status_code == 403
 
@@ -185,6 +192,7 @@ class TestAdminSetUserActive:
         login_response = await client.post(
             "/api/v1/auth/login",
             json={"email": "target_react@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
         )
         assert login_response.status_code == 200
 
@@ -208,6 +216,7 @@ class TestAdminDeleteUser:
         login_response = await client.post(
             "/api/v1/auth/login",
             json={"email": "target_delete@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
         )
         assert login_response.status_code == 401
 
@@ -223,3 +232,58 @@ class TestAdminDeleteUser:
             f"/api/v1/admin/users/{target['user']['id']}", cookies=user["cookies"]
         )
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_delete_blocked_when_user_has_activity(self, client: AsyncClient):
+        """Bloquea (409) el borrado definitivo si el usuario tiene actividad,
+        para no romper la restricción de BD (golf_courses.creator_id sin
+        ON DELETE) ni el dato de otros (competitions/quick_matches CASCADE).
+        La cuenta debe seguir existiendo tras el intento fallido."""
+        admin = await create_authenticated_user(
+            client, "admin_delete_blocked@test.com", "AdminPass123!", "Admin", "Blocked"
+        )
+        await _make_admin("admin_delete_blocked@test.com")
+        target = await create_authenticated_user(
+            client, "target_delete_blocked@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        await create_golf_course(client, target["cookies"])
+
+        set_auth_cookies(client, admin["cookies"])
+        response = await client.delete(f"/api/v1/admin/users/{target['user']['id']}")
+        assert response.status_code == 409
+        assert "golf course" in response.json()["detail"]
+
+        list_response = await client.get(
+            "/api/v1/admin/users", params={"search": "target_delete_blocked"}
+        )
+        assert list_response.status_code == 200
+        assert list_response.json()["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_admin_cannot_delete_own_account(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_self_delete@test.com", "AdminPass123!", "Admin", "Self"
+        )
+        await _make_admin("admin_self_delete@test.com")
+
+        response = await client.delete(
+            f"/api/v1/admin/users/{admin['user']['id']}", cookies=admin["cookies"]
+        )
+        assert response.status_code == 400
+
+
+class TestAdminSelfDeactivationGuard:
+    @pytest.mark.asyncio
+    async def test_admin_cannot_deactivate_own_account(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_self_deact@test.com", "AdminPass123!", "Admin", "SelfDeact"
+        )
+        await _make_admin("admin_self_deact@test.com")
+
+        response = await client.put(
+            f"/api/v1/admin/users/{admin['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 400

--- a/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
@@ -1,0 +1,111 @@
+"""Tests para AdminDeleteUserUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_uow_mock(**repo_attrs):
+    """Crea un UoW mock cuyo __aenter__/__aexit__ funcionan como context manager."""
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    for name, repo in repo_attrs.items():
+        setattr(uow, name, repo)
+    return uow
+
+
+class TestAdminDeleteUserUseCase:
+    @pytest.fixture
+    def user_uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, user_uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    def _make_use_case(
+        self,
+        user_uow,
+        competitions_created=0,
+        has_scores=False,
+        quick_match_created=False,
+        golf_courses_created=None,
+    ):
+        competitions_repo = AsyncMock()
+        competitions_repo.count_by_creator = AsyncMock(return_value=competitions_created)
+        hole_scores_repo = AsyncMock()
+        hole_scores_repo.exists_by_player = AsyncMock(return_value=has_scores)
+        competition_uow = _make_uow_mock(competitions=competitions_repo, hole_scores=hole_scores_repo)
+
+        quick_matches_repo = AsyncMock()
+        quick_matches_repo.exists_created_by = AsyncMock(return_value=quick_match_created)
+        quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
+
+        golf_courses_repo = AsyncMock()
+        golf_courses_repo.find_by_creator = AsyncMock(return_value=golf_courses_created or [])
+        golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
+
+        return AdminDeleteUserUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+    async def test_deletes_user_with_no_activity(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow)
+        await use_case.execute(str(existing_user.id.value))
+
+        async with user_uow:
+            assert await user_uow.users.find_by_id(existing_user.id) is None
+
+    async def test_blocks_delete_when_user_created_competitions(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, competitions_created=2)
+
+        with pytest.raises(UserHasActivityException) as exc_info:
+            await use_case.execute(str(existing_user.id.value))
+        assert "2 competition(s)" in str(exc_info.value)
+
+        async with user_uow:
+            assert await user_uow.users.find_by_id(existing_user.id) is not None
+
+    async def test_blocks_delete_when_user_has_hole_scores(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, has_scores=True)
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_blocks_delete_when_user_created_quick_match(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, quick_match_created=True)
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_blocks_delete_when_user_requested_golf_course(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, golf_courses_created=[object()])
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_raises_not_found_before_checking_activity(self, user_uow):
+        from uuid import uuid4
+
+        use_case = self._make_use_case(user_uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()))

--- a/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
@@ -50,20 +50,22 @@ class TestAdminDeleteUserUseCase:
         competitions_created=0,
         has_scores=False,
         quick_match_created=False,
-        golf_courses_created=None,
+        golf_courses_created=0,
     ):
         competitions_repo = AsyncMock()
         competitions_repo.count_by_creator = AsyncMock(return_value=competitions_created)
         hole_scores_repo = AsyncMock()
         hole_scores_repo.exists_by_player = AsyncMock(return_value=has_scores)
-        competition_uow = _make_uow_mock(competitions=competitions_repo, hole_scores=hole_scores_repo)
+        competition_uow = _make_uow_mock(
+            competitions=competitions_repo, hole_scores=hole_scores_repo
+        )
 
         quick_matches_repo = AsyncMock()
         quick_matches_repo.exists_created_by = AsyncMock(return_value=quick_match_created)
         quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
 
         golf_courses_repo = AsyncMock()
-        golf_courses_repo.find_by_creator = AsyncMock(return_value=golf_courses_created or [])
+        golf_courses_repo.count_by_creator = AsyncMock(return_value=golf_courses_created)
         golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
 
         return AdminDeleteUserUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
@@ -98,7 +100,7 @@ class TestAdminDeleteUserUseCase:
             await use_case.execute(str(existing_user.id.value))
 
     async def test_blocks_delete_when_user_requested_golf_course(self, user_uow, existing_user):
-        use_case = self._make_use_case(user_uow, golf_courses_created=[object()])
+        use_case = self._make_use_case(user_uow, golf_courses_created=1)
 
         with pytest.raises(UserHasActivityException):
             await use_case.execute(str(existing_user.id.value))

--- a/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
@@ -86,8 +86,13 @@ class TestAdminListUsersUseCase:
 
     async def test_filters_by_email_verified(self, uow):
         await self._create_user(uow, "Unverified", "User", "unverified@test.com")
+        verified = await self._create_user(uow, "Verified", "User", "verified@test.com")
+        async with uow:
+            verified.verify_email_from_oauth()
+            await uow.users.save(verified)
 
         use_case = AdminListUsersUseCase(uow)
         response = await use_case.execute(AdminListUsersRequestDTO(email_verified=False))
 
         assert response.total_count == 1
+        assert response.users[0].email == "unverified@test.com"

--- a/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
@@ -1,0 +1,93 @@
+"""Tests para AdminListUsersUseCase."""
+
+import pytest
+
+from src.modules.user.application.dto.admin_dto import AdminListUsersRequestDTO
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminListUsersUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    async def _create_user(self, uow, first_name, last_name, email):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_lists_all_users_paginated(self, uow):
+        await self._create_user(uow, "Ana", "Ruiz", "ana@test.com")
+        await self._create_user(uow, "Bea", "Soto", "bea@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(limit=1, offset=0))
+
+        assert response.total_count == 2
+        assert len(response.users) == 1
+
+    async def test_search_filters_by_name_or_email(self, uow):
+        await self._create_user(uow, "Marta", "Sánchez", "marta@test.com")
+        await self._create_user(uow, "Diego", "Molero", "diego@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="marta"))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "marta@test.com"
+
+    async def test_search_matches_email_too(self, uow):
+        await self._create_user(uow, "Marta", "Sánchez", "findme@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="findme"))
+
+        assert response.total_count == 1
+
+    async def test_filters_by_is_admin(self, uow):
+        admin = await self._create_user(uow, "Admin", "User", "admin@test.com")
+        async with uow:
+            admin.set_is_admin(True)
+            await uow.users.save(admin)
+        await self._create_user(uow, "Player", "User", "player@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(is_admin=True))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "admin@test.com"
+
+    async def test_filters_by_is_active(self, uow):
+        user = await self._create_user(uow, "Deactivated", "User", "gone@test.com")
+        async with uow:
+            user.deactivate(deactivated_by_user_id="admin-id")
+            await uow.users.save(user)
+        await self._create_user(uow, "Active", "User", "active@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(is_active=False))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "gone@test.com"
+
+    async def test_filters_by_email_verified(self, uow):
+        await self._create_user(uow, "Unverified", "User", "unverified@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(email_verified=False))
+
+        assert response.total_count == 1

--- a/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
@@ -63,3 +63,26 @@ class TestAdminSetUserActiveUseCase:
         use_case = AdminSetUserActiveUseCase(uow)
         with pytest.raises(UserNotFoundError):
             await use_case.execute(str(uuid4()), False, actor_user_id="admin-id")
+
+    async def test_blocks_admin_from_deactivating_own_account(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        actor_id = str(existing_user.id.value)
+
+        with pytest.raises(ValueError, match="cannot deactivate their own account"):
+            await use_case.execute(actor_id, False, actor_user_id=actor_id)
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_allows_admin_to_reactivate_own_account(self, uow, existing_user):
+        """El guard solo bloquea auto-desactivación; reactivar la propia cuenta es inofensivo."""
+        use_case = AdminSetUserActiveUseCase(uow)
+        actor_id = str(existing_user.id.value)
+        await use_case.execute(actor_id, False, actor_user_id="other-admin-id")
+
+        await use_case.execute(actor_id, True, actor_user_id=actor_id)
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True

--- a/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
@@ -1,0 +1,65 @@
+"""Tests para AdminSetUserActiveUseCase."""
+
+import pytest
+
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminSetUserActiveUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_deactivates_active_user(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        await use_case.execute(str(existing_user.id.value), False, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is False
+
+    async def test_reactivates_deactivated_user(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        await use_case.execute(str(existing_user.id.value), False, actor_user_id="admin-id")
+        await use_case.execute(str(existing_user.id.value), True, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_is_idempotent_when_already_in_target_state(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        # Ya está activo por defecto: no debe lanzar al pedir is_active=True
+        await use_case.execute(str(existing_user.id.value), True, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_raises_when_user_not_found(self, uow):
+        from uuid import uuid4
+
+        use_case = AdminSetUserActiveUseCase(uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()), False, actor_user_id="admin-id")

--- a/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
@@ -1,0 +1,84 @@
+"""Tests para AdminUpdateUserUseCase."""
+
+import pytest
+
+from src.modules.user.application.dto.admin_dto import AdminUpdateUserRequestDTO
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminUpdateUserUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_updates_name_and_handicap(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(first_name="Carlitos", handicap=12.5),
+        )
+
+        assert result.first_name == "Carlitos"
+        assert result.handicap == 12.5
+
+    async def test_promotes_user_to_admin(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value), AdminUpdateUserRequestDTO(is_admin=True)
+        )
+
+        assert result.is_admin is True
+
+    async def test_changes_email(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(email="new-email@test.com"),
+        )
+
+        assert result.email == "new-email@test.com"
+
+    async def test_raises_when_user_not_found(self, uow):
+        from uuid import uuid4
+
+        use_case = AdminUpdateUserUseCase(uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()), AdminUpdateUserRequestDTO(first_name="X"))
+
+    async def test_raises_on_duplicate_email(self, uow, existing_user):
+        other = User.create(
+            first_name="Otro",
+            last_name="Usuario",
+            email_str="taken@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(other)
+
+        use_case = AdminUpdateUserUseCase(uow)
+        with pytest.raises(DuplicateEmailError):
+            await use_case.execute(
+                str(existing_user.id.value),
+                AdminUpdateUserRequestDTO(email="taken@test.com"),
+            )

--- a/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
 from src.modules.user.application.use_cases.get_admin_stats_use_case import (
     GetAdminStatsUseCase,
 )
@@ -49,16 +50,12 @@ class TestGetAdminStatsUseCase:
         quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
 
         golf_courses_repo = AsyncMock()
-        golf_courses_repo.find_by_approval_status = AsyncMock(
-            side_effect=lambda status: [object()] * 9
-            if status.value == "APPROVED"
-            else [object()] * 2
+        golf_courses_repo.count_by_approval_status = AsyncMock(
+            side_effect=lambda status: 9 if status is ApprovalStatus.APPROVED else 2
         )
         golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
 
-        use_case = GetAdminStatsUseCase(
-            user_uow, competition_uow, quick_match_uow, golf_course_uow
-        )
+        use_case = GetAdminStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
         stats = await use_case.execute()
 
         assert stats.total_users == 3

--- a/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
@@ -1,0 +1,68 @@
+"""Tests para GetAdminStatsUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_uow_mock(**repo_attrs):
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    for name, repo in repo_attrs.items():
+        setattr(uow, name, repo)
+    return uow
+
+
+class TestGetAdminStatsUseCase:
+    @pytest.fixture
+    def user_uow(self):
+        return InMemoryUnitOfWork()
+
+    async def test_aggregates_counts_from_all_modules(self, user_uow):
+        for i in range(3):
+            user = User.create(
+                first_name=f"User{i}",
+                last_name="Test",
+                email_str=f"user{i}@test.com",
+                plain_password="SecureP@ssw0rd123",
+            )
+            async with user_uow:
+                await user_uow.users.save(user)
+
+        competitions_repo = AsyncMock()
+        competitions_repo.count_all = AsyncMock(return_value=12)
+        competition_uow = _make_uow_mock(competitions=competitions_repo)
+
+        quick_matches_repo = AsyncMock()
+        quick_matches_repo.count_all = AsyncMock(return_value=58)
+        quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
+
+        golf_courses_repo = AsyncMock()
+        golf_courses_repo.find_by_approval_status = AsyncMock(
+            side_effect=lambda status: [object()] * 9
+            if status.value == "APPROVED"
+            else [object()] * 2
+        )
+        golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
+
+        use_case = GetAdminStatsUseCase(
+            user_uow, competition_uow, quick_match_uow, golf_course_uow
+        )
+        stats = await use_case.execute()
+
+        assert stats.total_users == 3
+        assert stats.total_competitions == 12
+        assert stats.total_quick_matches == 58
+        assert stats.total_golf_courses_approved == 9
+        assert stats.total_golf_courses_pending == 2

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -13,6 +13,7 @@ from src.modules.user.application.dto.user_dto import LoginRequestDTO
 from src.modules.user.application.use_cases.login_user_use_case import LoginUserUseCase
 from src.modules.user.domain.entities.user import User
 from src.modules.user.domain.errors.handicap_errors import HandicapServiceUnavailableError
+from src.modules.user.domain.exceptions import AccountDeactivatedException
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -46,6 +47,7 @@ def _rebuild_user(user: User, **overrides) -> User:
         "failed_login_attempts": user.failed_login_attempts,
         "locked_until": user.locked_until,
         "is_admin": user.is_admin,
+        "is_active": user.is_active,
         "gender": user.gender,
         "domain_events": user.get_domain_events(),
     }
@@ -449,9 +451,7 @@ class TestLoginUserUseCaseHandicapRFEG:
             country_code_str="ES",
         )
         user.update_handicap(12.5)
-        user = _rebuild_user(
-            user, handicap_updated_at=user.handicap_updated_at - timedelta(days=1)
-        )
+        user = _rebuild_user(user, handicap_updated_at=user.handicap_updated_at - timedelta(days=1))
         async with uow:
             await uow.users.save(user)
             await uow.commit()
@@ -467,3 +467,50 @@ class TestLoginUserUseCaseHandicapRFEG:
         assert response.needs_handicap is False
         assert response.user.handicap == 15.0
         handicap_svc.search_handicap.assert_awaited_once_with("Juan Garcia")
+
+
+@pytest.mark.asyncio
+class TestLoginUserUseCaseDeactivatedAccount:
+    """
+    Tests para el bloqueo de login en cuentas desactivadas (Admin Panel v2.4.0).
+
+    La verificación de is_active ocurre DESPUÉS de validar la contraseña, para
+    no filtrar el estado de la cuenta a quien no conoce las credenciales.
+    """
+
+    async def test_deactivated_account_with_correct_password_raises_exception(
+        self, uow, token_service, register_device_use_case, existing_user
+    ):
+        """Contraseña correcta + cuenta desactivada → AccountDeactivatedException."""
+        deactivated_user = _rebuild_user(existing_user, is_active=False)
+        async with uow:
+            await uow.users.save(deactivated_user)
+            await uow.commit()
+
+        use_case = LoginUserUseCase(uow, token_service, register_device_use_case)
+        request = LoginRequestDTO(email="test@example.com", password="V@l1dP@ss123!")
+
+        with pytest.raises(AccountDeactivatedException):
+            await use_case.execute(request)
+
+    async def test_deactivated_account_with_wrong_password_returns_none(
+        self, uow, token_service, register_device_use_case, existing_user
+    ):
+        """
+        Contraseña incorrecta + cuenta desactivada → None (no la excepción).
+
+        Verifica el orden correcto: la contraseña se valida ANTES que el
+        estado is_active, así que unas credenciales inválidas no revelan si
+        la cuenta está o no desactivada.
+        """
+        deactivated_user = _rebuild_user(existing_user, is_active=False)
+        async with uow:
+            await uow.users.save(deactivated_user)
+            await uow.commit()
+
+        use_case = LoginUserUseCase(uow, token_service, register_device_use_case)
+        request = LoginRequestDTO(email="test@example.com", password="Wr0ngP@ssw0rd!")
+
+        response = await use_case.execute(request)
+
+        assert response is None

--- a/tests/unit/modules/user/domain/entities/test_user.py
+++ b/tests/unit/modules/user/domain/entities/test_user.py
@@ -11,6 +11,8 @@ Este archivo contiene tests que verifican:
 import pytest
 
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.events.account_deactivated_event import AccountDeactivatedEvent
+from src.modules.user.domain.events.account_reactivated_event import AccountReactivatedEvent
 from src.modules.user.domain.value_objects.email import InvalidEmailError
 
 
@@ -155,6 +157,66 @@ class TestUserMethods:
 
         # Assert
         assert full_name == "Ana Martín"
+
+
+class TestUserAccountDeactivation:
+    """Tests para deactivate()/reactivate() (panel de administración)."""
+
+    def _make_user(self):
+        return User.create(
+            first_name="Carlos",
+            last_name="Rodríguez",
+            email_str="carlos@test.com",
+            plain_password="DefaultPassword123!",
+        )
+
+    def test_new_user_is_active_by_default(self):
+        user = self._make_user()
+        assert user.is_active is True
+
+    def test_deactivate_sets_is_active_false(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        assert user.is_active is False
+
+    def test_deactivate_raises_if_already_deactivated(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        with pytest.raises(ValueError, match="already deactivated"):
+            user.deactivate(deactivated_by_user_id="admin-id")
+
+    def test_deactivate_emits_account_deactivated_event(self):
+        user = self._make_user()
+        user.clear_domain_events()
+        user.deactivate(deactivated_by_user_id="admin-id")
+
+        events = user.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AccountDeactivatedEvent)
+        assert events[0].user_id == str(user.id.value)
+        assert events[0].deactivated_by_user_id == "admin-id"
+
+    def test_reactivate_sets_is_active_true(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        user.reactivate(reactivated_by_user_id="admin-id")
+        assert user.is_active is True
+
+    def test_reactivate_raises_if_already_active(self):
+        user = self._make_user()
+        with pytest.raises(ValueError, match="already active"):
+            user.reactivate(reactivated_by_user_id="admin-id")
+
+    def test_reactivate_emits_account_reactivated_event(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        user.clear_domain_events()
+        user.reactivate(reactivated_by_user_id="admin-id")
+
+        events = user.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AccountReactivatedEvent)
+        assert events[0].reactivated_by_user_id == "admin-id"
 
 
 class TestUserValidation:


### PR DESCRIPTION
## Summary
Backend half of the admin panel (issue #233). New `/api/v1/admin/*` endpoints, all guarded by `require_admin()` (giving real use to that previously-unused helper — every other admin route in this repo currently repeats its own inline `if not current_user.is_admin` check):

- `GET /admin/stats` — total users, competitions, quick matches, golf courses (approved/pending). Cross-module orchestration in `GetAdminStatsUseCase`.
- `GET /admin/users` — paginated + searchable (name/email) listing, filterable by role/active/verified.
- `PUT /admin/users/{id}` — edit name, email, handicap, country, admin flag.
- `PUT /admin/users/{id}/active` — deactivate/reactivate (reversible, blocks login, no data touched).
- `DELETE /admin/users/{id}` — permanent delete, **blocked with 409** if the account has created competitions/quick matches, requested golf courses, or has hole scores. `competitions.creator_id` and `quick_matches.creator_id` are `ON DELETE CASCADE` (would wipe the tournament/match for every other participant), and `hole_scores.player_user_id` has no `ON DELETE` (would raise a raw `IntegrityError`). Deactivation is the safe alternative offered in those cases.

## Supporting changes
- `User.is_active` (migration `f3a9c2e7b1d4`, default `true`) + `deactivate()`/`reactivate()`/`set_is_admin()` domain methods + `AccountDeactivatedEvent`/`AccountReactivatedEvent`. Login now returns 403 for deactivated accounts.
- Fixed `SQLAlchemyUserRepository.find_all()`/`delete_by_id()`: signatures had drifted from the interface (no pagination, wrong return type) since nothing called them before this PR. Added search + role/active/verified filters to `find_all()`/`count_all()` in both the SQLAlchemy and in-memory implementations.
- New `count_all()` / `exists_created_by()` / `exists_by_player()` repository methods on Competition, QuickMatch and GolfCourse — needed for both the stats endpoint and the delete-activity check.

## Test plan
- [x] `pytest tests/unit/` — 2315 passed
- [x] `pytest tests/integration/` — 329 passed, 1 skipped (pre-existing), including 11 new admin endpoint tests
- [x] `ruff check` + `mypy` clean
- [x] Verified end-to-end against the real local cluster: `alembic upgrade head` applied to the live Postgres (not just the test schema), image rebuilt/redeployed, admin endpoints smoke-tested with a real temporarily-promoted admin account (reverted after)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrator panel with platform statistics and paginated, searchable, filterable user listings.
  * Administrators can edit profiles, manage administrator status, and activate or deactivate accounts.
  * Added guarded permanent account deletion, preventing removal when related activity exists or when deleting the administrator’s own account.
* **Bug Fixes**
  * Deactivated accounts can no longer log in and receive a clear access message.
* **Documentation**
  * Documented account status, migrations, and activation or deactivation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->