### PR TITLE
feat(quick-match): Allow a participant to hide a quick match from their own history

### DIFF
--- a/alembic/versions/2a33bf8e43ff_add_hidden_by_participant_ids_to_quick_.py
+++ b/alembic/versions/2a33bf8e43ff_add_hidden_by_participant_ids_to_quick_.py
@@ -1,0 +1,38 @@
+"""Add hidden_by_participant_ids to quick_matches
+
+Revision ID: 2a33bf8e43ff
+Revises: f3a9c2e7b1d4
+Create Date: 2026-08-02 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2a33bf8e43ff"
+down_revision = "f3a9c2e7b1d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Lista (JSONB) de ParticipantId que han ocultado la partida de su propio
+    # historial — reemplaza el borrado fisico originalmente planteado en #127:
+    # un participante deja de verla en /quick-matches/me sin afectar al resto
+    # ni borrar ningun dato.
+    op.add_column(
+        "quick_matches",
+        sa.Column(
+            "hidden_by_participant_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("quick_matches", "hidden_by_participant_ids")

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -217,6 +217,9 @@ from src.modules.quick_match.application.use_cases.create_quick_match_use_case i
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
 )
@@ -234,6 +237,9 @@ from src.modules.quick_match.application.use_cases.submit_hole_score_use_case im
 )
 from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
     SubmitProxyHoleScoreUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -1230,6 +1236,22 @@ def get_remove_quick_match_participant_use_case(
 ) -> RemoveParticipantUseCase:
     """Proveedor del caso de uso RemoveParticipantUseCase."""
     return RemoveParticipantUseCase(uow, user_uow)
+
+
+def get_hide_quick_match_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> HideQuickMatchUseCase:
+    """Proveedor del caso de uso HideQuickMatchUseCase."""
+    return HideQuickMatchUseCase(uow, user_uow)
+
+
+def get_unhide_quick_match_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> UnhideQuickMatchUseCase:
+    """Proveedor del caso de uso UnhideQuickMatchUseCase."""
+    return UnhideQuickMatchUseCase(uow, user_uow)
 
 
 def get_set_quick_match_participant_handicap_use_case(

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -105,6 +105,13 @@ class RemoveParticipantRequestDTO(BaseModel):
     target_participant_id: UUID
 
 
+class HideQuickMatchRequestDTO(BaseModel):
+    """DTO para ocultar/mostrar una partida rapida del propio historial (siempre self-scoped)."""
+
+    quick_match_id: UUID
+    requester_id: UUID
+
+
 class StartQuickMatchRequestDTO(BaseModel):
     """DTO para iniciar la partida, configurando quien anota (1 a 4 anotadores)."""
 

--- a/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
@@ -1,0 +1,47 @@
+"""Caso de Uso: Ocultar una partida rapida del propio historial."""
+
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
+    QuickMatchResponseDTO,
+)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class HideQuickMatchUseCase:
+    """
+    Oculta una partida rapida del historial del propio solicitante.
+
+    Siempre self-scoped: cualquier participante (no solo el creador) puede
+    ocultarla, y solo afecta a su propia vista (`GET /quick-matches/me`) —
+    el resto de participantes la siguen viendo con normalidad.
+    """
+
+    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
+        requester_id = UserId(request.requester_id)
+        requester_participant_id = ParticipantId(requester_id.value)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
+                QuickMatchId(request.quick_match_id)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
+
+            quick_match.hide_for(requester_participant_id)
+            await self._uow.quick_matches.update(quick_match)
+
+        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
@@ -1,0 +1,41 @@
+"""Caso de Uso: Volver a mostrar una partida rapida ocultada del propio historial."""
+
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
+    QuickMatchResponseDTO,
+)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class UnhideQuickMatchUseCase:
+    """Contrario de HideQuickMatchUseCase: vuelve a mostrar la partida en el historial propio."""
+
+    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
+        requester_id = UserId(request.requester_id)
+        requester_participant_id = ParticipantId(requester_id.value)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
+                QuickMatchId(request.quick_match_id)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
+
+            quick_match.unhide_for(requester_participant_id)
+            await self._uow.quick_matches.update(quick_match)
+
+        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -18,12 +18,14 @@ from src.shared.domain.value_objects.gender import Gender
 from ..events.quick_match_cancelled_event import QuickMatchCancelledEvent
 from ..events.quick_match_completed_event import QuickMatchCompletedEvent
 from ..events.quick_match_created_event import QuickMatchCreatedEvent
+from ..events.quick_match_hidden_event import QuickMatchHiddenEvent
 from ..events.quick_match_participant_added_event import QuickMatchParticipantAddedEvent
 from ..events.quick_match_participant_handicap_updated_event import (
     QuickMatchParticipantHandicapUpdatedEvent,
 )
 from ..events.quick_match_participant_removed_event import QuickMatchParticipantRemovedEvent
 from ..events.quick_match_started_event import QuickMatchStartedEvent
+from ..events.quick_match_unhidden_event import QuickMatchUnhiddenEvent
 from ..exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
     DuplicateParticipantViolation,
@@ -83,6 +85,7 @@ class QuickMatch:
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
         scorer_ids: list[ParticipantId] | None = None,
+        hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
@@ -99,6 +102,9 @@ class QuickMatch:
         self._participants = list(participants)
         self._name = self._validate_name(name)
         self._scorer_ids = list(scorer_ids) if scorer_ids else []
+        self._hidden_by_participant_ids = (
+            list(hidden_by_participant_ids) if hidden_by_participant_ids else []
+        )
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
         self._domain_events: list[DomainEvent] = domain_events or []
@@ -218,6 +224,7 @@ class QuickMatch:
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
         scorer_ids: list[ParticipantId] | None = None,
+        hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ) -> "QuickMatch":
@@ -233,6 +240,7 @@ class QuickMatch:
             participants=participants,
             name=name,
             scorer_ids=scorer_ids,
+            hidden_by_participant_ids=hidden_by_participant_ids,
             created_at=created_at,
             updated_at=updated_at,
         )
@@ -307,6 +315,11 @@ class QuickMatch:
         return list(self._scorer_ids)
 
     @property
+    def hidden_by_participant_ids(self) -> list[ParticipantId]:
+        """Participantes que han ocultado esta partida de su propio historial."""
+        return list(self._hidden_by_participant_ids)
+
+    @property
     def created_at(self) -> datetime:
         return self._created_at
 
@@ -329,6 +342,9 @@ class QuickMatch:
 
     def is_scorer(self, participant_id: ParticipantId) -> bool:
         return participant_id in self._scorer_ids
+
+    def is_hidden_for(self, participant_id: ParticipantId) -> bool:
+        return participant_id in self._hidden_by_participant_ids
 
     def capacity(self) -> int:
         """Numero maximo de jugadores admitidos por el formato."""
@@ -491,6 +507,52 @@ class QuickMatch:
                 quick_match_id=str(self._id),
                 participant_id=str(participant_id),
                 handicap=handicap,
+            )
+        )
+
+    def hide_for(self, participant_id: ParticipantId) -> None:
+        """
+        Oculta la partida del historial personal de un participante.
+
+        No requiere ningun estado concreto de la partida (a diferencia de
+        add/remove_participant): un participante puede ocultar una partida
+        PENDING, IN_PROGRESS, COMPLETED o CANCELLED por igual. No afecta al
+        resto de participantes ni borra ningun dato — es puramente personal.
+        Idempotente: ocultar dos veces no es un error.
+        """
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if participant_id in self._hidden_by_participant_ids:
+            return
+
+        self._hidden_by_participant_ids = [*self._hidden_by_participant_ids, participant_id]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchHiddenEvent(quick_match_id=str(self._id), participant_id=str(participant_id))
+        )
+
+    def unhide_for(self, participant_id: ParticipantId) -> None:
+        """Vuelve a mostrar la partida en el historial personal de un participante. Idempotente."""
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if participant_id not in self._hidden_by_participant_ids:
+            return
+
+        self._hidden_by_participant_ids = [
+            pid for pid in self._hidden_by_participant_ids if pid != participant_id
+        ]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchUnhiddenEvent(
+                quick_match_id=str(self._id), participant_id=str(participant_id)
             )
         )
 

--- a/src/modules/quick_match/domain/events/quick_match_hidden_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_hidden_event.py
@@ -1,0 +1,13 @@
+"""QuickMatchHiddenEvent - Se emite cuando un participante oculta la partida de su historial."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchHiddenEvent(DomainEvent):
+    """Evento emitido cuando un participante oculta una partida rapida de su propio historial."""
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/events/quick_match_unhidden_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_unhidden_event.py
@@ -1,0 +1,13 @@
+"""QuickMatchUnhiddenEvent - Se emite cuando un participante vuelve a mostrar la partida."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchUnhiddenEvent(DomainEvent):
+    """Evento emitido cuando un participante deja de ocultar una partida rapida de su historial."""
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -19,12 +19,14 @@ from src.config.dependencies import (
     get_create_quick_match_use_case,
     get_current_user,
     get_get_quick_match_use_case,
+    get_hide_quick_match_use_case,
     get_list_my_quick_matches_use_case,
     get_remove_quick_match_participant_use_case,
     get_set_quick_match_participant_handicap_use_case,
     get_start_quick_match_use_case,
     get_submit_quick_match_hole_score_use_case,
     get_submit_quick_match_proxy_hole_score_use_case,
+    get_unhide_quick_match_use_case,
 )
 from src.config.rate_limit import limiter
 from src.modules.quick_match.application.dto.quick_match_dto import (
@@ -35,6 +37,7 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     AddGuestParticipantRequestDTO,
     AddParticipantRequestDTO,
     CreateQuickMatchRequestDTO,
+    HideQuickMatchRequestDTO,
     HoleScoreResponseDTO,
     PaginatedQuickMatchResponseDTO,
     QuickMatchDetailResponseDTO,
@@ -76,6 +79,9 @@ from src.modules.quick_match.application.use_cases.create_quick_match_use_case i
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
 )
@@ -93,6 +99,9 @@ from src.modules.quick_match.application.use_cases.submit_hole_score_use_case im
 )
 from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
     SubmitProxyHoleScoreUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
 )
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
@@ -368,6 +377,59 @@ async def remove_participant(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.post(
+    "/quick-matches/{quick_match_id}/hide",
+    response_model=QuickMatchResponseDTO,
+    summary="Hide quick match from my history",
+    description=(
+        "Hides the quick match from the caller's own /quick-matches/me list, without "
+        "affecting what other participants see or deleting any data. Any participant "
+        "(not just the creator) can hide it for themselves, in any match status. "
+        "Idempotent."
+    ),
+)
+async def hide_quick_match(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: HideQuickMatchUseCase = Depends(get_hide_quick_match_use_case),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.delete(
+    "/quick-matches/{quick_match_id}/hide",
+    response_model=QuickMatchResponseDTO,
+    summary="Unhide quick match from my history",
+    description="Reverses hide_quick_match: the match shows up again in the caller's own list. Idempotent.",
+)
+async def unhide_quick_match(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: UnhideQuickMatchUseCase = Depends(get_unhide_quick_match_use_case),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
 @router.patch(

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -29,6 +29,16 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
     async def find_by_id_for_update(self, quick_match_id: QuickMatchId) -> QuickMatch | None:
         return self._quick_matches.get(quick_match_id)
 
+    def _matches_user(
+        self, qm: QuickMatch, user_id: UserId, status: QuickMatchStatus | None
+    ) -> bool:
+        participant_id = ParticipantId(user_id.value)
+        return (
+            qm.is_participant(participant_id)
+            and not qm.is_hidden_for(participant_id)
+            and (status is None or qm.status == status)
+        )
+
     async def list_for_user(
         self,
         user_id: UserId,
@@ -37,9 +47,7 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         offset: int = 0,
     ) -> list[QuickMatch]:
         results = [
-            qm
-            for qm in self._quick_matches.values()
-            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
+            qm for qm in self._quick_matches.values() if self._matches_user(qm, user_id, status)
         ]
         results.sort(key=lambda x: x.created_at, reverse=True)
         return results[offset : offset + limit]
@@ -48,9 +56,7 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
         return sum(
-            1
-            for qm in self._quick_matches.values()
-            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
+            1 for qm in self._quick_matches.values() if self._matches_user(qm, user_id, status)
         )
 
     async def count_all(self) -> int:

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -251,7 +251,12 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
 
 
 class ScorerIdsJsonType(sqlalchemy.types.TypeDecorator[list]):
-    """TypeDecorator para serializar list[ParticipantId] (scorer_ids) a/desde JSONB."""
+    """
+    TypeDecorator para serializar list[ParticipantId] a/desde JSONB.
+
+    Generico: se reutiliza tanto para `scorer_ids` como para
+    `hidden_by_participant_ids` (misma forma, listas de ParticipantId).
+    """
 
     impl = JSONB
     cache_ok = True
@@ -294,6 +299,7 @@ quick_matches_table = Table(
     Column("allowance_percentage", Integer, nullable=True),
     Column("participants", QuickMatchParticipantsJsonType, nullable=False),
     Column("scorer_ids", ScorerIdsJsonType, nullable=False, default=list),
+    Column("hidden_by_participant_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
     CheckConstraint(
@@ -348,6 +354,7 @@ def start_quick_match_mappers() -> None:
                 "_allowance_percentage": quick_matches_table.c.allowance_percentage,
                 "_participants": quick_matches_table.c.participants,
                 "_scorer_ids": quick_matches_table.c.scorer_ids,
+                "_hidden_by_participant_ids": quick_matches_table.c.hidden_by_participant_ids,
                 "_created_at": quick_matches_table.c.created_at,
                 "_updated_at": quick_matches_table.c.updated_at,
             },

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -48,6 +48,12 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
             cast([{"user_id": str(user_id.value)}], JSONB)
         )
 
+    def _not_hidden_filter(self, user_id: UserId):
+        """Excluye partidas que el propio usuario ha ocultado de su historial (ver hide_for())."""
+        return ~quick_matches_table.c.hidden_by_participant_ids.op("@>")(
+            cast([str(user_id.value)], JSONB)
+        )
+
     async def list_for_user(
         self,
         user_id: UserId,
@@ -55,7 +61,7 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
         limit: int = 20,
         offset: int = 0,
     ) -> list[QuickMatch]:
-        conditions = [self._participant_filter(user_id)]
+        conditions = [self._participant_filter(user_id), self._not_hidden_filter(user_id)]
         if status is not None:
             conditions.append(QuickMatch._status == status)
 
@@ -72,7 +78,7 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
     async def count_for_user(
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
-        conditions = [self._participant_filter(user_id)]
+        conditions = [self._participant_filter(user_id), self._not_hidden_filter(user_id)]
         if status is not None:
             conditions.append(QuickMatch._status == status)
 

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -928,3 +928,127 @@ class TestQuickMatchSetParticipantHandicap:
         )
 
         assert response.status_code == 422
+
+
+class TestQuickMatchHideFromHistory:
+    """Tests para POST/DELETE /api/v1/quick-matches/{id}/hide (RyderCupAm#127)."""
+
+    async def _create_match_with_two_participants(
+        self, client: AsyncClient
+    ) -> tuple[dict, dict, dict, str]:
+        admin = await create_admin_user(
+            client, "qm_admin_hide1@test.com", "P@ssw0rd123!", "Admin", "HideOne"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hide1@test.com", "P@ssw0rd123!", "Creator", "HideOne"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_hide1@test.com", "P@ssw0rd123!", "Friend", "HideOne"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+
+        return admin, creator, friend, quick_match_id
+
+    @pytest.mark.asyncio
+    async def test_hide_removes_it_from_my_list_but_not_from_the_other_participant(
+        self, client: AsyncClient
+    ):
+        _admin, creator, friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        hide_response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        assert hide_response.status_code == 200, hide_response.text
+
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id not in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+        # El otro participante, que no la ha ocultado, la sigue viendo.
+        set_auth_cookies(client, friend["cookies"])
+        friend_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id in [m["id"] for m in friend_matches.json()["quick_matches"]]
+
+        # Tampoco se ha borrado ni afectado el registro en si.
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        assert detail_response.status_code == 200
+        assert len(detail_response.json()["participants"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_creator_participant_can_hide_it_too(self, client: AsyncClient):
+        _admin, _creator, friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, friend["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert response.status_code == 200, response.text
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id not in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+    @pytest.mark.asyncio
+    async def test_hide_is_idempotent(self, client: AsyncClient):
+        _admin, creator, _friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        first = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        second = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_unhide_brings_it_back_to_my_list(self, client: AsyncClient):
+        _admin, creator, _friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+        set_auth_cookies(client, creator["cookies"])
+        await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        unhide_response = await client.delete(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        assert unhide_response.status_code == 200, unhide_response.text
+
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+    @pytest.mark.asyncio
+    async def test_hide_a_non_participant_match_returns_404(self, client: AsyncClient):
+        _admin, _creator, _friend, quick_match_id = (
+            await self._create_match_with_two_participants(client)
+        )
+        outsider = await create_authenticated_user(
+            client, "qm_outsider_hide1@test.com", "P@ssw0rd123!", "Outsider", "HideOne"
+        )
+
+        set_auth_cookies(client, outsider["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_hide_nonexistent_match_returns_404(self, client: AsyncClient):
+        creator = await create_authenticated_user(
+            client, "qm_creator_hide2@test.com", "P@ssw0rd123!", "Creator", "HideTwo"
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        response = await client.post(
+            "/api/v1/quick-matches/00000000-0000-0000-0000-000000000000/hide"
+        )
+
+        assert response.status_code == 404

--- a/tests/unit/modules/quick_match/application/use_cases/test_hide_unhide_quick_match_use_cases.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_hide_unhide_quick_match_use_cases.py
@@ -1,0 +1,99 @@
+"""Tests para HideQuickMatchUseCase y UnhideQuickMatchUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import HideQuickMatchRequestDTO
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_pending_match_with_participant(qm_uow, creator_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    other = QuickMatchParticipant.for_user(UserId(uuid4()))
+    qm.add_participant(other)
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm, other
+
+
+class TestHideQuickMatchUseCase:
+    async def test_creator_can_hide(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_pending_match_with_participant(qm_uow, creator)
+
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_non_creator_participant_can_hide(self, qm_uow, user_uow):
+        """Cualquier participante puede ocultarla, no solo el creador."""
+        creator = UserId(uuid4())
+        qm, other = await _create_pending_match_with_participant(qm_uow, creator)
+
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(
+                quick_match_id=qm.id.value, requester_id=other.user_id.value
+            )
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_hidden_for(other.participant_id)
+        assert not stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=uuid4(), requester_id=uuid4())
+            )
+
+
+class TestUnhideQuickMatchUseCase:
+    async def test_reverses_a_previous_hide(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_pending_match_with_participant(qm_uow, creator)
+        qm.hide_for(qm.creator_participant_id)
+        async with qm_uow:
+            await qm_uow.quick_matches.update(qm)
+
+        use_case = UnhideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert not stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = UnhideQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=uuid4(), requester_id=uuid4())
+            )

--- a/tests/unit/modules/quick_match/application/use_cases/test_list_my_quick_matches_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_list_my_quick_matches_use_case.py
@@ -42,3 +42,30 @@ class TestListMyQuickMatchesUseCase:
 
         assert result.total_count == 1
         assert result.quick_matches[0].id == mine.id.value
+
+    async def test_excludes_matches_the_user_has_hidden(self, qm_uow, user_uow):
+        """Ver RyderCupAm#127: ocultar una partida la saca del listado propio (no un borrado)."""
+        me = await create_user(user_uow, "me-hides@test.com")
+
+        visible = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=me.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.SINGLES,
+        )
+        hidden = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=me.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.SINGLES,
+        )
+        hidden.hide_for(hidden.creator_participant_id)
+        async with qm_uow:
+            await qm_uow.quick_matches.add(visible)
+            await qm_uow.quick_matches.add(hidden)
+
+        use_case = ListMyQuickMatchesUseCase(qm_uow, user_uow)
+        result = await use_case.execute(str(me.id.value))
+
+        assert result.total_count == 1
+        assert result.quick_matches[0].id == visible.id.value

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -16,6 +16,9 @@ from src.modules.quick_match.domain.events.quick_match_completed_event import (
 from src.modules.quick_match.domain.events.quick_match_created_event import (
     QuickMatchCreatedEvent,
 )
+from src.modules.quick_match.domain.events.quick_match_hidden_event import (
+    QuickMatchHiddenEvent,
+)
 from src.modules.quick_match.domain.events.quick_match_participant_added_event import (
     QuickMatchParticipantAddedEvent,
 )
@@ -27,6 +30,9 @@ from src.modules.quick_match.domain.events.quick_match_participant_removed_event
 )
 from src.modules.quick_match.domain.events.quick_match_started_event import (
     QuickMatchStartedEvent,
+)
+from src.modules.quick_match.domain.events.quick_match_unhidden_event import (
+    QuickMatchUnhiddenEvent,
 )
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
@@ -266,6 +272,93 @@ class TestQuickMatchRemoveParticipant:
         qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
             qm.remove_participant(other.participant_id)
+
+
+class TestQuickMatchHideForHistory:
+    def test_hide_for_creator_succeeds(self):
+        qm = _make_quick_match()
+        qm.clear_domain_events()
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchHiddenEvent)
+
+    def test_hide_for_non_creator_participant_succeeds(self):
+        """Cualquier participante puede ocultar la partida, no solo el creador."""
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+
+        qm.hide_for(other.participant_id)
+
+        assert qm.is_hidden_for(other.participant_id)
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+
+    def test_hide_for_non_participant_raises(self):
+        qm = _make_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.hide_for(ParticipantId.generate())
+
+    def test_hide_for_is_idempotent(self):
+        qm = _make_quick_match()
+        qm.hide_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_hide_does_not_require_pending_status(self):
+        """A diferencia de add/remove_participant, ocultar no depende del estado."""
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        qm.start([qm.creator_participant_id])
+
+        qm.hide_for(other.participant_id)
+
+        assert qm.is_hidden_for(other.participant_id)
+
+    def test_unhide_for_reverses_hide(self):
+        qm = _make_quick_match()
+        qm.hide_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.unhide_for(qm.creator_participant_id)
+
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchUnhiddenEvent)
+
+    def test_unhide_for_non_participant_raises(self):
+        qm = _make_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.unhide_for(ParticipantId.generate())
+
+    def test_unhide_for_is_idempotent(self):
+        qm = _make_quick_match()
+        qm.clear_domain_events()
+
+        qm.unhide_for(qm.creator_participant_id)
+
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_hiding_does_not_affect_other_participants(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        assert not qm.is_hidden_for(other.participant_id)
+        assert qm.is_participant(qm.creator_participant_id)  # sigue siendo participante
 
 
 class TestQuickMatchSetParticipantHandicap:


### PR DESCRIPTION
## Summary
- Replaces the originally planned physical `DELETE /quick-matches/{id}` (#127) with a per-participant hide/unhide, decided during scoping: deleting a record shared between several participants because one of them wants it out of their own history was wrong — it would remove it for everyone.
- Any participant (not just the creator) can hide/unhide a quick match from their own `GET /quick-matches/me` list, in any match status (PENDING/IN_PROGRESS/COMPLETED/CANCELLED). No data is touched — scores, roster, and the match itself stay intact for every other participant.
- New `hidden_by_participant_ids` JSONB column on `quick_matches` (migration `2a33bf8e43ff`), reusing the existing `list[ParticipantId]` TypeDecorator already used for `scorer_ids`.
- `POST /api/v1/quick-matches/{id}/hide` / `DELETE .../hide` — idempotent, 404 if the caller isn't a participant.
- `GET /quick-matches/me` filters out matches hidden by the calling participant (both SQLAlchemy and in-memory repos).

Closes #127. Sets up the exclusion criterion already noted in #128 (a player's own hidden matches shouldn't count in their own aggregated stats, but still count for other participants who haven't hidden them).

## Test plan
- [x] `pytest tests/unit/ -q -n auto` — 2334 passed
- [x] `pytest tests/integration/api/v1/test_quick_match_endpoints.py -q` — 33 passed (6 new: hide/unhide flow, non-creator can hide, idempotency, unhide, 404s)
- [x] `ruff check` on touched files — clean (5 pre-existing unrelated `noqa` warnings elsewhere in the integration test file, untouched by this PR)
- [x] `mypy --ignore-missing-imports` — clean
- [x] `alembic heads` — single head, migration chains cleanly on top of `f3a9c2e7b1d4`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participants can hide quick matches from their personal history.
  * Hidden matches can be restored at any time.
  * Hiding is participant-specific, preserves the match for others, and is safely repeatable.
  * Non-participants receive an appropriate not-found response.

* **Bug Fixes**
  * Personal quick-match lists now exclude matches hidden by the requesting participant.

* **Tests**
  * Added coverage for hiding, restoring, visibility isolation, validation, and repeat actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->