### PR TITLE
feat(admin): Add last login to admin user list

### DIFF
--- a/src/modules/user/application/dto/admin_dto.py
+++ b/src/modules/user/application/dto/admin_dto.py
@@ -37,6 +37,7 @@ class AdminUserSummaryDTO(BaseModel):
     is_active: bool
     email_verified: bool
     created_at: datetime
+    last_login_at: datetime | None = None
 
 
 class AdminListUsersResponseDTO(BaseModel):

--- a/src/modules/user/application/use_cases/admin_list_users_use_case.py
+++ b/src/modules/user/application/use_cases/admin_list_users_use_case.py
@@ -32,6 +32,9 @@ class AdminListUsersUseCase:
                 is_active=request.is_active,
                 email_verified=request.email_verified,
             )
+            last_login_map = await self._uow.user_devices.find_last_login_map(
+                [user.id for user in users if user.id is not None]
+            )
 
         return AdminListUsersResponseDTO(
             users=[
@@ -45,6 +48,7 @@ class AdminListUsersUseCase:
                     is_active=user.is_active,
                     email_verified=user.email_verified,
                     created_at=user.created_at,
+                    last_login_at=last_login_map.get(str(user.id.value)),
                 )
                 for user in users
             ],

--- a/src/modules/user/application/use_cases/admin_update_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_update_user_use_case.py
@@ -53,6 +53,9 @@ class AdminUpdateUserUseCase:
                 user.set_is_admin(request.is_admin)
 
             await self._uow.users.save(user)
+            last_login_map = await self._uow.user_devices.find_last_login_map(
+                [uid] if (uid := user.id) is not None else []
+            )
 
         return AdminUserSummaryDTO(
             id=user.id.value,
@@ -64,4 +67,5 @@ class AdminUpdateUserUseCase:
             is_active=user.is_active,
             email_verified=user.email_verified,
             created_at=user.created_at,
+            last_login_at=last_login_map.get(str(user.id.value)),
         )

--- a/src/modules/user/domain/repositories/user_device_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_device_repository_interface.py
@@ -18,6 +18,7 @@ Patrón: Repository Pattern + Dependency Inversion Principle (SOLID)
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
@@ -209,6 +210,25 @@ class UserDeviceRepositoryInterface(ABC):
             ...     print(f"{device.device_name} - Usado: {device.last_used_at}")
             Chrome on macOS - Usado: 2026-01-09 10:30:00
             Safari on iOS - Usado: 2026-01-08 14:20:00
+        """
+        pass
+
+    @abstractmethod
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Devuelve, para cada usuario con al menos un dispositivo registrado,
+        el last_used_at más reciente entre todos sus dispositivos (activos o no).
+
+        Usado por el panel de administración para mostrar la "última conexión"
+        sin añadir una columna dedicada en `users` (se reutiliza el tracking
+        de dispositivos ya existente).
+
+        Args:
+            user_ids: IDs de usuario a consultar (p.ej. la página actual del listado admin)
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> último last_used_at. Usuarios sin
+            dispositivos registrados no aparecen en el dict.
         """
         pass
 

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_device_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_device_repository.py
@@ -5,6 +5,8 @@ Este módulo implementa UserDeviceRepositoryInterface para tests unitarios.
 Los datos se almacenan en diccionarios Python en memoria.
 """
 
+from datetime import datetime
+
 from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.repositories.user_device_repository_interface import (
     UserDeviceRepositoryInterface,
@@ -118,6 +120,27 @@ class InMemoryUserDeviceRepository(UserDeviceRepositoryInterface):
             if device.user_id == user_id and device.is_active
         ]
         return active_devices
+
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Agrega el last_used_at más reciente por usuario entre todos sus dispositivos.
+
+        Args:
+            user_ids: IDs de usuario a consultar
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> última conexión. Usuarios sin
+            dispositivos no aparecen en el dict.
+        """
+        target_ids = {str(uid.value) for uid in user_ids}
+        result: dict[str, datetime] = {}
+        for device in self._devices.values():
+            key = str(device.user_id.value)
+            if key not in target_ids:
+                continue
+            if key not in result or device.last_used_at > result[key]:
+                result[key] = device.last_used_at
+        return result
 
     async def revoke(self, device_id: UserDeviceId) -> None:
         """

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_device_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_device_repository.py
@@ -14,7 +14,9 @@ Responsabilidades:
 Patrón: Repository Pattern + Async SQLAlchemy
 """
 
-from sqlalchemy import select
+from datetime import datetime
+
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.user.domain.entities.user_device import UserDevice
@@ -188,6 +190,31 @@ class SQLAlchemyUserDeviceRepository(UserDeviceRepositoryInterface):
         )
         result = await self._session.execute(statement)
         return list(result.scalars().all())
+
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Agrega MAX(last_used_at) por usuario entre todos sus dispositivos.
+
+        No filtra por is_active: un dispositivo revocado sigue reflejando
+        una conexión real pasada.
+
+        Args:
+            user_ids: IDs de usuario a consultar
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> última conexión. Usuarios sin
+            dispositivos no aparecen en el dict.
+        """
+        if not user_ids:
+            return {}
+
+        statement = (
+            select(UserDevice._user_id, func.max(UserDevice._last_used_at))  # type: ignore[call-overload]
+            .where(UserDevice._user_id.in_(user_ids))
+            .group_by(UserDevice._user_id)
+        )
+        result = await self._session.execute(statement)
+        return {str(user_id): last_used_at for user_id, last_used_at in result.all()}
 
     async def revoke(self, device_id: UserDeviceId) -> None:
         """

--- a/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
@@ -1,5 +1,7 @@
 """Tests para AdminListUsersUseCase."""
 
+from datetime import datetime, timedelta
+
 import pytest
 
 from src.modules.user.application.dto.admin_dto import AdminListUsersRequestDTO
@@ -7,6 +9,8 @@ from src.modules.user.application.use_cases.admin_list_users_use_case import (
     AdminListUsersUseCase,
 )
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.entities.user_device import UserDevice
+from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -96,3 +100,48 @@ class TestAdminListUsersUseCase:
 
         assert response.total_count == 1
         assert response.users[0].email == "unverified@test.com"
+
+    async def test_last_login_at_is_max_last_used_at_across_devices(self, uow):
+        user = await self._create_user(uow, "Con", "Dispositivos", "devices@test.com")
+        older = datetime.now() - timedelta(days=5)
+        newer = datetime.now() - timedelta(hours=1)
+        async with uow:
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=user.id,
+                    device_name="Chrome on macOS",
+                    user_agent="ua-1",
+                    ip_address="1.1.1.1",
+                    fingerprint_hash="hash-1",
+                    is_active=True,
+                    last_used_at=older,
+                    created_at=older,
+                )
+            )
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=user.id,
+                    device_name="Safari on iOS",
+                    user_agent="ua-2",
+                    ip_address="1.1.1.2",
+                    fingerprint_hash="hash-2",
+                    is_active=False,
+                    last_used_at=newer,
+                    created_at=older,
+                )
+            )
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="devices@test.com"))
+
+        assert response.users[0].last_login_at == newer
+
+    async def test_last_login_at_is_none_without_devices(self, uow):
+        await self._create_user(uow, "Sin", "Dispositivos", "nodevice@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="nodevice@test.com"))
+
+        assert response.users[0].last_login_at is None

--- a/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
@@ -1,5 +1,7 @@
 """Tests para AdminUpdateUserUseCase."""
 
+from datetime import datetime
+
 import pytest
 
 from src.modules.user.application.dto.admin_dto import AdminUpdateUserRequestDTO
@@ -7,7 +9,9 @@ from src.modules.user.application.use_cases.admin_update_user_use_case import (
     AdminUpdateUserUseCase,
 )
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -58,6 +62,37 @@ class TestAdminUpdateUserUseCase:
         )
 
         assert result.email == "new-email@test.com"
+
+    async def test_response_preserves_last_login_at(self, uow, existing_user):
+        """
+        Regression test: la respuesta de PUT /admin/users/{id} usaba el mismo
+        AdminUserSummaryDTO que el listado, pero olvidaba rellenar last_login_at
+        (quedaba siempre None) — el frontend lo pisaba con "Nunca" tras cualquier
+        edicion, aunque el usuario si tuviera una conexion registrada.
+        """
+        last_used_at = datetime(2026, 7, 30, 10, 0, 0)
+        async with uow:
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=existing_user.id,
+                    device_name="Chrome on macOS",
+                    user_agent="ua-1",
+                    ip_address="1.1.1.1",
+                    fingerprint_hash="hash-1",
+                    is_active=True,
+                    last_used_at=last_used_at,
+                    created_at=last_used_at,
+                )
+            )
+
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(first_name="Carlitos"),
+        )
+
+        assert result.last_login_at == last_used_at
 
     async def test_raises_when_user_not_found(self, uow):
         from uuid import uuid4


### PR DESCRIPTION
## Summary
- Adds `last_login_at` to the admin panel user list, reusing the existing device-fingerprinting `last_used_at` tracking instead of a new column/migration.
- New `UserDeviceRepositoryInterface.find_last_login_map(user_ids)` aggregates `MAX(last_used_at)` per user (SQLAlchemy + in-memory implementations).
- `AdminListUsersUseCase` attaches it to `AdminUserSummaryDTO.last_login_at` (nullable — users without any tracked device get `None`).

Supports the Competitions tab admin panel work on the frontend (RyderCupWeb #282), which bundles this field into the same Users tab.

## Test plan
- [x] `pytest tests/unit/ -q -n auto` — 2321 passed
- [x] `ruff check` on touched files — clean
- [x] `mypy --ignore-missing-imports` on touched files — clean
- [ ] CI green (unit + integration + lint + type + Snyk)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin user listings now display each user’s most recent login time.
  * Users without registered devices show no login timestamp.
  * Login activity is calculated across both active and inactive devices.

* **Tests**
  * Added coverage for latest login selection and users without device activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->