### PR TITLE
chore(release): Prepare v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Email de notificación al enviar una solicitud de amistad (`ISocialEmailService`/`send_friend_request_email`), siguiendo el mismo patrón que las invitaciones a competición. Envío no bloqueante: un fallo de Mailgun no impide crear la solicitud.
+- **Panel de administración — gestión de usuarios y estadísticas** (issue FE #233, mitad backend): nuevos endpoints `/api/v1/admin/*` (solo Admin, vía `require_admin()`):
+  - `GET /admin/stats`: usuarios registrados, torneos creados, partidas rápidas y campos de golf (aprobados/pendientes).
+  - `GET /admin/users`: listado paginado con búsqueda (nombre/apellidos/email) y filtros por rol, estado y verificación.
+  - `PUT /admin/users/{id}`: editar nombre, email, hándicap, país y rol de administrador.
+  - `PUT /admin/users/{id}/active`: desactivar/reactivar una cuenta (bloquea el login, reversible, no toca ningún dato).
+  - `DELETE /admin/users/{id}`: borrado definitivo, bloqueado (409) si la cuenta ha creado torneos/partidas rápidas, solicitado campos de golf, o tiene scores registrados — evita borrar en cascada datos de otros usuarios o romper una restricción de base de datos.
+  - Un admin no puede desactivar (400) ni borrar (400) su propia cuenta, evitando quedarse sin acceso al panel si es el único administrador.
+  - Nuevo campo `User.is_active` (migración `f3a9c2e7b1d4`), con eventos de dominio `AccountDeactivatedEvent`/`AccountReactivatedEvent`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Email de notificación al enviar una solicitud de amistad (`ISocialEmailService`/`send_friend_request_email`), siguiendo el mismo patrón que las invitaciones a competición. Envío no bloqueante: un fallo de Mailgun no impide crear la solicitud.
+
+### Changed
+
+- Extraído `mask_email()` (enmascarado de emails para logs de seguridad) a `src/shared/infrastructure/security/email_masking.py`, reemplazando 3 copias idénticas/divergentes en los módulos Competition y Social.
+
 ## [2.3.1] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-02
+
 ### Added
 
 - Email de notificación al enviar una solicitud de amistad (`ISocialEmailService`/`send_friend_request_email`), siguiendo el mismo patrón que las invitaciones a competición. Envío no bloqueante: un fallo de Mailgun no impide crear la solicitud.
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `DELETE /admin/users/{id}`: borrado definitivo, bloqueado (409) si la cuenta ha creado torneos/partidas rápidas, solicitado campos de golf, o tiene scores registrados — evita borrar en cascada datos de otros usuarios o romper una restricción de base de datos.
   - Un admin no puede desactivar (400) ni borrar (400) su propia cuenta, evitando quedarse sin acceso al panel si es el único administrador.
   - Nuevo campo `User.is_active` (migración `f3a9c2e7b1d4`), con eventos de dominio `AccountDeactivatedEvent`/`AccountReactivatedEvent`.
+- **Última conexión en el listado de usuarios del panel de administración**: nuevo campo `last_login_at` en `GET /admin/users` y `PUT /admin/users/{id}`, reutilizando el tracking de device fingerprinting ya existente (`MAX(last_used_at)` por usuario vía `UserDeviceRepositoryInterface.find_last_login_map()`) — sin migración ni columna nueva. `null` para usuarios sin ningún dispositivo registrado.
+- **Ocultar una partida rápida del propio historial** (sustituye el borrado físico planteado originalmente en #127): nuevos endpoints `POST`/`DELETE /api/v1/quick-matches/{id}/hide`. Cualquier participante (no solo el creador) puede excluir una partida de su propio `GET /quick-matches/me`, en cualquier estado, sin afectar lo que ven los demás participantes ni borrar ningún dato (scores, roster, etc.). Nuevo campo `hidden_by_participant_ids` en `QuickMatch` (migración `2a33bf8e43ff`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Extraído `mask_email()` (enmascarado de emails para logs de seguridad) a `src/shared/infrastructure/security/email_masking.py`, reemplazando 3 copias idénticas/divergentes en los módulos Competition y Social.
+- `EmailService`: los métodos async (`send_password_reset_email`, `send_password_changed_notification`, `send_invitation_email`, `send_friend_request_email`) ya no bloquean el event loop mientras esperan a Mailgun — el envío síncrono ahora se despacha vía `asyncio.to_thread`. Issue de deuda técnica para migrar a un cliente HTTP async de verdad: #148.
+
+### Fixed
+
+- `mask_email()` no enmascaraba correctamente emails con dominio vacío (ej. `"alice@"`), devolviendo `"a***@"` en vez de `"***"`.
 
 ## [2.3.1] - 2026-08-01
 

--- a/alembic/versions/2a33bf8e43ff_add_hidden_by_participant_ids_to_quick_.py
+++ b/alembic/versions/2a33bf8e43ff_add_hidden_by_participant_ids_to_quick_.py
@@ -1,0 +1,38 @@
+"""Add hidden_by_participant_ids to quick_matches
+
+Revision ID: 2a33bf8e43ff
+Revises: f3a9c2e7b1d4
+Create Date: 2026-08-02 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2a33bf8e43ff"
+down_revision = "f3a9c2e7b1d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Lista (JSONB) de ParticipantId que han ocultado la partida de su propio
+    # historial — reemplaza el borrado fisico originalmente planteado en #127:
+    # un participante deja de verla en /quick-matches/me sin afectar al resto
+    # ni borrar ningun dato.
+    op.add_column(
+        "quick_matches",
+        sa.Column(
+            "hidden_by_participant_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("quick_matches", "hidden_by_participant_ids")

--- a/alembic/versions/f3a9c2e7b1d4_add_is_active_field_to_users_table.py
+++ b/alembic/versions/f3a9c2e7b1d4_add_is_active_field_to_users_table.py
@@ -1,0 +1,56 @@
+"""add is_active field to users table
+
+Revision ID: f3a9c2e7b1d4
+Revises: 5e13a3225101
+Create Date: 2026-08-02 10:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'f3a9c2e7b1d4'
+down_revision: str | None = '5e13a3225101'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Añade campo is_active a la tabla users para el panel de administración.
+
+    Campo añadido:
+    - is_active: Flag booleano que indica si la cuenta está activa. Un admin
+      puede desactivar una cuenta (bloquea login, conserva todos los datos)
+      desde el panel de administración.
+
+    Default: TRUE (todos los usuarios existentes quedan activos).
+    """
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+            comment="Cuenta activa (FALSE si un admin la desactivó desde el panel)",
+        ),
+    )
+
+    # Partial index: solo indexar cuentas desactivadas (caso poco frecuente)
+    # para acelerar el listado "usuarios desactivados" en el panel de admin.
+    op.create_index(
+        "ix_users_is_active_false",
+        "users",
+        ["is_active"],
+        postgresql_where=sa.text("is_active = FALSE"),
+    )
+
+
+def downgrade() -> None:
+    """Elimina el campo is_active de la tabla users."""
+    op.drop_index("ix_users_is_active_false", table_name="users")
+    op.drop_column("users", "is_active")

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ from src.modules.user.application.use_cases.upload_avatar_use_case import (  # n
     MAX_UPLOAD_BYTES,
 )
 from src.modules.user.infrastructure.api.v1 import (  # noqa: E402
+    admin_routes,
     auth_routes,
     avatar_routes,
     device_routes,
@@ -344,6 +345,12 @@ app.include_router(
     user_routes.router,
     prefix="/api/v1/users",
     tags=["Users"],
+)
+
+app.include_router(
+    admin_routes.router,
+    prefix="/api/v1/admin",
+    tags=["Admin"],
 )
 
 app.include_router(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -217,6 +217,9 @@ from src.modules.quick_match.application.use_cases.create_quick_match_use_case i
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
 )
@@ -234,6 +237,9 @@ from src.modules.quick_match.application.use_cases.submit_hole_score_use_case im
 )
 from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
     SubmitProxyHoleScoreUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -1230,6 +1236,22 @@ def get_remove_quick_match_participant_use_case(
 ) -> RemoveParticipantUseCase:
     """Proveedor del caso de uso RemoveParticipantUseCase."""
     return RemoveParticipantUseCase(uow, user_uow)
+
+
+def get_hide_quick_match_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> HideQuickMatchUseCase:
+    """Proveedor del caso de uso HideQuickMatchUseCase."""
+    return HideQuickMatchUseCase(uow, user_uow)
+
+
+def get_unhide_quick_match_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> UnhideQuickMatchUseCase:
+    """Proveedor del caso de uso UnhideQuickMatchUseCase."""
+    return UnhideQuickMatchUseCase(uow, user_uow)
 
 
 def get_set_quick_match_participant_handicap_use_case(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -284,7 +284,22 @@ from src.modules.user.application.ports.token_service_interface import ITokenSer
 from src.modules.user.application.use_cases.activate_uploaded_avatar_use_case import (
     ActivateUploadedAvatarUseCase,
 )
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
 from src.modules.user.application.use_cases.find_user_use_case import FindUserUseCase
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
 from src.modules.user.application.use_cases.get_avatar_image_use_case import (
     GetAvatarImageUseCase,
 )
@@ -1133,6 +1148,52 @@ def get_quick_match_uow(
     3. Devuelve la instancia, cumpliendo con la interfaz `QuickMatchUnitOfWorkInterface`.
     """
     return SQLAlchemyQuickMatchUnitOfWork(session)
+
+
+# ======================================================================================
+# ADMIN PANEL USE CASE PROVIDERS
+# ======================================================================================
+
+
+def get_admin_list_users_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminListUsersUseCase:
+    """Proveedor del caso de uso AdminListUsersUseCase."""
+    return AdminListUsersUseCase(uow)
+
+
+def get_admin_update_user_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminUpdateUserUseCase:
+    """Proveedor del caso de uso AdminUpdateUserUseCase."""
+    return AdminUpdateUserUseCase(uow)
+
+
+def get_admin_set_user_active_use_case(
+    uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> AdminSetUserActiveUseCase:
+    """Proveedor del caso de uso AdminSetUserActiveUseCase."""
+    return AdminSetUserActiveUseCase(uow)
+
+
+def get_admin_delete_user_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> AdminDeleteUserUseCase:
+    """Proveedor del caso de uso AdminDeleteUserUseCase."""
+    return AdminDeleteUserUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+
+def get_get_admin_stats_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> GetAdminStatsUseCase:
+    """Proveedor del caso de uso GetAdminStatsUseCase."""
+    return GetAdminStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
 
 
 def get_create_quick_match_use_case(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -244,6 +244,9 @@ from src.modules.quick_match.domain.services.scoring_coverage_service import (
 from src.modules.quick_match.infrastructure.persistence.sqlalchemy.quick_match_unit_of_work import (
     SQLAlchemyQuickMatchUnitOfWork,
 )
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.social.application.use_cases.block_user_use_case import BlockUserUseCase
 from src.modules.social.application.use_cases.list_friends_use_case import ListFriendsUseCase
 from src.modules.social.application.use_cases.list_pending_requests_use_case import (
@@ -1065,12 +1068,18 @@ def get_social_uow(
     return SQLAlchemySocialUnitOfWork(session)
 
 
+def get_social_email_service() -> ISocialEmailService:
+    """Proveedor del servicio de email para el modulo Social (amistades)."""
+    return EmailService()
+
+
 def get_send_friend_request_use_case(
     uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    email_service: ISocialEmailService = Depends(get_social_email_service),
 ) -> SendFriendRequestUseCase:
     """Proveedor del caso de uso SendFriendRequestUseCase."""
-    return SendFriendRequestUseCase(uow, user_uow)
+    return SendFriendRequestUseCase(uow, user_uow, email_service)
 
 
 def get_respond_friend_request_use_case(

--- a/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_email_use_case.py
@@ -31,18 +31,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
 
 logger = logging.getLogger(__name__)
-
-
-def _mask_email(email: str) -> str:
-    """Enmascara un email para logging seguro (ej: t***@example.com)."""
-    parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
-        return "***"
-    local = parts[0]
-    masked_local = local[0] + "***" if len(local) > 1 else "***"
-    return f"{masked_local}@{parts[1]}"
 
 
 class SendInvitationByEmailUseCase:

--- a/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
+++ b/src/modules/competition/application/use_cases/send_invitation_by_user_id_use_case.py
@@ -31,18 +31,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
 
 logger = logging.getLogger(__name__)
-
-
-def _mask_email(email: str) -> str:
-    """Enmascara un email para logging seguro (ej: t***@example.com)."""
-    parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
-        return "***"
-    local = parts[0]
-    masked_local = local[0] + "***" if len(local) > 1 else "***"
-    return f"{masked_local}@{parts[1]}"
 
 
 class SendInvitationByUserIdUseCase:

--- a/src/modules/competition/domain/repositories/competition_repository_interface.py
+++ b/src/modules/competition/domain/repositories/competition_repository_interface.py
@@ -209,6 +209,21 @@ class CompetitionRepositoryInterface(ABC):
         pass
 
     @abstractmethod
+    async def count_all(self) -> int:
+        """
+        Cuenta el total de competiciones en el sistema.
+
+        Útil para: Estadísticas del panel de administración.
+
+        Returns:
+            int: Número total de competiciones
+
+        Raises:
+            RepositoryError: Si ocurre un error de consulta
+        """
+        pass
+
+    @abstractmethod
     async def count_by_creator(self, creator_id: UserId) -> int:
         """
         Cuenta el total de competiciones creadas por un usuario.

--- a/src/modules/competition/domain/repositories/hole_score_repository_interface.py
+++ b/src/modules/competition/domain/repositories/hole_score_repository_interface.py
@@ -54,3 +54,14 @@ class HoleScoreRepositoryInterface(ABC):
     async def delete_by_match(self, match_id: MatchId) -> int:
         """Elimina todos los hole scores de un partido. Retorna la cantidad eliminada."""
         pass
+
+    @abstractmethod
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        """
+        True si el jugador tiene algun hole score registrado (en cualquier partido).
+
+        Util para bloquear el borrado definitivo de una cuenta: hole_scores.player_user_id
+        no tiene ON DELETE definido (RESTRICT por defecto en Postgres), asi que borrar a
+        un jugador con historial de scores fallaria con un IntegrityError si no se bloquea antes.
+        """
+        pass

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_competition_repository.py
@@ -88,6 +88,10 @@ class InMemoryCompetitionRepository(CompetitionRepositoryInterface):
         """Retorna todas las competiciones."""
         return list(self._competitions.values())
 
+    async def count_all(self) -> int:
+        """Cuenta el total de competiciones en el sistema."""
+        return len(self._competitions)
+
     async def count_by_creator(self, creator_id: UserId) -> int:
         """Cuenta el total de competiciones creadas por un usuario."""
         return sum(1 for comp in self._competitions.values() if comp.creator_id == creator_id)

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_hole_score_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_hole_score_repository.py
@@ -62,3 +62,6 @@ class InMemoryHoleScoreRepository(HoleScoreRepositoryInterface):
         for hs_id in to_delete:
             del self._scores[hs_id]
         return len(to_delete)
+
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        return any(hs.player_user_id == player_user_id for hs in self._scores.values())

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -268,6 +268,12 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
         result = await self._session.execute(statement)
         return list(result.scalars().all())
 
+    async def count_all(self) -> int:
+        """Cuenta el total de competiciones en el sistema."""
+        statement = select(func.count()).select_from(Competition)
+        result = await self._session.execute(statement)
+        return result.scalar_one()
+
     async def count_by_creator(self, creator_id: UserId) -> int:
         """
         Cuenta el total de competiciones creadas por un usuario.

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/hole_score_repository.py
@@ -1,6 +1,6 @@
 """HoleScore Repository - SQLAlchemy Implementation."""
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.competition.domain.entities.hole_score import HoleScore
 from src.modules.competition.domain.repositories.hole_score_repository_interface import (
@@ -71,3 +71,12 @@ class SQLAlchemyHoleScoreRepository(HoleScoreRepositoryInterface):
         statement = delete(HoleScore).where(HoleScore._match_id == match_id)
         result = await self._session.execute(statement)
         return result.rowcount
+
+    async def exists_by_player(self, player_user_id: UserId) -> bool:
+        statement = (
+            select(func.count())
+            .select_from(HoleScore)
+            .where(HoleScore._player_user_id == player_user_id)
+        )
+        result = await self._session.execute(statement)
+        return result.scalar_one() > 0

--- a/src/modules/golf_course/domain/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/domain/repositories/golf_course_repository.py
@@ -91,6 +91,32 @@ class IGolfCourseRepository(ABC):
         pass
 
     @abstractmethod
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos de golf por estado de aprobación, sin materializarlos.
+
+        Args:
+            approval_status: Estado a contar (PENDING_APPROVAL, APPROVED, REJECTED)
+
+        Returns:
+            Número de campos con ese estado
+        """
+        pass
+
+    @abstractmethod
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico, sin materializarlos.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        pass
+
+    @abstractmethod
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """
         Elimina un campo de golf (hard delete).

--- a/src/modules/golf_course/infrastructure/persistence/in_memory/in_memory_golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/in_memory/in_memory_golf_course_repository.py
@@ -97,6 +97,30 @@ class InMemoryGolfCourseRepository(IGolfCourseRepository):
         """
         return [gc for gc in self._golf_courses.values() if gc.requested_by == creator_id]
 
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos por estado de aprobación.
+
+        Args:
+            approval_status: Estado a contar
+
+        Returns:
+            Número de campos con ese estado
+        """
+        return len(await self.find_by_approval_status(approval_status))
+
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        return len(await self.find_by_creator(creator_id))
+
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """
         Elimina un campo de golf (hard delete).

--- a/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
@@ -2,7 +2,7 @@
 GolfCourseRepository - Implementación SQLAlchemy del repositorio de campos de golf.
 """
 
-from sqlalchemy import delete, inspect, select
+from sqlalchemy import delete, func, inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -183,6 +183,42 @@ class GolfCourseRepository(IGolfCourseRepository):
         result = await self._session.execute(stmt)
         result = result.unique()
         return list(result.scalars().all())
+
+    async def count_by_approval_status(self, approval_status: ApprovalStatus) -> int:
+        """
+        Cuenta campos de golf por estado de aprobación, sin materializarlos.
+
+        Args:
+            approval_status: Estado a contar (PENDING_APPROVAL, APPROVED, REJECTED)
+
+        Returns:
+            Número de campos con ese estado
+        """
+        stmt = (
+            select(func.count())
+            .select_from(golf_courses_table)
+            .where(golf_courses_table.c.approval_status == approval_status)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
+
+    async def count_by_creator(self, creator_id: UserId) -> int:
+        """
+        Cuenta campos creados por un usuario específico, sin materializarlos.
+
+        Args:
+            creator_id: ID del creator
+
+        Returns:
+            Número de campos creados por ese usuario
+        """
+        stmt = (
+            select(func.count())
+            .select_from(golf_courses_table)
+            .where(golf_courses_table.c.creator_id == creator_id)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
 
     async def delete(self, golf_course_id: GolfCourseId) -> None:
         """

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -105,6 +105,13 @@ class RemoveParticipantRequestDTO(BaseModel):
     target_participant_id: UUID
 
 
+class HideQuickMatchRequestDTO(BaseModel):
+    """DTO para ocultar/mostrar una partida rapida del propio historial (siempre self-scoped)."""
+
+    quick_match_id: UUID
+    requester_id: UUID
+
+
 class StartQuickMatchRequestDTO(BaseModel):
     """DTO para iniciar la partida, configurando quien anota (1 a 4 anotadores)."""
 

--- a/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
@@ -1,0 +1,47 @@
+"""Caso de Uso: Ocultar una partida rapida del propio historial."""
+
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
+    QuickMatchResponseDTO,
+)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class HideQuickMatchUseCase:
+    """
+    Oculta una partida rapida del historial del propio solicitante.
+
+    Siempre self-scoped: cualquier participante (no solo el creador) puede
+    ocultarla, y solo afecta a su propia vista (`GET /quick-matches/me`) —
+    el resto de participantes la siguen viendo con normalidad.
+    """
+
+    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
+        requester_id = UserId(request.requester_id)
+        requester_participant_id = ParticipantId(requester_id.value)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
+                QuickMatchId(request.quick_match_id)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
+
+            quick_match.hide_for(requester_participant_id)
+            await self._uow.quick_matches.update(quick_match)
+
+        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
@@ -1,0 +1,41 @@
+"""Caso de Uso: Volver a mostrar una partida rapida ocultada del propio historial."""
+
+from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
+    QuickMatchResponseDTO,
+)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class UnhideQuickMatchUseCase:
+    """Contrario de HideQuickMatchUseCase: vuelve a mostrar la partida en el historial propio."""
+
+    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+        self._uow = uow
+        self._user_uow = user_uow
+
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
+        requester_id = UserId(request.requester_id)
+        requester_participant_id = ParticipantId(requester_id.value)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id_for_update(
+                QuickMatchId(request.quick_match_id)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
+
+            quick_match.unhide_for(requester_participant_id)
+            await self._uow.quick_matches.update(quick_match)
+
+        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -18,12 +18,14 @@ from src.shared.domain.value_objects.gender import Gender
 from ..events.quick_match_cancelled_event import QuickMatchCancelledEvent
 from ..events.quick_match_completed_event import QuickMatchCompletedEvent
 from ..events.quick_match_created_event import QuickMatchCreatedEvent
+from ..events.quick_match_hidden_event import QuickMatchHiddenEvent
 from ..events.quick_match_participant_added_event import QuickMatchParticipantAddedEvent
 from ..events.quick_match_participant_handicap_updated_event import (
     QuickMatchParticipantHandicapUpdatedEvent,
 )
 from ..events.quick_match_participant_removed_event import QuickMatchParticipantRemovedEvent
 from ..events.quick_match_started_event import QuickMatchStartedEvent
+from ..events.quick_match_unhidden_event import QuickMatchUnhiddenEvent
 from ..exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
     DuplicateParticipantViolation,
@@ -83,6 +85,7 @@ class QuickMatch:
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
         scorer_ids: list[ParticipantId] | None = None,
+        hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
@@ -99,6 +102,9 @@ class QuickMatch:
         self._participants = list(participants)
         self._name = self._validate_name(name)
         self._scorer_ids = list(scorer_ids) if scorer_ids else []
+        self._hidden_by_participant_ids = (
+            list(hidden_by_participant_ids) if hidden_by_participant_ids else []
+        )
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
         self._domain_events: list[DomainEvent] = domain_events or []
@@ -218,6 +224,7 @@ class QuickMatch:
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
         scorer_ids: list[ParticipantId] | None = None,
+        hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ) -> "QuickMatch":
@@ -233,6 +240,7 @@ class QuickMatch:
             participants=participants,
             name=name,
             scorer_ids=scorer_ids,
+            hidden_by_participant_ids=hidden_by_participant_ids,
             created_at=created_at,
             updated_at=updated_at,
         )
@@ -307,6 +315,11 @@ class QuickMatch:
         return list(self._scorer_ids)
 
     @property
+    def hidden_by_participant_ids(self) -> list[ParticipantId]:
+        """Participantes que han ocultado esta partida de su propio historial."""
+        return list(self._hidden_by_participant_ids)
+
+    @property
     def created_at(self) -> datetime:
         return self._created_at
 
@@ -329,6 +342,9 @@ class QuickMatch:
 
     def is_scorer(self, participant_id: ParticipantId) -> bool:
         return participant_id in self._scorer_ids
+
+    def is_hidden_for(self, participant_id: ParticipantId) -> bool:
+        return participant_id in self._hidden_by_participant_ids
 
     def capacity(self) -> int:
         """Numero maximo de jugadores admitidos por el formato."""
@@ -491,6 +507,52 @@ class QuickMatch:
                 quick_match_id=str(self._id),
                 participant_id=str(participant_id),
                 handicap=handicap,
+            )
+        )
+
+    def hide_for(self, participant_id: ParticipantId) -> None:
+        """
+        Oculta la partida del historial personal de un participante.
+
+        No requiere ningun estado concreto de la partida (a diferencia de
+        add/remove_participant): un participante puede ocultar una partida
+        PENDING, IN_PROGRESS, COMPLETED o CANCELLED por igual. No afecta al
+        resto de participantes ni borra ningun dato — es puramente personal.
+        Idempotente: ocultar dos veces no es un error.
+        """
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if participant_id in self._hidden_by_participant_ids:
+            return
+
+        self._hidden_by_participant_ids = [*self._hidden_by_participant_ids, participant_id]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchHiddenEvent(quick_match_id=str(self._id), participant_id=str(participant_id))
+        )
+
+    def unhide_for(self, participant_id: ParticipantId) -> None:
+        """Vuelve a mostrar la partida en el historial personal de un participante. Idempotente."""
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if participant_id not in self._hidden_by_participant_ids:
+            return
+
+        self._hidden_by_participant_ids = [
+            pid for pid in self._hidden_by_participant_ids if pid != participant_id
+        ]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchUnhiddenEvent(
+                quick_match_id=str(self._id), participant_id=str(participant_id)
             )
         )
 

--- a/src/modules/quick_match/domain/events/quick_match_hidden_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_hidden_event.py
@@ -1,0 +1,13 @@
+"""QuickMatchHiddenEvent - Se emite cuando un participante oculta la partida de su historial."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchHiddenEvent(DomainEvent):
+    """Evento emitido cuando un participante oculta una partida rapida de su propio historial."""
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/events/quick_match_unhidden_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_unhidden_event.py
@@ -1,0 +1,13 @@
+"""QuickMatchUnhiddenEvent - Se emite cuando un participante vuelve a mostrar la partida."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchUnhiddenEvent(DomainEvent):
+    """Evento emitido cuando un participante deja de ocultar una partida rapida de su historial."""
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
+++ b/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
@@ -52,3 +52,19 @@ class QuickMatchRepositoryInterface(ABC):
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
         pass
+
+    @abstractmethod
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema (estadisticas de admin)."""
+        pass
+
+    @abstractmethod
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """
+        True si el usuario ha creado alguna partida rapida.
+
+        Util para bloquear el borrado definitivo de una cuenta: quick_matches.creator_id
+        tiene ON DELETE CASCADE, asi que borrar al creador borraria la partida entera
+        (incluyendo a otros participantes) si no se bloquea antes.
+        """
+        pass

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -19,12 +19,14 @@ from src.config.dependencies import (
     get_create_quick_match_use_case,
     get_current_user,
     get_get_quick_match_use_case,
+    get_hide_quick_match_use_case,
     get_list_my_quick_matches_use_case,
     get_remove_quick_match_participant_use_case,
     get_set_quick_match_participant_handicap_use_case,
     get_start_quick_match_use_case,
     get_submit_quick_match_hole_score_use_case,
     get_submit_quick_match_proxy_hole_score_use_case,
+    get_unhide_quick_match_use_case,
 )
 from src.config.rate_limit import limiter
 from src.modules.quick_match.application.dto.quick_match_dto import (
@@ -35,6 +37,7 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     AddGuestParticipantRequestDTO,
     AddParticipantRequestDTO,
     CreateQuickMatchRequestDTO,
+    HideQuickMatchRequestDTO,
     HoleScoreResponseDTO,
     PaginatedQuickMatchResponseDTO,
     QuickMatchDetailResponseDTO,
@@ -76,6 +79,9 @@ from src.modules.quick_match.application.use_cases.create_quick_match_use_case i
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
 )
@@ -93,6 +99,9 @@ from src.modules.quick_match.application.use_cases.submit_hole_score_use_case im
 )
 from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_case import (
     SubmitProxyHoleScoreUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
 )
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
@@ -368,6 +377,59 @@ async def remove_participant(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except InvalidQuickMatchStatusViolation as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.post(
+    "/quick-matches/{quick_match_id}/hide",
+    response_model=QuickMatchResponseDTO,
+    summary="Hide quick match from my history",
+    description=(
+        "Hides the quick match from the caller's own /quick-matches/me list, without "
+        "affecting what other participants see or deleting any data. Any participant "
+        "(not just the creator) can hide it for themselves, in any match status. "
+        "Idempotent."
+    ),
+)
+async def hide_quick_match(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: HideQuickMatchUseCase = Depends(get_hide_quick_match_use_case),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.delete(
+    "/quick-matches/{quick_match_id}/hide",
+    response_model=QuickMatchResponseDTO,
+    summary="Unhide quick match from my history",
+    description="Reverses hide_quick_match: the match shows up again in the caller's own list. Idempotent.",
+)
+async def unhide_quick_match(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: UnhideQuickMatchUseCase = Depends(get_unhide_quick_match_use_case),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
 @router.patch(

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -52,3 +52,11 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
             for qm in self._quick_matches.values()
             if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
         )
+
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema."""
+        return len(self._quick_matches)
+
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """True si el usuario ha creado alguna partida rapida."""
+        return any(qm.creator_id == creator_id for qm in self._quick_matches.values())

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -29,6 +29,16 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
     async def find_by_id_for_update(self, quick_match_id: QuickMatchId) -> QuickMatch | None:
         return self._quick_matches.get(quick_match_id)
 
+    def _matches_user(
+        self, qm: QuickMatch, user_id: UserId, status: QuickMatchStatus | None
+    ) -> bool:
+        participant_id = ParticipantId(user_id.value)
+        return (
+            qm.is_participant(participant_id)
+            and not qm.is_hidden_for(participant_id)
+            and (status is None or qm.status == status)
+        )
+
     async def list_for_user(
         self,
         user_id: UserId,
@@ -37,9 +47,7 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         offset: int = 0,
     ) -> list[QuickMatch]:
         results = [
-            qm
-            for qm in self._quick_matches.values()
-            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
+            qm for qm in self._quick_matches.values() if self._matches_user(qm, user_id, status)
         ]
         results.sort(key=lambda x: x.created_at, reverse=True)
         return results[offset : offset + limit]
@@ -48,9 +56,7 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
         return sum(
-            1
-            for qm in self._quick_matches.values()
-            if qm.is_participant(ParticipantId(user_id.value)) and (status is None or qm.status == status)
+            1 for qm in self._quick_matches.values() if self._matches_user(qm, user_id, status)
         )
 
     async def count_all(self) -> int:

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -251,7 +251,12 @@ class QuickMatchParticipantsJsonType(sqlalchemy.types.TypeDecorator[list]):
 
 
 class ScorerIdsJsonType(sqlalchemy.types.TypeDecorator[list]):
-    """TypeDecorator para serializar list[ParticipantId] (scorer_ids) a/desde JSONB."""
+    """
+    TypeDecorator para serializar list[ParticipantId] a/desde JSONB.
+
+    Generico: se reutiliza tanto para `scorer_ids` como para
+    `hidden_by_participant_ids` (misma forma, listas de ParticipantId).
+    """
 
     impl = JSONB
     cache_ok = True
@@ -294,6 +299,7 @@ quick_matches_table = Table(
     Column("allowance_percentage", Integer, nullable=True),
     Column("participants", QuickMatchParticipantsJsonType, nullable=False),
     Column("scorer_ids", ScorerIdsJsonType, nullable=False, default=list),
+    Column("hidden_by_participant_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
     CheckConstraint(
@@ -348,6 +354,7 @@ def start_quick_match_mappers() -> None:
                 "_allowance_percentage": quick_matches_table.c.allowance_percentage,
                 "_participants": quick_matches_table.c.participants,
                 "_scorer_ids": quick_matches_table.c.scorer_ids,
+                "_hidden_by_participant_ids": quick_matches_table.c.hidden_by_participant_ids,
                 "_created_at": quick_matches_table.c.created_at,
                 "_updated_at": quick_matches_table.c.updated_at,
             },

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -79,3 +79,19 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
         stmt = select(func.count()).select_from(QuickMatch).where(and_(*conditions))
         result = await self._session.execute(stmt)
         return result.scalar() or 0
+
+    async def count_all(self) -> int:
+        """Cuenta el total de partidas rapidas en el sistema."""
+        stmt = select(func.count()).select_from(QuickMatch)
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0
+
+    async def exists_created_by(self, creator_id: UserId) -> bool:
+        """True si el usuario ha creado alguna partida rapida."""
+        stmt = (
+            select(func.count())
+            .select_from(QuickMatch)
+            .where(QuickMatch._creator_id == creator_id)
+        )
+        result = await self._session.execute(stmt)
+        return (result.scalar() or 0) > 0

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -48,6 +48,12 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
             cast([{"user_id": str(user_id.value)}], JSONB)
         )
 
+    def _not_hidden_filter(self, user_id: UserId):
+        """Excluye partidas que el propio usuario ha ocultado de su historial (ver hide_for())."""
+        return ~quick_matches_table.c.hidden_by_participant_ids.op("@>")(
+            cast([str(user_id.value)], JSONB)
+        )
+
     async def list_for_user(
         self,
         user_id: UserId,
@@ -55,7 +61,7 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
         limit: int = 20,
         offset: int = 0,
     ) -> list[QuickMatch]:
-        conditions = [self._participant_filter(user_id)]
+        conditions = [self._participant_filter(user_id), self._not_hidden_filter(user_id)]
         if status is not None:
             conditions.append(QuickMatch._status == status)
 
@@ -72,7 +78,7 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
     async def count_for_user(
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:
-        conditions = [self._participant_filter(user_id)]
+        conditions = [self._participant_filter(user_id), self._not_hidden_filter(user_id)]
         if status is not None:
             conditions.append(QuickMatch._status == status)
 

--- a/src/modules/social/application/ports/social_email_service_interface.py
+++ b/src/modules/social/application/ports/social_email_service_interface.py
@@ -1,0 +1,38 @@
+"""
+Social Email Service Interface - Application Layer Port
+
+Define el contrato para envio de emails relacionados con el modulo Social
+(amistades). Vive en el Social module (Interface Segregation Principle).
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ISocialEmailService(ABC):
+    """
+    Puerto para envio de emails relacionados con amistades.
+
+    Separado de IEmailService (User module) e IInvitationEmailService
+    (Competition module) para respetar ISP. La implementacion concreta
+    (EmailService) puede implementar las tres interfaces.
+    """
+
+    @abstractmethod
+    async def send_friend_request_email(
+        self,
+        to_email: str,
+        addressee_name: str,
+        requester_name: str,
+    ) -> bool:
+        """
+        Envia un email notificando una nueva solicitud de amistad.
+
+        Args:
+            to_email: Email del destinatario de la solicitud
+            addressee_name: Nombre del destinatario de la solicitud
+            requester_name: Nombre de quien envia la solicitud
+
+        Returns:
+            True si se envio correctamente, False en caso contrario
+        """
+        pass

--- a/src/modules/social/application/use_cases/send_friend_request_use_case.py
+++ b/src/modules/social/application/use_cases/send_friend_request_use_case.py
@@ -1,10 +1,15 @@
 """Caso de Uso: Enviar una Solicitud de Amistad."""
 
+import logging
+
 from src.modules.social.application.dto.friendship_dto import (
     FriendshipResponseDTO,
     SendFriendRequestRequestDTO,
 )
 from src.modules.social.application.exceptions import AddresseeNotFoundError
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.social.domain.entities.friendship import Friendship
 from src.modules.social.domain.exceptions.social_violations import (
     BlockedUserViolation,
@@ -19,6 +24,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.email_masking import mask_email as _mask_email
+
+logger = logging.getLogger(__name__)
 
 
 class SendFriendRequestUseCase:
@@ -28,9 +36,11 @@ class SendFriendRequestUseCase:
         self,
         uow: SocialUnitOfWorkInterface,
         user_uow: UserUnitOfWorkInterface,
+        email_service: ISocialEmailService | None = None,
     ):
         self._uow = uow
         self._user_uow = user_uow
+        self._email_service = email_service
 
     async def execute(self, request: SendFriendRequestRequestDTO) -> FriendshipResponseDTO:
         requester_id = UserId(request.requester_id)
@@ -82,6 +92,22 @@ class SendFriendRequestUseCase:
             addressee_name = (
                 f"{addressee.first_name} {addressee.last_name}" if addressee else "Unknown"
             )
+
+        # Enviar email de notificacion (fuera de la transaccion, no bloquea la creacion)
+        if self._email_service and addressee and addressee.email:
+            addressee_email = str(addressee.email)
+            try:
+                await self._email_service.send_friend_request_email(
+                    to_email=addressee_email,
+                    addressee_name=addressee_name,
+                    requester_name=requester_name,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to send friend request email to %s: %s",
+                    _mask_email(addressee_email),
+                    str(e),
+                )
 
         return FriendshipResponseDTO(
             id=friendship.id.value,

--- a/src/modules/user/application/dto/admin_dto.py
+++ b/src/modules/user/application/dto/admin_dto.py
@@ -1,0 +1,79 @@
+"""DTOs para el panel de administración (gestión de usuarios y estadísticas)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class AdminListUsersRequestDTO(BaseModel):
+    """DTO de entrada para listar usuarios (admin)."""
+
+    search: str | None = Field(
+        default=None, description="Filtro por nombre, apellidos o email (opcional)."
+    )
+    is_admin: bool | None = Field(
+        default=None, description="Filtra por rol: True=admins, False=jugadores."
+    )
+    is_active: bool | None = Field(
+        default=None, description="Filtra por estado: True=activas, False=desactivadas."
+    )
+    email_verified: bool | None = Field(
+        default=None, description="Filtra por verificación de email."
+    )
+    limit: int = Field(default=20, ge=1, le=100, description="Tamaño de página.")
+    offset: int = Field(default=0, ge=0, description="Desplazamiento de paginación.")
+
+
+class AdminUserSummaryDTO(BaseModel):
+    """Fila de la tabla de usuarios del panel de administración."""
+
+    id: UUID
+    first_name: str
+    last_name: str
+    email: EmailStr
+    handicap: float | None = None
+    is_admin: bool
+    is_active: bool
+    email_verified: bool
+    created_at: datetime
+
+
+class AdminListUsersResponseDTO(BaseModel):
+    """Respuesta paginada del listado de usuarios."""
+
+    users: list[AdminUserSummaryDTO]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class AdminUpdateUserRequestDTO(BaseModel):
+    """
+    DTO de entrada para editar un usuario desde el panel de administración.
+
+    Todos los campos son opcionales: solo se actualizan los que vengan informados.
+    """
+
+    first_name: str | None = None
+    last_name: str | None = None
+    email: EmailStr | None = None
+    handicap: float | None = None
+    country_code: str | None = None
+    is_admin: bool | None = None
+
+
+class AdminSetUserActiveRequestDTO(BaseModel):
+    """DTO de entrada para (des)activar una cuenta."""
+
+    is_active: bool = Field(..., description="True para reactivar, False para desactivar.")
+
+
+class AdminStatsResponseDTO(BaseModel):
+    """Estadísticas globales de la plataforma para el panel de administración."""
+
+    total_users: int
+    total_competitions: int
+    total_quick_matches: int
+    total_golf_courses_approved: int
+    total_golf_courses_pending: int

--- a/src/modules/user/application/dto/admin_dto.py
+++ b/src/modules/user/application/dto/admin_dto.py
@@ -37,6 +37,7 @@ class AdminUserSummaryDTO(BaseModel):
     is_active: bool
     email_verified: bool
     created_at: datetime
+    last_login_at: datetime | None = None
 
 
 class AdminListUsersResponseDTO(BaseModel):

--- a/src/modules/user/application/use_cases/admin_delete_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_delete_user_use_case.py
@@ -1,0 +1,88 @@
+"""Caso de Uso: Borrado definitivo de una cuenta de usuario (panel de administración)."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminDeleteUserUseCase:
+    """
+    Borra definitivamente la cuenta de un usuario (solo Admin).
+
+    Bloquea el borrado si la cuenta tiene actividad de la que dependen otros
+    usuarios o que rompería una restriccion de la base de datos:
+    - Ha creado alguna competicion (competitions.creator_id es ON DELETE CASCADE:
+      borraria el torneo entero para todos sus participantes).
+    - Ha creado alguna partida rapida (mismo motivo, quick_matches.creator_id CASCADE).
+    - Ha solicitado algun campo de golf (golf_courses.creator_id sin ON DELETE: fallaria).
+    - Tiene algun hole score registrado (hole_scores.player_user_id sin ON DELETE: fallaria).
+
+    En esos casos, el panel de administracion debe ofrecer "Desactivar" en su lugar
+    (ver AdminSetUserActiveUseCase).
+    """
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+
+    async def execute(self, user_id_str: str) -> None:
+        user_id = UserId(user_id_str)
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+        reasons = await self._collect_activity_reasons(user_id)
+        if reasons:
+            raise UserHasActivityException(reasons)
+
+        async with self._user_uow:
+            await self._user_uow.users.delete_by_id(user_id)
+
+    async def _collect_activity_reasons(self, user_id: UserId) -> list[str]:
+        reasons: list[str] = []
+
+        async with self._competition_uow:
+            competitions_created = await self._competition_uow.competitions.count_by_creator(
+                user_id
+            )
+            if competitions_created > 0:
+                reasons.append(f"has created {competitions_created} competition(s)")
+
+            has_scores = await self._competition_uow.hole_scores.exists_by_player(user_id)
+            if has_scores:
+                reasons.append("has recorded hole scores in one or more matches")
+
+        async with self._quick_match_uow:
+            if await self._quick_match_uow.quick_matches.exists_created_by(user_id):
+                reasons.append("has created one or more quick matches")
+
+        async with self._golf_course_uow:
+            golf_courses_requested = await self._golf_course_uow.golf_courses.count_by_creator(
+                user_id
+            )
+            if golf_courses_requested > 0:
+                reasons.append(f"has requested {golf_courses_requested} golf course(s)")
+
+        return reasons

--- a/src/modules/user/application/use_cases/admin_list_users_use_case.py
+++ b/src/modules/user/application/use_cases/admin_list_users_use_case.py
@@ -32,6 +32,9 @@ class AdminListUsersUseCase:
                 is_active=request.is_active,
                 email_verified=request.email_verified,
             )
+            last_login_map = await self._uow.user_devices.find_last_login_map(
+                [user.id for user in users if user.id is not None]
+            )
 
         return AdminListUsersResponseDTO(
             users=[
@@ -45,6 +48,7 @@ class AdminListUsersUseCase:
                     is_active=user.is_active,
                     email_verified=user.email_verified,
                     created_at=user.created_at,
+                    last_login_at=last_login_map.get(str(user.id.value)),
                 )
                 for user in users
             ],

--- a/src/modules/user/application/use_cases/admin_list_users_use_case.py
+++ b/src/modules/user/application/use_cases/admin_list_users_use_case.py
@@ -1,0 +1,54 @@
+"""Caso de Uso: Listar usuarios (panel de administración)."""
+
+from src.modules.user.application.dto.admin_dto import (
+    AdminListUsersRequestDTO,
+    AdminListUsersResponseDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+
+
+class AdminListUsersUseCase:
+    """Lista usuarios paginados, opcionalmente filtrados por búsqueda (solo Admin)."""
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(self, request: AdminListUsersRequestDTO) -> AdminListUsersResponseDTO:
+        async with self._uow:
+            users = await self._uow.users.find_all(
+                limit=request.limit,
+                offset=request.offset,
+                search=request.search,
+                is_admin=request.is_admin,
+                is_active=request.is_active,
+                email_verified=request.email_verified,
+            )
+            total_count = await self._uow.users.count_all(
+                search=request.search,
+                is_admin=request.is_admin,
+                is_active=request.is_active,
+                email_verified=request.email_verified,
+            )
+
+        return AdminListUsersResponseDTO(
+            users=[
+                AdminUserSummaryDTO(
+                    id=user.id.value,
+                    first_name=user.first_name,
+                    last_name=user.last_name,
+                    email=str(user.email),
+                    handicap=float(user.handicap) if user.handicap is not None else None,
+                    is_admin=user.is_admin,
+                    is_active=user.is_active,
+                    email_verified=user.email_verified,
+                    created_at=user.created_at,
+                )
+                for user in users
+            ],
+            total_count=total_count,
+            limit=request.limit,
+            offset=request.offset,
+        )

--- a/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
+++ b/src/modules/user/application/use_cases/admin_set_user_active_use_case.py
@@ -1,0 +1,38 @@
+"""Caso de Uso: (Des)activar una cuenta de usuario (panel de administración)."""
+
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminSetUserActiveUseCase:
+    """
+    Desactiva o reactiva la cuenta de un usuario (solo Admin).
+
+    Una cuenta desactivada no puede iniciar sesión pero conserva todos sus
+    datos (torneos, partidas, amistades) intactos — acción reversible.
+    """
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(self, user_id_str: str, is_active: bool, actor_user_id: str) -> None:
+        if not is_active and user_id_str == actor_user_id:
+            raise ValueError("Admins cannot deactivate their own account")
+
+        user_id = UserId(user_id_str)
+
+        async with self._uow:
+            user = await self._uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+            if is_active:
+                if not user.is_active:
+                    user.reactivate(reactivated_by_user_id=actor_user_id)
+            elif user.is_active:
+                user.deactivate(deactivated_by_user_id=actor_user_id)
+
+            await self._uow.users.save(user)

--- a/src/modules/user/application/use_cases/admin_update_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_update_user_use_case.py
@@ -1,0 +1,67 @@
+"""Caso de Uso: Editar un usuario (panel de administración)."""
+
+from src.modules.user.application.dto.admin_dto import (
+    AdminUpdateUserRequestDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.email import Email
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class AdminUpdateUserUseCase:
+    """Edita los datos de un usuario desde el panel de administración (solo Admin)."""
+
+    def __init__(self, uow: UserUnitOfWorkInterface):
+        self._uow = uow
+
+    async def execute(
+        self, user_id_str: str, request: AdminUpdateUserRequestDTO
+    ) -> AdminUserSummaryDTO:
+        user_id = UserId(user_id_str)
+
+        async with self._uow:
+            user = await self._uow.users.find_by_id(user_id)
+            if not user:
+                raise UserNotFoundError(f"User not found: {user_id_str}")
+
+            if (
+                request.first_name is not None
+                or request.last_name is not None
+                or request.country_code is not None
+            ):
+                user.update_profile(
+                    first_name=request.first_name,
+                    last_name=request.last_name,
+                    country_code_str=request.country_code,
+                )
+
+            if request.email is not None and str(request.email) != str(user.email):
+                new_email_str = str(request.email)
+                existing = await self._uow.users.find_by_email(Email(new_email_str))
+                if existing and existing.id != user.id:
+                    raise DuplicateEmailError(f"Email {new_email_str} is already in use")
+                user.change_email(new_email_str)
+
+            if request.handicap is not None:
+                user.update_handicap(request.handicap)
+
+            if request.is_admin is not None and request.is_admin != user.is_admin:
+                user.set_is_admin(request.is_admin)
+
+            await self._uow.users.save(user)
+
+        return AdminUserSummaryDTO(
+            id=user.id.value,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=str(user.email),
+            handicap=float(user.handicap) if user.handicap is not None else None,
+            is_admin=user.is_admin,
+            is_active=user.is_active,
+            email_verified=user.email_verified,
+            created_at=user.created_at,
+        )

--- a/src/modules/user/application/use_cases/admin_update_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_update_user_use_case.py
@@ -53,6 +53,9 @@ class AdminUpdateUserUseCase:
                 user.set_is_admin(request.is_admin)
 
             await self._uow.users.save(user)
+            last_login_map = await self._uow.user_devices.find_last_login_map(
+                [uid] if (uid := user.id) is not None else []
+            )
 
         return AdminUserSummaryDTO(
             id=user.id.value,
@@ -64,4 +67,5 @@ class AdminUpdateUserUseCase:
             is_active=user.is_active,
             email_verified=user.email_verified,
             created_at=user.created_at,
+            last_login_at=last_login_map.get(str(user.id.value)),
         )

--- a/src/modules/user/application/use_cases/get_admin_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_admin_stats_use_case.py
@@ -1,0 +1,58 @@
+"""Caso de Uso: Estadísticas globales de la plataforma (panel de administración)."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.user.application.dto.admin_dto import AdminStatsResponseDTO
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+
+
+class GetAdminStatsUseCase:
+    """Agrega contadores globales de los distintos módulos para el panel de admin."""
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+
+    async def execute(self) -> AdminStatsResponseDTO:
+        async with self._user_uow:
+            total_users = await self._user_uow.users.count_all()
+
+        async with self._competition_uow:
+            total_competitions = await self._competition_uow.competitions.count_all()
+
+        async with self._quick_match_uow:
+            total_quick_matches = await self._quick_match_uow.quick_matches.count_all()
+
+        async with self._golf_course_uow:
+            approved_count = await self._golf_course_uow.golf_courses.count_by_approval_status(
+                ApprovalStatus.APPROVED
+            )
+            pending_count = await self._golf_course_uow.golf_courses.count_by_approval_status(
+                ApprovalStatus.PENDING_APPROVAL
+            )
+
+        return AdminStatsResponseDTO(
+            total_users=total_users,
+            total_competitions=total_competitions,
+            total_quick_matches=total_quick_matches,
+            total_golf_courses_approved=approved_count,
+            total_golf_courses_pending=pending_count,
+        )

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -27,7 +27,7 @@ from src.modules.user.application.use_cases.register_device_use_case import (
 )
 from src.modules.user.domain.entities.refresh_token import RefreshToken
 from src.modules.user.domain.entities.user import User
-from src.modules.user.domain.exceptions import AccountLockedException
+from src.modules.user.domain.exceptions import AccountDeactivatedException, AccountLockedException
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
@@ -184,6 +184,20 @@ class LoginUserUseCase:
 
         # Account Lockout (v1.13.0): Resetear intentos fallidos tras login exitoso
         user.reset_failed_attempts()
+
+        # Admin Panel (v2.4.0): Verificar si la cuenta fue desactivada por un admin.
+        # Se comprueba DESPUES de validar la contraseña para no filtrar el estado
+        # de la cuenta (activa/desactivada) a quien no conoce las credenciales.
+        if not user.is_active:
+            security_logger.log_login_attempt(
+                user_id=str(user.id.value),
+                email=request.email,
+                success=False,
+                failure_reason="Account deactivated by admin",
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+            raise AccountDeactivatedException()
 
         # Registrar evento de login exitoso (Clean Architecture)
         # UTC-aware: handicap_updated_at ahora es timezone-aware, y la comparación

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -6,7 +6,9 @@ from src.shared.domain.value_objects.country_code import CountryCode
 from src.shared.domain.value_objects.gender import Gender
 
 from ..errors.user_errors import InvalidAvatarPresetError
+from ..events.account_deactivated_event import AccountDeactivatedEvent
 from ..events.account_locked_event import AccountLockedEvent
+from ..events.account_reactivated_event import AccountReactivatedEvent
 from ..events.account_unlocked_event import AccountUnlockedEvent
 from ..events.email_verified_event import EmailVerifiedEvent
 from ..events.google_account_unlinked_event import GoogleAccountUnlinkedEvent
@@ -101,6 +103,7 @@ class User:
         failed_login_attempts: int = 0,
         locked_until: datetime | None = None,
         is_admin: bool = False,
+        is_active: bool = True,
         gender: Gender | None = None,
         avatar_source: AvatarSource = AvatarSource.NONE,
         avatar_preset_id: int | None = None,
@@ -125,6 +128,7 @@ class User:
         self._failed_login_attempts = failed_login_attempts
         self._locked_until = locked_until
         self._is_admin = is_admin
+        self._is_active = is_active
         self._gender = gender
         self._avatar_source = avatar_source
         self._avatar_preset_id = avatar_preset_id
@@ -202,6 +206,10 @@ class User:
     @property
     def is_admin(self) -> bool:
         return self._is_admin
+
+    @property
+    def is_active(self) -> bool:
+        return self._is_active
 
     @property
     def gender(self) -> Gender | None:
@@ -1079,6 +1087,71 @@ class User:
         if self.failed_login_attempts > 0:
             self._failed_login_attempts = 0
             self._updated_at = datetime.now()
+
+    def set_is_admin(self, is_admin: bool) -> None:
+        """Concede o revoca privilegios de administrador (solo desde el panel de admin)."""
+        self._is_admin = is_admin
+        self._updated_at = datetime.now()
+
+    # === Account Deactivation Methods (Admin) ===
+
+    def deactivate(self, deactivated_by_user_id: str) -> None:
+        """
+        Desactiva la cuenta del usuario (solo Admin, desde el panel de administración).
+
+        Una cuenta desactivada no puede iniciar sesión (ver LoginUserUseCase),
+        pero conserva todos sus datos (torneos, partidas, amistades) intactos.
+        Es una acción reversible mediante reactivate().
+
+        Emite AccountDeactivatedEvent para auditoría.
+
+        Args:
+            deactivated_by_user_id: ID del admin que realiza la desactivación
+
+        Raises:
+            ValueError: Si la cuenta ya está desactivada
+        """
+        if not self._is_active:
+            raise ValueError("Account is already deactivated")
+
+        now = datetime.now()
+        self._is_active = False
+        self._updated_at = now
+
+        self._add_domain_event(
+            AccountDeactivatedEvent(
+                user_id=str(self.id.value),
+                deactivated_by_user_id=deactivated_by_user_id,
+                deactivated_at=now,
+            )
+        )
+
+    def reactivate(self, reactivated_by_user_id: str) -> None:
+        """
+        Reactiva una cuenta previamente desactivada por un admin.
+
+        Emite AccountReactivatedEvent para auditoría.
+
+        Args:
+            reactivated_by_user_id: ID del admin que realiza la reactivación
+
+        Raises:
+            ValueError: Si la cuenta ya está activa
+        """
+        if self._is_active:
+            raise ValueError("Account is already active")
+
+        now = datetime.now()
+        self._is_active = True
+        self._updated_at = now
+
+        self._add_domain_event(
+            AccountReactivatedEvent(
+                user_id=str(self.id.value),
+                reactivated_by_user_id=reactivated_by_user_id,
+                reactivated_at=now,
+            )
+        )
 
     def __str__(self) -> str:
         """Representación string del usuario (sin mostrar password)."""

--- a/src/modules/user/domain/events/account_deactivated_event.py
+++ b/src/modules/user/domain/events/account_deactivated_event.py
@@ -1,0 +1,32 @@
+"""Account Deactivated Event - Emitido cuando un admin desactiva una cuenta."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class AccountDeactivatedEvent(DomainEvent):
+    """
+    Evento de dominio emitido cuando un administrador desactiva la cuenta
+    de un usuario desde el panel de administración.
+
+    Security (OWASP A09):
+        - Evento de auditoría: registra quién desactivó y cuándo
+        - La cuenta desactivada no puede iniciar sesión (ver User.deactivate())
+
+    Attributes:
+        user_id: ID del usuario cuya cuenta fue desactivada
+        deactivated_by_user_id: ID del admin que realizó la desactivación
+        deactivated_at: Timestamp de la desactivación
+    """
+
+    user_id: str
+    deactivated_by_user_id: str
+    deactivated_at: datetime
+
+    @property
+    def aggregate_id(self) -> str:
+        """El ID del agregado es el ID del usuario."""
+        return self.user_id

--- a/src/modules/user/domain/events/account_reactivated_event.py
+++ b/src/modules/user/domain/events/account_reactivated_event.py
@@ -1,0 +1,28 @@
+"""Account Reactivated Event - Emitido cuando un admin reactiva una cuenta."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class AccountReactivatedEvent(DomainEvent):
+    """
+    Evento de dominio emitido cuando un administrador reactiva la cuenta
+    de un usuario previamente desactivada.
+
+    Attributes:
+        user_id: ID del usuario cuya cuenta fue reactivada
+        reactivated_by_user_id: ID del admin que realizó la reactivación
+        reactivated_at: Timestamp de la reactivación
+    """
+
+    user_id: str
+    reactivated_by_user_id: str
+    reactivated_at: datetime
+
+    @property
+    def aggregate_id(self) -> str:
+        """El ID del agregado es el ID del usuario."""
+        return self.user_id

--- a/src/modules/user/domain/exceptions/__init__.py
+++ b/src/modules/user/domain/exceptions/__init__.py
@@ -1,6 +1,13 @@
 """User Domain Exceptions."""
 
+from .account_deactivated_exception import AccountDeactivatedException
 from .account_locked_exception import AccountLockedException
 from .current_device_revocation_exception import CurrentDeviceRevocationException
+from .user_has_activity_exception import UserHasActivityException
 
-__all__ = ["AccountLockedException", "CurrentDeviceRevocationException"]
+__all__ = [
+    "AccountDeactivatedException",
+    "AccountLockedException",
+    "CurrentDeviceRevocationException",
+    "UserHasActivityException",
+]

--- a/src/modules/user/domain/exceptions/account_deactivated_exception.py
+++ b/src/modules/user/domain/exceptions/account_deactivated_exception.py
@@ -1,0 +1,19 @@
+"""Account Deactivated Exception - Lanzada cuando se intenta login en cuenta desactivada."""
+
+
+class AccountDeactivatedException(Exception):  # noqa: N818 - Exception is intentional naming
+    """
+    Excepción lanzada cuando un usuario intenta hacer login en una cuenta
+    desactivada por un administrador.
+
+    Esta excepción se lanza en el Application Layer (LoginUserUseCase) cuando:
+    - user.is_active es False
+
+    Security (OWASP A07):
+        - Impide el acceso a cuentas desactivadas por un admin
+        - NO revela si la cuenta existe/está bloqueada por otro motivo
+    """
+
+    def __init__(self, message: str | None = None):
+        self.message = message or "Account has been deactivated"
+        super().__init__(self.message)

--- a/src/modules/user/domain/exceptions/user_has_activity_exception.py
+++ b/src/modules/user/domain/exceptions/user_has_activity_exception.py
@@ -1,0 +1,23 @@
+"""User Has Activity Exception - Bloquea el borrado definitivo de cuentas con datos."""
+
+
+class UserHasActivityException(Exception):  # noqa: N818 - Exception is intentional naming
+    """
+    Lanzada al intentar borrar definitivamente una cuenta que tiene datos
+    de los que depende otra gente (torneos creados, partidas rápidas creadas,
+    campos de golf solicitados, o historial de scores).
+
+    Borrar sin este chequeo podría:
+    - Borrar en cascada torneos/partidas rápidas de OTROS participantes
+      (competitions.creator_id y quick_matches.creator_id son ON DELETE CASCADE).
+    - Fallar con un IntegrityError de base de datos (hole_scores.player_user_id
+      no tiene ON DELETE definido).
+
+    Attributes:
+        reasons: Lista de motivos legibles por los que se bloquea el borrado.
+    """
+
+    def __init__(self, reasons: list[str]):
+        self.reasons = reasons
+        message = "Cannot permanently delete this account: " + "; ".join(reasons)
+        super().__init__(message)

--- a/src/modules/user/domain/repositories/user_device_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_device_repository_interface.py
@@ -18,6 +18,7 @@ Patrón: Repository Pattern + Dependency Inversion Principle (SOLID)
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
@@ -209,6 +210,25 @@ class UserDeviceRepositoryInterface(ABC):
             ...     print(f"{device.device_name} - Usado: {device.last_used_at}")
             Chrome on macOS - Usado: 2026-01-09 10:30:00
             Safari on iOS - Usado: 2026-01-08 14:20:00
+        """
+        pass
+
+    @abstractmethod
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Devuelve, para cada usuario con al menos un dispositivo registrado,
+        el last_used_at más reciente entre todos sus dispositivos (activos o no).
+
+        Usado por el panel de administración para mostrar la "última conexión"
+        sin añadir una columna dedicada en `users` (se reutiliza el tracking
+        de dispositivos ya existente).
+
+        Args:
+            user_ids: IDs de usuario a consultar (p.ej. la página actual del listado admin)
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> último last_used_at. Usuarios sin
+            dispositivos registrados no aparecen en el dict.
         """
         pass
 

--- a/src/modules/user/domain/repositories/user_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_repository_interface.py
@@ -181,13 +181,26 @@ class UserRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    async def find_all(self, limit: int = 100, offset: int = 0) -> list[User]:
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
         """
-        Obtiene una lista paginada de usuarios.
+        Obtiene una lista paginada de usuarios, opcionalmente filtrada.
 
         Args:
             limit (int): Número máximo de usuarios a retornar (default: 100)
             offset (int): Número de usuarios a saltar (default: 0)
+            search (str | None): Si se indica, filtra por coincidencia parcial
+                (case-insensitive) en nombre, apellidos o email
+            is_admin (bool | None): Si se indica, filtra por rol (admin/jugador)
+            is_active (bool | None): Si se indica, filtra por cuentas activas/desactivadas
+            email_verified (bool | None): Si se indica, filtra por email verificado o no
 
         Returns:
             List[User]: Lista de usuarios encontrados
@@ -198,12 +211,18 @@ class UserRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    async def count_all(self) -> int:
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
         """
-        Cuenta el total de usuarios en el repositorio.
+        Cuenta usuarios, opcionalmente filtrados (ver find_all).
 
         Returns:
-            int: Número total de usuarios
+            int: Número total de usuarios que coinciden con el filtro
 
         Raises:
             RepositoryError: Si ocurre un error de consulta

--- a/src/modules/user/infrastructure/api/v1/admin_routes.py
+++ b/src/modules/user/infrastructure/api/v1/admin_routes.py
@@ -1,0 +1,161 @@
+"""
+Admin Panel Routes - API Layer.
+
+Endpoints exclusivos de administrador para gestionar usuarios y consultar
+estadisticas globales de la plataforma. Todos los endpoints requieren
+autenticacion + require_admin().
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.config.dependencies import (
+    get_admin_delete_user_use_case,
+    get_admin_list_users_use_case,
+    get_admin_set_user_active_use_case,
+    get_admin_update_user_use_case,
+    get_current_user,
+    get_get_admin_stats_use_case,
+)
+from src.modules.user.application.dto.admin_dto import (
+    AdminListUsersRequestDTO,
+    AdminListUsersResponseDTO,
+    AdminSetUserActiveRequestDTO,
+    AdminStatsResponseDTO,
+    AdminUpdateUserRequestDTO,
+    AdminUserSummaryDTO,
+)
+from src.modules.user.application.dto.user_dto import UserResponseDTO
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.shared.infrastructure.security.authorization import require_admin
+
+router = APIRouter()
+
+
+@router.get(
+    "/stats",
+    response_model=AdminStatsResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Estadisticas globales de la plataforma (Admin)",
+)
+async def get_admin_stats(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetAdminStatsUseCase = Depends(get_get_admin_stats_use_case),
+):
+    require_admin(current_user)
+    return await use_case.execute()
+
+
+@router.get(
+    "/users",
+    response_model=AdminListUsersResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Listar usuarios (Admin)",
+)
+async def list_users(
+    search: str | None = Query(default=None),
+    is_admin_filter: bool | None = Query(default=None, alias="is_admin"),
+    is_active: bool | None = Query(default=None),
+    email_verified: bool | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminListUsersUseCase = Depends(get_admin_list_users_use_case),
+):
+    require_admin(current_user)
+    request = AdminListUsersRequestDTO(
+        search=search,
+        is_admin=is_admin_filter,
+        is_active=is_active,
+        email_verified=email_verified,
+        limit=limit,
+        offset=offset,
+    )
+    return await use_case.execute(request)
+
+
+@router.put(
+    "/users/{user_id}",
+    response_model=AdminUserSummaryDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Editar un usuario (Admin)",
+)
+async def update_user(
+    user_id: str,
+    body: AdminUpdateUserRequestDTO,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminUpdateUserUseCase = Depends(get_admin_update_user_use_case),
+):
+    require_admin(current_user)
+    try:
+        return await use_case.execute(user_id, body)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except DuplicateEmailError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+@router.put(
+    "/users/{user_id}/active",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Activar o desactivar una cuenta (Admin)",
+)
+async def set_user_active(
+    user_id: str,
+    body: AdminSetUserActiveRequestDTO,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminSetUserActiveUseCase = Depends(get_admin_set_user_active_use_case),
+):
+    require_admin(current_user)
+    try:
+        await use_case.execute(user_id, body.is_active, actor_user_id=str(current_user.id))
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+@router.delete(
+    "/users/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Borrado definitivo de una cuenta (Admin)",
+    description=(
+        "Borra la cuenta permanentemente. Bloqueado (409) si el usuario ha creado "
+        "competiciones/partidas rapidas, solicitado campos de golf, o tiene scores "
+        "registrados - en ese caso, usar /active para desactivar en su lugar."
+    ),
+)
+async def delete_user(
+    user_id: str,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: AdminDeleteUserUseCase = Depends(get_admin_delete_user_use_case),
+):
+    require_admin(current_user)
+    if user_id == str(current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Admins cannot delete their own account",
+        )
+    try:
+        await use_case.execute(user_id)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except UserHasActivityException as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e

--- a/src/modules/user/infrastructure/api/v1/auth_routes.py
+++ b/src/modules/user/infrastructure/api/v1/auth_routes.py
@@ -71,7 +71,7 @@ from src.modules.user.application.use_cases.verify_email_use_case import (
     VerifyEmailUseCase,
 )
 from src.modules.user.domain.errors.user_errors import UserAlreadyExistsError
-from src.modules.user.domain.exceptions import AccountLockedException
+from src.modules.user.domain.exceptions import AccountDeactivatedException, AccountLockedException
 from src.shared.infrastructure.http.http_context_validator import (
     get_trusted_client_ip,
     get_user_agent,
@@ -249,6 +249,12 @@ async def login_user(
         raise HTTPException(
             status_code=status.HTTP_423_LOCKED,
             detail=f"Account locked until {e.locked_until.isoformat()}. Too many failed login attempts.",
+        ) from e
+    except AccountDeactivatedException as e:
+        # Admin Panel (v2.4.0): Cuenta desactivada por un administrador
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This account has been deactivated. Contact an administrator.",
         ) from e
 
     if not login_response:

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_device_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_device_repository.py
@@ -5,6 +5,8 @@ Este módulo implementa UserDeviceRepositoryInterface para tests unitarios.
 Los datos se almacenan en diccionarios Python en memoria.
 """
 
+from datetime import datetime
+
 from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.repositories.user_device_repository_interface import (
     UserDeviceRepositoryInterface,
@@ -118,6 +120,27 @@ class InMemoryUserDeviceRepository(UserDeviceRepositoryInterface):
             if device.user_id == user_id and device.is_active
         ]
         return active_devices
+
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Agrega el last_used_at más reciente por usuario entre todos sus dispositivos.
+
+        Args:
+            user_ids: IDs de usuario a consultar
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> última conexión. Usuarios sin
+            dispositivos no aparecen en el dict.
+        """
+        target_ids = {str(uid.value) for uid in user_ids}
+        result: dict[str, datetime] = {}
+        for device in self._devices.values():
+            key = str(device.user_id.value)
+            if key not in target_ids:
+                continue
+            if key not in result or device.last_used_at > result[key]:
+                result[key] = device.last_used_at
+        return result
 
     async def revoke(self, device_id: UserDeviceId) -> None:
         """

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
@@ -33,23 +33,71 @@ class InMemoryUserRepository(UserRepositoryInterface):
                 return user
         return None
 
-    async def find_all(self, limit: int = 100, offset: int = 0) -> list[User]:
+    def _matches_search(self, user: User, search: str | None) -> bool:
+        if not search or not search.strip():
+            return True
+        q = search.strip().lower()
+        full_name = f"{user.first_name} {user.last_name}".lower()
+        email = str(user.email).lower() if user.email else ""
+        return (
+            q in user.first_name.lower()
+            or q in user.last_name.lower()
+            or q in full_name
+            or q in email
+        )
+
+    def _matches_filters(
+        self,
+        user: User,
+        search: str | None,
+        is_admin: bool | None,
+        is_active: bool | None,
+        email_verified: bool | None,
+    ) -> bool:
+        if not self._matches_search(user, search):
+            return False
+        if is_admin is not None and user.is_admin != is_admin:
+            return False
+        if is_active is not None and user.is_active != is_active:
+            return False
+        return email_verified is None or user.email_verified == email_verified
+
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
         """
-        Obtiene una lista paginada de usuarios.
+        Obtiene una lista paginada de usuarios, opcionalmente filtrada.
 
         Args:
             limit: Número máximo de usuarios a retornar
             offset: Número de usuarios a saltar
+            search: Filtro opcional por nombre/apellidos/email
+            is_admin: Filtro opcional por rol
+            is_active: Filtro opcional por cuentas activas/desactivadas
+            email_verified: Filtro opcional por verificación de email
 
         Returns:
             Lista de usuarios paginada
         """
-        all_users = list(self._users.values())
-        return all_users[offset : offset + limit]
+        matching = [
+            u
+            for u in self._users.values()
+            if self._matches_filters(u, search, is_admin, is_active, email_verified)
+        ]
+        matching.sort(key=lambda u: (u.created_at, str(u.id)), reverse=True)
+        return matching[offset : offset + limit]
 
-    async def delete_by_id(self, user_id: UserId) -> None:
+    async def delete_by_id(self, user_id: UserId) -> bool:
         if user_id in self._users:
             del self._users[user_id]
+            return True
+        return False
 
     async def update(self, user: User) -> None:
         if user.id in self._users:
@@ -86,8 +134,20 @@ class InMemoryUserRepository(UserRepositoryInterface):
     async def exists_by_email(self, email: Email) -> bool:
         return any(user.email == email for user in self._users.values())
 
-    async def count_all(self) -> int:
-        return len(self._users)
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
+        return len(
+            [
+                u
+                for u in self._users.values()
+                if self._matches_filters(u, search, is_admin, is_active, email_verified)
+            ]
+        )
 
     async def find_by_verification_token(self, token: str) -> User | None:
         """Busca un usuario por su token de verificación."""

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -168,6 +168,8 @@ users_table = Table(
     Column("locked_until", DateTime, nullable=True),
     # RBAC field (v2.0.0)
     Column("is_admin", Boolean, nullable=False, default=False),
+    # Admin panel: deactivation (v2.4.0)
+    Column("is_active", Boolean, nullable=False, default=True, server_default="true"),
     # Gender field (tee system refactor)
     Column("gender", GenderDecorator(), nullable=True),
     # Avatar fields (v2.3.0)
@@ -222,6 +224,7 @@ def start_mappers():
                 "_failed_login_attempts": users_table.c.failed_login_attempts,
                 "_locked_until": users_table.c.locked_until,
                 "_is_admin": users_table.c.is_admin,
+                "_is_active": users_table.c.is_active,
                 "_gender": users_table.c.gender,
                 "_avatar_source": users_table.c.avatar_source,
                 "_avatar_preset_id": users_table.c.avatar_preset_id,

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_device_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_device_repository.py
@@ -14,7 +14,9 @@ Responsabilidades:
 Patrón: Repository Pattern + Async SQLAlchemy
 """
 
-from sqlalchemy import select
+from datetime import datetime
+
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.user.domain.entities.user_device import UserDevice
@@ -188,6 +190,31 @@ class SQLAlchemyUserDeviceRepository(UserDeviceRepositoryInterface):
         )
         result = await self._session.execute(statement)
         return list(result.scalars().all())
+
+    async def find_last_login_map(self, user_ids: list[UserId]) -> dict[str, datetime]:
+        """
+        Agrega MAX(last_used_at) por usuario entre todos sus dispositivos.
+
+        No filtra por is_active: un dispositivo revocado sigue reflejando
+        una conexión real pasada.
+
+        Args:
+            user_ids: IDs de usuario a consultar
+
+        Returns:
+            dict[str, datetime]: user_id (str) -> última conexión. Usuarios sin
+            dispositivos no aparecen en el dict.
+        """
+        if not user_ids:
+            return {}
+
+        statement = (
+            select(UserDevice._user_id, func.max(UserDevice._last_used_at))  # type: ignore[call-overload]
+            .where(UserDevice._user_id.in_(user_ids))
+            .group_by(UserDevice._user_id)
+        )
+        result = await self._session.execute(statement)
+        return {str(user_id): last_used_at for user_id, last_used_at in result.all()}
 
     async def revoke(self, device_id: UserDeviceId) -> None:
         """

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -52,17 +52,61 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
-    async def find_all(self) -> list[User]:
-        """Devuelve todos los usuarios."""
-        statement = select(User)
+    def _search_filter(self, search: str | None):
+        """Construye la condición ILIKE compartida por find_all/count_all."""
+        if not search or not search.strip():
+            return None
+        q = search.strip().lower()
+        return or_(
+            func.lower(User._first_name).contains(q, autoescape=True),
+            func.lower(User._last_name).contains(q, autoescape=True),
+            func.lower(User._first_name + " " + User._last_name).contains(q, autoescape=True),
+            func.lower(User._email_value).contains(q, autoescape=True),
+        )
+
+    def _build_filters(
+        self,
+        search: str | None,
+        is_admin: bool | None,
+        is_active: bool | None,
+        email_verified: bool | None,
+    ) -> list:
+        conditions = []
+        search_condition = self._search_filter(search)
+        if search_condition is not None:
+            conditions.append(search_condition)
+        if is_admin is not None:
+            conditions.append(User._is_admin == is_admin)
+        if is_active is not None:
+            conditions.append(User._is_active == is_active)
+        if email_verified is not None:
+            conditions.append(User._email_verified == email_verified)
+        return conditions
+
+    async def find_all(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> list[User]:
+        """Devuelve una página de usuarios, opcionalmente filtrada."""
+        statement = select(User).order_by(User._created_at.desc(), User._id.desc())  # type: ignore[union-attr]
+        for condition in self._build_filters(search, is_admin, is_active, email_verified):
+            statement = statement.where(condition)
+        statement = statement.limit(limit).offset(offset)
         result = await self._session.execute(statement)
         return list(result.scalars().all())
 
-    async def delete_by_id(self, user_id: UserId) -> None:
-        """Elimina un usuario por su ID."""
+    async def delete_by_id(self, user_id: UserId) -> bool:
+        """Elimina un usuario por su ID. Devuelve True si existía y se eliminó."""
         user = await self.find_by_id(user_id)
-        if user:
-            await self._session.delete(user)
+        if not user:
+            return False
+        await self._session.delete(user)
+        return True
 
     async def update(self, user: User) -> None:
         """
@@ -125,9 +169,17 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         result = await self._session.execute(statement)
         return result.scalar_one() > 0
 
-    async def count_all(self) -> int:
-        """Cuenta todos los usuarios."""
+    async def count_all(
+        self,
+        search: str | None = None,
+        is_admin: bool | None = None,
+        is_active: bool | None = None,
+        email_verified: bool | None = None,
+    ) -> int:
+        """Cuenta usuarios, opcionalmente filtrados (ver find_all)."""
         statement = select(func.count()).select_from(User)
+        for condition in self._build_filters(search, is_admin, is_active, email_verified):
+            statement = statement.where(condition)
         result = await self._session.execute(statement)
         return result.scalar_one()
 

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -4,6 +4,7 @@ Email Service - Infrastructure Layer
 Servicio para enviar emails usando Mailgun.
 """
 
+import asyncio
 import html
 import logging
 from datetime import datetime
@@ -370,7 +371,7 @@ The Ryder Cup Friends Team
 </html>
         """
 
-        return self._send_email(to_email, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, to_email, subject, text_body, html_body)
 
     async def send_password_changed_notification(self, to_email: str, user_name: str) -> bool:
         """
@@ -524,7 +525,7 @@ The Ryder Cup Friends Team
 </html>
         """
 
-        return self._send_email(to_email, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, to_email, subject, text_body, html_body)
 
     def _sanitize_name(self, name: str) -> str:
         """Sanitiza un nombre para prevenir inyeccion de headers (RFC 5322)."""
@@ -742,7 +743,7 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_invitee}" <{to_email}>' if safe_invitee else to_email
-        return self._send_email(recipient, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, recipient, subject, text_body, html_body)
 
     async def send_friend_request_email(
         self,
@@ -875,4 +876,4 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_addressee}" <{to_email}>'
-        return self._send_email(recipient, subject, text_body, html_body)
+        return await asyncio.to_thread(self._send_email, recipient, subject, text_body, html_body)

--- a/src/shared/infrastructure/email/email_service.py
+++ b/src/shared/infrastructure/email/email_service.py
@@ -15,12 +15,15 @@ from src.config.settings import settings
 from src.modules.competition.application.ports.invitation_email_service_interface import (
     IInvitationEmailService,
 )
+from src.modules.social.application.ports.social_email_service_interface import (
+    ISocialEmailService,
+)
 from src.modules.user.application.ports.email_service_interface import IEmailService
 
 logger = logging.getLogger(__name__)
 
 
-class EmailService(IEmailService, IInvitationEmailService):
+class EmailService(IEmailService, IInvitationEmailService, ISocialEmailService):
     """
     Implementación de IEmailService usando Mailgun.
 
@@ -739,4 +742,137 @@ The Ryder Cup Friends Team
         """
 
         recipient = f'"{safe_invitee}" <{to_email}>' if safe_invitee else to_email
+        return self._send_email(recipient, subject, text_body, html_body)
+
+    async def send_friend_request_email(
+        self,
+        to_email: str,
+        addressee_name: str,
+        requester_name: str,
+    ) -> bool:
+        """
+        Envia un email notificando una nueva solicitud de amistad.
+
+        Template bilingue (ES/EN) con diseno consistente con send_invitation_email.
+        """
+        safe_addressee = self._sanitize_name(addressee_name)
+        safe_requester = self._sanitize_name(requester_name)
+        html_addressee = html.escape(safe_addressee)
+        html_requester = html.escape(safe_requester)
+
+        friends_link = f"{settings.FRONTEND_URL}/friends"
+
+        subject = (
+            f"{safe_requester} quiere ser tu amigo | {safe_requester} wants to be your friend"
+        )
+
+        text_body = f"""
+Hola {safe_addressee},
+
+{safe_requester} te ha enviado una solicitud de amistad en Ryder Cup Friends.
+
+Para aceptarla o rechazarla, visita: {friends_link}
+
+Saludos,
+El equipo de Ryder Cup Friends
+
+---
+
+Hello {safe_addressee},
+
+{safe_requester} has sent you a friend request on Ryder Cup Friends.
+
+To accept or decline it, visit: {friends_link}
+
+Best regards,
+The Ryder Cup Friends Team
+        """
+
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }}
+        .container {{
+            background-color: #f9f9f9;
+            border-radius: 10px;
+            padding: 30px;
+        }}
+        .header {{
+            background-color: #0066cc;
+            color: white;
+            padding: 20px;
+            border-radius: 10px 10px 0 0;
+            text-align: center;
+        }}
+        .content {{
+            background-color: white;
+            padding: 30px;
+            border-radius: 0 0 10px 10px;
+        }}
+        .button {{
+            display: inline-block;
+            padding: 15px 30px;
+            background-color: #0066cc;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 20px 0;
+            font-weight: bold;
+        }}
+        .footer {{
+            margin-top: 30px;
+            font-size: 12px;
+            color: #666;
+            border-top: 1px solid #ddd;
+            padding-top: 20px;
+        }}
+        .divider {{
+            border-top: 2px solid #ddd;
+            margin: 30px 0;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Nueva Solicitud de Amistad</h1>
+            <h2>New Friend Request</h2>
+        </div>
+        <div class="content">
+            <!-- Spanish -->
+            <p>Hola <strong>{html_addressee}</strong>,</p>
+            <p><strong>{html_requester}</strong> te ha enviado una solicitud de amistad en Ryder Cup Friends.</p>
+            <center>
+                <a href="{friends_link}" class="button">Ver solicitud</a>
+            </center>
+
+            <div class="divider"></div>
+
+            <!-- English -->
+            <p>Hello <strong>{html_addressee}</strong>,</p>
+            <p><strong>{html_requester}</strong> has sent you a friend request on Ryder Cup Friends.</p>
+            <center>
+                <a href="{friends_link}" class="button">View request</a>
+            </center>
+
+            <div class="footer">
+                <p>Saludos | Best regards,<br>
+                <strong>El equipo de Ryder Cup Friends | The Ryder Cup Friends Team</strong></p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        recipient = f'"{safe_addressee}" <{to_email}>'
         return self._send_email(recipient, subject, text_body, html_body)

--- a/src/shared/infrastructure/security/email_masking.py
+++ b/src/shared/infrastructure/security/email_masking.py
@@ -1,0 +1,11 @@
+"""Utilidad compartida para enmascarar emails en logs de seguridad."""
+
+
+def mask_email(email: str) -> str:
+    """Enmascara un email para logging seguro (ej: t***@example.com)."""
+    parts = email.split("@")
+    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
+        return "***"
+    local = parts[0]
+    masked_local = local[0] + "***" if len(local) > 1 else "***"
+    return f"{masked_local}@{parts[1]}"

--- a/src/shared/infrastructure/security/email_masking.py
+++ b/src/shared/infrastructure/security/email_masking.py
@@ -4,7 +4,7 @@
 def mask_email(email: str) -> str:
     """Enmascara un email para logging seguro (ej: t***@example.com)."""
     parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:  # noqa: PLR2004
+    if len(parts) != 2 or not parts[0] or not parts[1]:  # noqa: PLR2004
         return "***"
     local = parts[0]
     masked_local = local[0] + "***" if len(local) > 1 else "***"

--- a/tests/integration/api/v1/test_admin_endpoints.py
+++ b/tests/integration/api/v1/test_admin_endpoints.py
@@ -1,0 +1,289 @@
+"""Tests de integración para /api/v1/admin/* (panel de administración)."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from tests.conftest import (
+    create_authenticated_user,
+    create_golf_course,
+    set_auth_cookies,
+)
+
+
+async def _make_admin(email: str) -> None:
+    from main import app as fastapi_app
+    from src.config.dependencies import get_db_session
+
+    db_session_override = fastapi_app.dependency_overrides[get_db_session]
+    async for session in db_session_override():
+        try:
+            await session.execute(
+                text("UPDATE users SET is_admin = true WHERE email = :email"),
+                {"email": email},
+            )
+            await session.commit()
+            break
+        finally:
+            await session.close()
+
+
+class TestAdminStats:
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_get_stats_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_stats@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        response = await client.get("/api/v1/admin/stats", cookies=user["cookies"])
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_gets_stats(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_stats@test.com", "AdminPass123!", "Admin", "Stats"
+        )
+        await _make_admin("admin_stats@test.com")
+
+        response = await client.get("/api/v1/admin/stats", cookies=admin["cookies"])
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_users" in data
+        assert data["total_users"] >= 1
+        assert "total_competitions" in data
+        assert "total_quick_matches" in data
+        assert "total_golf_courses_approved" in data
+        assert "total_golf_courses_pending" in data
+
+
+class TestAdminListUsers:
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_list_users_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_list@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        response = await client.get("/api/v1/admin/users", cookies=user["cookies"])
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_lists_and_searches_users(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_list@test.com", "AdminPass123!", "Admin", "List"
+        )
+        await _make_admin("admin_list@test.com")
+        await create_authenticated_user(
+            client, "findable_target@test.com", "P@ssw0rd123!", "Findable", "Target"
+        )
+
+        response = await client.get(
+            "/api/v1/admin/users", params={"search": "findable_target"}, cookies=admin["cookies"]
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        assert data["users"][0]["email"] == "findable_target@test.com"
+
+
+class TestAdminUpdateUser:
+    @pytest.mark.asyncio
+    async def test_admin_updates_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_update@test.com", "AdminPass123!", "Admin", "Update"
+        )
+        await _make_admin("admin_update@test.com")
+        target = await create_authenticated_user(
+            client, "target_update@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"first_name": "Renamed", "handicap": 15.3},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["first_name"] == "Renamed"
+        assert data["handicap"] == 15.3
+
+    @pytest.mark.asyncio
+    async def test_admin_update_duplicate_email_returns_409(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_dup@test.com", "AdminPass123!", "Admin", "Dup"
+        )
+        await _make_admin("admin_dup@test.com")
+        await create_authenticated_user(
+            client, "already_taken@test.com", "P@ssw0rd123!", "Taken", "User"
+        )
+        target = await create_authenticated_user(
+            client, "target_dup@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"email": "already_taken@test.com"},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update_user_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_update@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        target = await create_authenticated_user(
+            client, "target_notadmin@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}",
+            json={"first_name": "Hacked"},
+            cookies=user["cookies"],
+        )
+        assert response.status_code == 403
+
+
+class TestAdminSetUserActive:
+    @pytest.mark.asyncio
+    async def test_admin_deactivates_and_blocks_login(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_deact@test.com", "AdminPass123!", "Admin", "Deact"
+        )
+        await _make_admin("admin_deact@test.com")
+        target = await create_authenticated_user(
+            client, "target_deact@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_deact@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
+        )
+        assert login_response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_reactivates_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_react@test.com", "AdminPass123!", "Admin", "React"
+        )
+        await _make_admin("admin_react@test.com")
+        target = await create_authenticated_user(
+            client, "target_react@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        response = await client.put(
+            f"/api/v1/admin/users/{target['user']['id']}/active",
+            json={"is_active": True},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_react@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
+        )
+        assert login_response.status_code == 200
+
+
+class TestAdminDeleteUser:
+    @pytest.mark.asyncio
+    async def test_admin_deletes_clean_user(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_delete@test.com", "AdminPass123!", "Admin", "Delete"
+        )
+        await _make_admin("admin_delete@test.com")
+        target = await create_authenticated_user(
+            client, "target_delete@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        response = await client.delete(
+            f"/api/v1/admin/users/{target['user']['id']}", cookies=admin["cookies"]
+        )
+        assert response.status_code == 204
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "target_delete@test.com", "password": "P@ssw0rd123!"},
+            headers={"X-Test-Client-ID": f"login-{uuid.uuid4()}"},
+        )
+        assert login_response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_delete_user_returns_403(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "notadmin_delete@test.com", "P@ssw0rd123!", "Not", "Admin"
+        )
+        target = await create_authenticated_user(
+            client, "target_notadmin_delete@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+        response = await client.delete(
+            f"/api/v1/admin/users/{target['user']['id']}", cookies=user["cookies"]
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_delete_blocked_when_user_has_activity(self, client: AsyncClient):
+        """Bloquea (409) el borrado definitivo si el usuario tiene actividad,
+        para no romper la restricción de BD (golf_courses.creator_id sin
+        ON DELETE) ni el dato de otros (competitions/quick_matches CASCADE).
+        La cuenta debe seguir existiendo tras el intento fallido."""
+        admin = await create_authenticated_user(
+            client, "admin_delete_blocked@test.com", "AdminPass123!", "Admin", "Blocked"
+        )
+        await _make_admin("admin_delete_blocked@test.com")
+        target = await create_authenticated_user(
+            client, "target_delete_blocked@test.com", "P@ssw0rd123!", "Target", "User"
+        )
+
+        await create_golf_course(client, target["cookies"])
+
+        set_auth_cookies(client, admin["cookies"])
+        response = await client.delete(f"/api/v1/admin/users/{target['user']['id']}")
+        assert response.status_code == 409
+        assert "golf course" in response.json()["detail"]
+
+        list_response = await client.get(
+            "/api/v1/admin/users", params={"search": "target_delete_blocked"}
+        )
+        assert list_response.status_code == 200
+        assert list_response.json()["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_admin_cannot_delete_own_account(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_self_delete@test.com", "AdminPass123!", "Admin", "Self"
+        )
+        await _make_admin("admin_self_delete@test.com")
+
+        response = await client.delete(
+            f"/api/v1/admin/users/{admin['user']['id']}", cookies=admin["cookies"]
+        )
+        assert response.status_code == 400
+
+
+class TestAdminSelfDeactivationGuard:
+    @pytest.mark.asyncio
+    async def test_admin_cannot_deactivate_own_account(self, client: AsyncClient):
+        admin = await create_authenticated_user(
+            client, "admin_self_deact@test.com", "AdminPass123!", "Admin", "SelfDeact"
+        )
+        await _make_admin("admin_self_deact@test.com")
+
+        response = await client.put(
+            f"/api/v1/admin/users/{admin['user']['id']}/active",
+            json={"is_active": False},
+            cookies=admin["cookies"],
+        )
+        assert response.status_code == 400

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -928,3 +928,127 @@ class TestQuickMatchSetParticipantHandicap:
         )
 
         assert response.status_code == 422
+
+
+class TestQuickMatchHideFromHistory:
+    """Tests para POST/DELETE /api/v1/quick-matches/{id}/hide (RyderCupAm#127)."""
+
+    async def _create_match_with_two_participants(
+        self, client: AsyncClient
+    ) -> tuple[dict, dict, dict, str]:
+        admin = await create_admin_user(
+            client, "qm_admin_hide1@test.com", "P@ssw0rd123!", "Admin", "HideOne"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_hide1@test.com", "P@ssw0rd123!", "Creator", "HideOne"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_hide1@test.com", "P@ssw0rd123!", "Friend", "HideOne"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+
+        return admin, creator, friend, quick_match_id
+
+    @pytest.mark.asyncio
+    async def test_hide_removes_it_from_my_list_but_not_from_the_other_participant(
+        self, client: AsyncClient
+    ):
+        _admin, creator, friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        hide_response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        assert hide_response.status_code == 200, hide_response.text
+
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id not in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+        # El otro participante, que no la ha ocultado, la sigue viendo.
+        set_auth_cookies(client, friend["cookies"])
+        friend_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id in [m["id"] for m in friend_matches.json()["quick_matches"]]
+
+        # Tampoco se ha borrado ni afectado el registro en si.
+        detail_response = await client.get(f"/api/v1/quick-matches/{quick_match_id}")
+        assert detail_response.status_code == 200
+        assert len(detail_response.json()["participants"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_creator_participant_can_hide_it_too(self, client: AsyncClient):
+        _admin, _creator, friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, friend["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert response.status_code == 200, response.text
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id not in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+    @pytest.mark.asyncio
+    async def test_hide_is_idempotent(self, client: AsyncClient):
+        _admin, creator, _friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        first = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        second = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_unhide_brings_it_back_to_my_list(self, client: AsyncClient):
+        _admin, creator, _friend, quick_match_id = await self._create_match_with_two_participants(
+            client
+        )
+        set_auth_cookies(client, creator["cookies"])
+        await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        unhide_response = await client.delete(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        assert unhide_response.status_code == 200, unhide_response.text
+
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        assert quick_match_id in [m["id"] for m in my_matches.json()["quick_matches"]]
+
+    @pytest.mark.asyncio
+    async def test_hide_a_non_participant_match_returns_404(self, client: AsyncClient):
+        _admin, _creator, _friend, quick_match_id = (
+            await self._create_match_with_two_participants(client)
+        )
+        outsider = await create_authenticated_user(
+            client, "qm_outsider_hide1@test.com", "P@ssw0rd123!", "Outsider", "HideOne"
+        )
+
+        set_auth_cookies(client, outsider["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_hide_nonexistent_match_returns_404(self, client: AsyncClient):
+        creator = await create_authenticated_user(
+            client, "qm_creator_hide2@test.com", "P@ssw0rd123!", "Creator", "HideTwo"
+        )
+
+        set_auth_cookies(client, creator["cookies"])
+        response = await client.post(
+            "/api/v1/quick-matches/00000000-0000-0000-0000-000000000000/hide"
+        )
+
+        assert response.status_code == 404

--- a/tests/unit/modules/quick_match/application/use_cases/test_hide_unhide_quick_match_use_cases.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_hide_unhide_quick_match_use_cases.py
@@ -1,0 +1,99 @@
+"""Tests para HideQuickMatchUseCase y UnhideQuickMatchUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import HideQuickMatchRequestDTO
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
+    HideQuickMatchUseCase,
+)
+from src.modules.quick_match.application.use_cases.unhide_quick_match_use_case import (
+    UnhideQuickMatchUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_pending_match_with_participant(qm_uow, creator_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    other = QuickMatchParticipant.for_user(UserId(uuid4()))
+    qm.add_participant(other)
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm, other
+
+
+class TestHideQuickMatchUseCase:
+    async def test_creator_can_hide(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_pending_match_with_participant(qm_uow, creator)
+
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_non_creator_participant_can_hide(self, qm_uow, user_uow):
+        """Cualquier participante puede ocultarla, no solo el creador."""
+        creator = UserId(uuid4())
+        qm, other = await _create_pending_match_with_participant(qm_uow, creator)
+
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(
+                quick_match_id=qm.id.value, requester_id=other.user_id.value
+            )
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_hidden_for(other.participant_id)
+        assert not stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = HideQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=uuid4(), requester_id=uuid4())
+            )
+
+
+class TestUnhideQuickMatchUseCase:
+    async def test_reverses_a_previous_hide(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_pending_match_with_participant(qm_uow, creator)
+        qm.hide_for(qm.creator_participant_id)
+        async with qm_uow:
+            await qm_uow.quick_matches.update(qm)
+
+        use_case = UnhideQuickMatchUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert not stored.is_hidden_for(qm.creator_participant_id)
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = UnhideQuickMatchUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=uuid4(), requester_id=uuid4())
+            )

--- a/tests/unit/modules/quick_match/application/use_cases/test_list_my_quick_matches_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_list_my_quick_matches_use_case.py
@@ -42,3 +42,30 @@ class TestListMyQuickMatchesUseCase:
 
         assert result.total_count == 1
         assert result.quick_matches[0].id == mine.id.value
+
+    async def test_excludes_matches_the_user_has_hidden(self, qm_uow, user_uow):
+        """Ver RyderCupAm#127: ocultar una partida la saca del listado propio (no un borrado)."""
+        me = await create_user(user_uow, "me-hides@test.com")
+
+        visible = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=me.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.SINGLES,
+        )
+        hidden = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=me.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.SINGLES,
+        )
+        hidden.hide_for(hidden.creator_participant_id)
+        async with qm_uow:
+            await qm_uow.quick_matches.add(visible)
+            await qm_uow.quick_matches.add(hidden)
+
+        use_case = ListMyQuickMatchesUseCase(qm_uow, user_uow)
+        result = await use_case.execute(str(me.id.value))
+
+        assert result.total_count == 1
+        assert result.quick_matches[0].id == visible.id.value

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -16,6 +16,9 @@ from src.modules.quick_match.domain.events.quick_match_completed_event import (
 from src.modules.quick_match.domain.events.quick_match_created_event import (
     QuickMatchCreatedEvent,
 )
+from src.modules.quick_match.domain.events.quick_match_hidden_event import (
+    QuickMatchHiddenEvent,
+)
 from src.modules.quick_match.domain.events.quick_match_participant_added_event import (
     QuickMatchParticipantAddedEvent,
 )
@@ -27,6 +30,9 @@ from src.modules.quick_match.domain.events.quick_match_participant_removed_event
 )
 from src.modules.quick_match.domain.events.quick_match_started_event import (
     QuickMatchStartedEvent,
+)
+from src.modules.quick_match.domain.events.quick_match_unhidden_event import (
+    QuickMatchUnhiddenEvent,
 )
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
@@ -266,6 +272,93 @@ class TestQuickMatchRemoveParticipant:
         qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
             qm.remove_participant(other.participant_id)
+
+
+class TestQuickMatchHideForHistory:
+    def test_hide_for_creator_succeeds(self):
+        qm = _make_quick_match()
+        qm.clear_domain_events()
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchHiddenEvent)
+
+    def test_hide_for_non_creator_participant_succeeds(self):
+        """Cualquier participante puede ocultar la partida, no solo el creador."""
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+
+        qm.hide_for(other.participant_id)
+
+        assert qm.is_hidden_for(other.participant_id)
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+
+    def test_hide_for_non_participant_raises(self):
+        qm = _make_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.hide_for(ParticipantId.generate())
+
+    def test_hide_for_is_idempotent(self):
+        qm = _make_quick_match()
+        qm.hide_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_hide_does_not_require_pending_status(self):
+        """A diferencia de add/remove_participant, ocultar no depende del estado."""
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+        qm.start([qm.creator_participant_id])
+
+        qm.hide_for(other.participant_id)
+
+        assert qm.is_hidden_for(other.participant_id)
+
+    def test_unhide_for_reverses_hide(self):
+        qm = _make_quick_match()
+        qm.hide_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.unhide_for(qm.creator_participant_id)
+
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchUnhiddenEvent)
+
+    def test_unhide_for_non_participant_raises(self):
+        qm = _make_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.unhide_for(ParticipantId.generate())
+
+    def test_unhide_for_is_idempotent(self):
+        qm = _make_quick_match()
+        qm.clear_domain_events()
+
+        qm.unhide_for(qm.creator_participant_id)
+
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_hiding_does_not_affect_other_participants(self):
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        other = _registered()
+        qm.add_participant(other)
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        assert not qm.is_hidden_for(other.participant_id)
+        assert qm.is_participant(qm.creator_participant_id)  # sigue siendo participante
 
 
 class TestQuickMatchSetParticipantHandicap:

--- a/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
@@ -1,5 +1,7 @@
 """Tests para SendFriendRequestUseCase."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from src.modules.social.application.dto.friendship_dto import SendFriendRequestRequestDTO
@@ -133,3 +135,56 @@ class TestSendFriendRequestUseCase:
 
         assert response.status == "PENDING"
         assert response.id != declined.id.value
+
+    async def test_should_call_email_service_on_success(self, uow, user_uow):
+        """Email service se llama con los parametros correctos al enviar la solicitud."""
+        requester = await self._create_user(user_uow, "requester6@test.com")
+        addressee = await self._create_user(user_uow, "addressee6@test.com")
+
+        mock_email = AsyncMock()
+        mock_email.send_friend_request_email = AsyncMock(return_value=True)
+
+        use_case = SendFriendRequestUseCase(uow, user_uow, email_service=mock_email)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"
+        mock_email.send_friend_request_email.assert_called_once()
+        call_kwargs = mock_email.send_friend_request_email.call_args[1]
+        assert call_kwargs["to_email"] == "addressee6@test.com"
+        assert call_kwargs["addressee_name"] == "Test User"
+        assert call_kwargs["requester_name"] == "Test User"
+
+    async def test_should_create_friendship_even_if_email_fails(self, uow, user_uow):
+        """La solicitud se crea aunque el envio del email falle."""
+        requester = await self._create_user(user_uow, "requester7@test.com")
+        addressee = await self._create_user(user_uow, "addressee7@test.com")
+
+        mock_email = AsyncMock()
+        mock_email.send_friend_request_email = AsyncMock(side_effect=Exception("SMTP error"))
+
+        use_case = SendFriendRequestUseCase(uow, user_uow, email_service=mock_email)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"
+
+    async def test_no_email_sent_when_email_service_not_provided(self, uow, user_uow):
+        """Sin email_service inyectado (default None), no debe intentarse enviar nada."""
+        requester = await self._create_user(user_uow, "requester8@test.com")
+        addressee = await self._create_user(user_uow, "addressee8@test.com")
+
+        use_case = SendFriendRequestUseCase(uow, user_uow)
+        response = await use_case.execute(
+            SendFriendRequestRequestDTO(
+                requester_id=requester.id.value, addressee_id=addressee.id.value
+            )
+        )
+
+        assert response.status == "PENDING"

--- a/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_send_friend_request_use_case.py
@@ -152,7 +152,7 @@ class TestSendFriendRequestUseCase:
         )
 
         assert response.status == "PENDING"
-        mock_email.send_friend_request_email.assert_called_once()
+        mock_email.send_friend_request_email.assert_awaited_once()
         call_kwargs = mock_email.send_friend_request_email.call_args[1]
         assert call_kwargs["to_email"] == "addressee6@test.com"
         assert call_kwargs["addressee_name"] == "Test User"

--- a/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_delete_user_use_case.py
@@ -1,0 +1,113 @@
+"""Tests para AdminDeleteUserUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.user.application.use_cases.admin_delete_user_use_case import (
+    AdminDeleteUserUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.exceptions import UserHasActivityException
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_uow_mock(**repo_attrs):
+    """Crea un UoW mock cuyo __aenter__/__aexit__ funcionan como context manager."""
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    for name, repo in repo_attrs.items():
+        setattr(uow, name, repo)
+    return uow
+
+
+class TestAdminDeleteUserUseCase:
+    @pytest.fixture
+    def user_uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, user_uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with user_uow:
+            await user_uow.users.save(user)
+        return user
+
+    def _make_use_case(
+        self,
+        user_uow,
+        competitions_created=0,
+        has_scores=False,
+        quick_match_created=False,
+        golf_courses_created=0,
+    ):
+        competitions_repo = AsyncMock()
+        competitions_repo.count_by_creator = AsyncMock(return_value=competitions_created)
+        hole_scores_repo = AsyncMock()
+        hole_scores_repo.exists_by_player = AsyncMock(return_value=has_scores)
+        competition_uow = _make_uow_mock(
+            competitions=competitions_repo, hole_scores=hole_scores_repo
+        )
+
+        quick_matches_repo = AsyncMock()
+        quick_matches_repo.exists_created_by = AsyncMock(return_value=quick_match_created)
+        quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
+
+        golf_courses_repo = AsyncMock()
+        golf_courses_repo.count_by_creator = AsyncMock(return_value=golf_courses_created)
+        golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
+
+        return AdminDeleteUserUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+    async def test_deletes_user_with_no_activity(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow)
+        await use_case.execute(str(existing_user.id.value))
+
+        async with user_uow:
+            assert await user_uow.users.find_by_id(existing_user.id) is None
+
+    async def test_blocks_delete_when_user_created_competitions(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, competitions_created=2)
+
+        with pytest.raises(UserHasActivityException) as exc_info:
+            await use_case.execute(str(existing_user.id.value))
+        assert "2 competition(s)" in str(exc_info.value)
+
+        async with user_uow:
+            assert await user_uow.users.find_by_id(existing_user.id) is not None
+
+    async def test_blocks_delete_when_user_has_hole_scores(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, has_scores=True)
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_blocks_delete_when_user_created_quick_match(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, quick_match_created=True)
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_blocks_delete_when_user_requested_golf_course(self, user_uow, existing_user):
+        use_case = self._make_use_case(user_uow, golf_courses_created=1)
+
+        with pytest.raises(UserHasActivityException):
+            await use_case.execute(str(existing_user.id.value))
+
+    async def test_raises_not_found_before_checking_activity(self, user_uow):
+        from uuid import uuid4
+
+        use_case = self._make_use_case(user_uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()))

--- a/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
@@ -1,0 +1,98 @@
+"""Tests para AdminListUsersUseCase."""
+
+import pytest
+
+from src.modules.user.application.dto.admin_dto import AdminListUsersRequestDTO
+from src.modules.user.application.use_cases.admin_list_users_use_case import (
+    AdminListUsersUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminListUsersUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    async def _create_user(self, uow, first_name, last_name, email):
+        user = User.create(
+            first_name=first_name,
+            last_name=last_name,
+            email_str=email,
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_lists_all_users_paginated(self, uow):
+        await self._create_user(uow, "Ana", "Ruiz", "ana@test.com")
+        await self._create_user(uow, "Bea", "Soto", "bea@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(limit=1, offset=0))
+
+        assert response.total_count == 2
+        assert len(response.users) == 1
+
+    async def test_search_filters_by_name_or_email(self, uow):
+        await self._create_user(uow, "Marta", "Sánchez", "marta@test.com")
+        await self._create_user(uow, "Diego", "Molero", "diego@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="marta"))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "marta@test.com"
+
+    async def test_search_matches_email_too(self, uow):
+        await self._create_user(uow, "Marta", "Sánchez", "findme@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="findme"))
+
+        assert response.total_count == 1
+
+    async def test_filters_by_is_admin(self, uow):
+        admin = await self._create_user(uow, "Admin", "User", "admin@test.com")
+        async with uow:
+            admin.set_is_admin(True)
+            await uow.users.save(admin)
+        await self._create_user(uow, "Player", "User", "player@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(is_admin=True))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "admin@test.com"
+
+    async def test_filters_by_is_active(self, uow):
+        user = await self._create_user(uow, "Deactivated", "User", "gone@test.com")
+        async with uow:
+            user.deactivate(deactivated_by_user_id="admin-id")
+            await uow.users.save(user)
+        await self._create_user(uow, "Active", "User", "active@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(is_active=False))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "gone@test.com"
+
+    async def test_filters_by_email_verified(self, uow):
+        await self._create_user(uow, "Unverified", "User", "unverified@test.com")
+        verified = await self._create_user(uow, "Verified", "User", "verified@test.com")
+        async with uow:
+            verified.verify_email_from_oauth()
+            await uow.users.save(verified)
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(email_verified=False))
+
+        assert response.total_count == 1
+        assert response.users[0].email == "unverified@test.com"

--- a/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_list_users_use_case.py
@@ -1,5 +1,7 @@
 """Tests para AdminListUsersUseCase."""
 
+from datetime import datetime, timedelta
+
 import pytest
 
 from src.modules.user.application.dto.admin_dto import AdminListUsersRequestDTO
@@ -7,6 +9,8 @@ from src.modules.user.application.use_cases.admin_list_users_use_case import (
     AdminListUsersUseCase,
 )
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.entities.user_device import UserDevice
+from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -96,3 +100,48 @@ class TestAdminListUsersUseCase:
 
         assert response.total_count == 1
         assert response.users[0].email == "unverified@test.com"
+
+    async def test_last_login_at_is_max_last_used_at_across_devices(self, uow):
+        user = await self._create_user(uow, "Con", "Dispositivos", "devices@test.com")
+        older = datetime.now() - timedelta(days=5)
+        newer = datetime.now() - timedelta(hours=1)
+        async with uow:
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=user.id,
+                    device_name="Chrome on macOS",
+                    user_agent="ua-1",
+                    ip_address="1.1.1.1",
+                    fingerprint_hash="hash-1",
+                    is_active=True,
+                    last_used_at=older,
+                    created_at=older,
+                )
+            )
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=user.id,
+                    device_name="Safari on iOS",
+                    user_agent="ua-2",
+                    ip_address="1.1.1.2",
+                    fingerprint_hash="hash-2",
+                    is_active=False,
+                    last_used_at=newer,
+                    created_at=older,
+                )
+            )
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="devices@test.com"))
+
+        assert response.users[0].last_login_at == newer
+
+    async def test_last_login_at_is_none_without_devices(self, uow):
+        await self._create_user(uow, "Sin", "Dispositivos", "nodevice@test.com")
+
+        use_case = AdminListUsersUseCase(uow)
+        response = await use_case.execute(AdminListUsersRequestDTO(search="nodevice@test.com"))
+
+        assert response.users[0].last_login_at is None

--- a/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_set_user_active_use_case.py
@@ -1,0 +1,88 @@
+"""Tests para AdminSetUserActiveUseCase."""
+
+import pytest
+
+from src.modules.user.application.use_cases.admin_set_user_active_use_case import (
+    AdminSetUserActiveUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminSetUserActiveUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_deactivates_active_user(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        await use_case.execute(str(existing_user.id.value), False, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is False
+
+    async def test_reactivates_deactivated_user(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        await use_case.execute(str(existing_user.id.value), False, actor_user_id="admin-id")
+        await use_case.execute(str(existing_user.id.value), True, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_is_idempotent_when_already_in_target_state(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        # Ya está activo por defecto: no debe lanzar al pedir is_active=True
+        await use_case.execute(str(existing_user.id.value), True, actor_user_id="admin-id")
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_raises_when_user_not_found(self, uow):
+        from uuid import uuid4
+
+        use_case = AdminSetUserActiveUseCase(uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()), False, actor_user_id="admin-id")
+
+    async def test_blocks_admin_from_deactivating_own_account(self, uow, existing_user):
+        use_case = AdminSetUserActiveUseCase(uow)
+        actor_id = str(existing_user.id.value)
+
+        with pytest.raises(ValueError, match="cannot deactivate their own account"):
+            await use_case.execute(actor_id, False, actor_user_id=actor_id)
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True
+
+    async def test_allows_admin_to_reactivate_own_account(self, uow, existing_user):
+        """El guard solo bloquea auto-desactivación; reactivar la propia cuenta es inofensivo."""
+        use_case = AdminSetUserActiveUseCase(uow)
+        actor_id = str(existing_user.id.value)
+        await use_case.execute(actor_id, False, actor_user_id="other-admin-id")
+
+        await use_case.execute(actor_id, True, actor_user_id=actor_id)
+
+        async with uow:
+            user = await uow.users.find_by_id(existing_user.id)
+        assert user.is_active is True

--- a/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
@@ -1,0 +1,84 @@
+"""Tests para AdminUpdateUserUseCase."""
+
+import pytest
+
+from src.modules.user.application.dto.admin_dto import AdminUpdateUserRequestDTO
+from src.modules.user.application.use_cases.admin_update_user_use_case import (
+    AdminUpdateUserUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestAdminUpdateUserUseCase:
+    @pytest.fixture
+    def uow(self):
+        return InMemoryUnitOfWork()
+
+    @pytest.fixture
+    async def existing_user(self, uow):
+        user = User.create(
+            first_name="Carlos",
+            last_name="Ruiz",
+            email_str="carlos@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(user)
+        return user
+
+    async def test_updates_name_and_handicap(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(first_name="Carlitos", handicap=12.5),
+        )
+
+        assert result.first_name == "Carlitos"
+        assert result.handicap == 12.5
+
+    async def test_promotes_user_to_admin(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value), AdminUpdateUserRequestDTO(is_admin=True)
+        )
+
+        assert result.is_admin is True
+
+    async def test_changes_email(self, uow, existing_user):
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(email="new-email@test.com"),
+        )
+
+        assert result.email == "new-email@test.com"
+
+    async def test_raises_when_user_not_found(self, uow):
+        from uuid import uuid4
+
+        use_case = AdminUpdateUserUseCase(uow)
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(str(uuid4()), AdminUpdateUserRequestDTO(first_name="X"))
+
+    async def test_raises_on_duplicate_email(self, uow, existing_user):
+        other = User.create(
+            first_name="Otro",
+            last_name="Usuario",
+            email_str="taken@test.com",
+            plain_password="SecureP@ssw0rd123",
+        )
+        async with uow:
+            await uow.users.save(other)
+
+        use_case = AdminUpdateUserUseCase(uow)
+        with pytest.raises(DuplicateEmailError):
+            await use_case.execute(
+                str(existing_user.id.value),
+                AdminUpdateUserRequestDTO(email="taken@test.com"),
+            )

--- a/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_admin_update_user_use_case.py
@@ -1,5 +1,7 @@
 """Tests para AdminUpdateUserUseCase."""
 
+from datetime import datetime
+
 import pytest
 
 from src.modules.user.application.dto.admin_dto import AdminUpdateUserRequestDTO
@@ -7,7 +9,9 @@ from src.modules.user.application.use_cases.admin_update_user_use_case import (
     AdminUpdateUserUseCase,
 )
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.entities.user_device import UserDevice
 from src.modules.user.domain.errors.user_errors import DuplicateEmailError, UserNotFoundError
+from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -58,6 +62,37 @@ class TestAdminUpdateUserUseCase:
         )
 
         assert result.email == "new-email@test.com"
+
+    async def test_response_preserves_last_login_at(self, uow, existing_user):
+        """
+        Regression test: la respuesta de PUT /admin/users/{id} usaba el mismo
+        AdminUserSummaryDTO que el listado, pero olvidaba rellenar last_login_at
+        (quedaba siempre None) — el frontend lo pisaba con "Nunca" tras cualquier
+        edicion, aunque el usuario si tuviera una conexion registrada.
+        """
+        last_used_at = datetime(2026, 7, 30, 10, 0, 0)
+        async with uow:
+            await uow.user_devices.save(
+                UserDevice.reconstitute(
+                    id=UserDeviceId.generate(),
+                    user_id=existing_user.id,
+                    device_name="Chrome on macOS",
+                    user_agent="ua-1",
+                    ip_address="1.1.1.1",
+                    fingerprint_hash="hash-1",
+                    is_active=True,
+                    last_used_at=last_used_at,
+                    created_at=last_used_at,
+                )
+            )
+
+        use_case = AdminUpdateUserUseCase(uow)
+        result = await use_case.execute(
+            str(existing_user.id.value),
+            AdminUpdateUserRequestDTO(first_name="Carlitos"),
+        )
+
+        assert result.last_login_at == last_used_at
 
     async def test_raises_when_user_not_found(self, uow):
         from uuid import uuid4

--- a/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_admin_stats_use_case.py
@@ -1,0 +1,65 @@
+"""Tests para GetAdminStatsUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
+from src.modules.user.application.use_cases.get_admin_stats_use_case import (
+    GetAdminStatsUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_uow_mock(**repo_attrs):
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    for name, repo in repo_attrs.items():
+        setattr(uow, name, repo)
+    return uow
+
+
+class TestGetAdminStatsUseCase:
+    @pytest.fixture
+    def user_uow(self):
+        return InMemoryUnitOfWork()
+
+    async def test_aggregates_counts_from_all_modules(self, user_uow):
+        for i in range(3):
+            user = User.create(
+                first_name=f"User{i}",
+                last_name="Test",
+                email_str=f"user{i}@test.com",
+                plain_password="SecureP@ssw0rd123",
+            )
+            async with user_uow:
+                await user_uow.users.save(user)
+
+        competitions_repo = AsyncMock()
+        competitions_repo.count_all = AsyncMock(return_value=12)
+        competition_uow = _make_uow_mock(competitions=competitions_repo)
+
+        quick_matches_repo = AsyncMock()
+        quick_matches_repo.count_all = AsyncMock(return_value=58)
+        quick_match_uow = _make_uow_mock(quick_matches=quick_matches_repo)
+
+        golf_courses_repo = AsyncMock()
+        golf_courses_repo.count_by_approval_status = AsyncMock(
+            side_effect=lambda status: 9 if status is ApprovalStatus.APPROVED else 2
+        )
+        golf_course_uow = _make_uow_mock(golf_courses=golf_courses_repo)
+
+        use_case = GetAdminStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+        stats = await use_case.execute()
+
+        assert stats.total_users == 3
+        assert stats.total_competitions == 12
+        assert stats.total_quick_matches == 58
+        assert stats.total_golf_courses_approved == 9
+        assert stats.total_golf_courses_pending == 2

--- a/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_login_user_use_case.py
@@ -13,6 +13,7 @@ from src.modules.user.application.dto.user_dto import LoginRequestDTO
 from src.modules.user.application.use_cases.login_user_use_case import LoginUserUseCase
 from src.modules.user.domain.entities.user import User
 from src.modules.user.domain.errors.handicap_errors import HandicapServiceUnavailableError
+from src.modules.user.domain.exceptions import AccountDeactivatedException
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
@@ -46,6 +47,7 @@ def _rebuild_user(user: User, **overrides) -> User:
         "failed_login_attempts": user.failed_login_attempts,
         "locked_until": user.locked_until,
         "is_admin": user.is_admin,
+        "is_active": user.is_active,
         "gender": user.gender,
         "domain_events": user.get_domain_events(),
     }
@@ -449,9 +451,7 @@ class TestLoginUserUseCaseHandicapRFEG:
             country_code_str="ES",
         )
         user.update_handicap(12.5)
-        user = _rebuild_user(
-            user, handicap_updated_at=user.handicap_updated_at - timedelta(days=1)
-        )
+        user = _rebuild_user(user, handicap_updated_at=user.handicap_updated_at - timedelta(days=1))
         async with uow:
             await uow.users.save(user)
             await uow.commit()
@@ -467,3 +467,50 @@ class TestLoginUserUseCaseHandicapRFEG:
         assert response.needs_handicap is False
         assert response.user.handicap == 15.0
         handicap_svc.search_handicap.assert_awaited_once_with("Juan Garcia")
+
+
+@pytest.mark.asyncio
+class TestLoginUserUseCaseDeactivatedAccount:
+    """
+    Tests para el bloqueo de login en cuentas desactivadas (Admin Panel v2.4.0).
+
+    La verificación de is_active ocurre DESPUÉS de validar la contraseña, para
+    no filtrar el estado de la cuenta a quien no conoce las credenciales.
+    """
+
+    async def test_deactivated_account_with_correct_password_raises_exception(
+        self, uow, token_service, register_device_use_case, existing_user
+    ):
+        """Contraseña correcta + cuenta desactivada → AccountDeactivatedException."""
+        deactivated_user = _rebuild_user(existing_user, is_active=False)
+        async with uow:
+            await uow.users.save(deactivated_user)
+            await uow.commit()
+
+        use_case = LoginUserUseCase(uow, token_service, register_device_use_case)
+        request = LoginRequestDTO(email="test@example.com", password="V@l1dP@ss123!")
+
+        with pytest.raises(AccountDeactivatedException):
+            await use_case.execute(request)
+
+    async def test_deactivated_account_with_wrong_password_returns_none(
+        self, uow, token_service, register_device_use_case, existing_user
+    ):
+        """
+        Contraseña incorrecta + cuenta desactivada → None (no la excepción).
+
+        Verifica el orden correcto: la contraseña se valida ANTES que el
+        estado is_active, así que unas credenciales inválidas no revelan si
+        la cuenta está o no desactivada.
+        """
+        deactivated_user = _rebuild_user(existing_user, is_active=False)
+        async with uow:
+            await uow.users.save(deactivated_user)
+            await uow.commit()
+
+        use_case = LoginUserUseCase(uow, token_service, register_device_use_case)
+        request = LoginRequestDTO(email="test@example.com", password="Wr0ngP@ssw0rd!")
+
+        response = await use_case.execute(request)
+
+        assert response is None

--- a/tests/unit/modules/user/domain/entities/test_user.py
+++ b/tests/unit/modules/user/domain/entities/test_user.py
@@ -11,6 +11,8 @@ Este archivo contiene tests que verifican:
 import pytest
 
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.events.account_deactivated_event import AccountDeactivatedEvent
+from src.modules.user.domain.events.account_reactivated_event import AccountReactivatedEvent
 from src.modules.user.domain.value_objects.email import InvalidEmailError
 
 
@@ -155,6 +157,66 @@ class TestUserMethods:
 
         # Assert
         assert full_name == "Ana Martín"
+
+
+class TestUserAccountDeactivation:
+    """Tests para deactivate()/reactivate() (panel de administración)."""
+
+    def _make_user(self):
+        return User.create(
+            first_name="Carlos",
+            last_name="Rodríguez",
+            email_str="carlos@test.com",
+            plain_password="DefaultPassword123!",
+        )
+
+    def test_new_user_is_active_by_default(self):
+        user = self._make_user()
+        assert user.is_active is True
+
+    def test_deactivate_sets_is_active_false(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        assert user.is_active is False
+
+    def test_deactivate_raises_if_already_deactivated(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        with pytest.raises(ValueError, match="already deactivated"):
+            user.deactivate(deactivated_by_user_id="admin-id")
+
+    def test_deactivate_emits_account_deactivated_event(self):
+        user = self._make_user()
+        user.clear_domain_events()
+        user.deactivate(deactivated_by_user_id="admin-id")
+
+        events = user.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AccountDeactivatedEvent)
+        assert events[0].user_id == str(user.id.value)
+        assert events[0].deactivated_by_user_id == "admin-id"
+
+    def test_reactivate_sets_is_active_true(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        user.reactivate(reactivated_by_user_id="admin-id")
+        assert user.is_active is True
+
+    def test_reactivate_raises_if_already_active(self):
+        user = self._make_user()
+        with pytest.raises(ValueError, match="already active"):
+            user.reactivate(reactivated_by_user_id="admin-id")
+
+    def test_reactivate_emits_account_reactivated_event(self):
+        user = self._make_user()
+        user.deactivate(deactivated_by_user_id="admin-id")
+        user.clear_domain_events()
+        user.reactivate(reactivated_by_user_id="admin-id")
+
+        events = user.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AccountReactivatedEvent)
+        assert events[0].reactivated_by_user_id == "admin-id"
 
 
 class TestUserValidation:

--- a/tests/unit/shared/infrastructure/security/test_email_masking.py
+++ b/tests/unit/shared/infrastructure/security/test_email_masking.py
@@ -1,0 +1,20 @@
+"""Tests para la utilidad compartida mask_email."""
+
+from src.shared.infrastructure.security.email_masking import mask_email
+
+
+class TestMaskEmail:
+    def test_masks_local_part_keeping_first_char(self):
+        assert mask_email("test@example.com") == "t***@example.com"
+
+    def test_single_char_local_part_fully_masked(self):
+        assert mask_email("a@test.com") == "***@test.com"
+
+    def test_no_at_sign_returns_fully_masked(self):
+        assert mask_email("not-an-email") == "***"
+
+    def test_multiple_at_signs_returns_fully_masked(self):
+        assert mask_email("a@b@c.com") == "***"
+
+    def test_empty_local_part_returns_fully_masked(self):
+        assert mask_email("@example.com") == "***"

--- a/tests/unit/shared/infrastructure/security/test_email_masking.py
+++ b/tests/unit/shared/infrastructure/security/test_email_masking.py
@@ -18,3 +18,6 @@ class TestMaskEmail:
 
     def test_empty_local_part_returns_fully_masked(self):
         assert mask_email("@example.com") == "***"
+
+    def test_empty_domain_part_returns_fully_masked(self):
+        assert mask_email("alice@") == "***"


### PR DESCRIPTION
## Summary
Release v2.4.0 — friend-request email notification, admin panel backend (users/stats management), last-login tracking, and quick match hide-from-history.

See [CHANGELOG.md](https://github.com/agustinEDev/RyderCupAM/blob/release/2.4.0/CHANGELOG.md) for the full list.

## Test plan
- [x] `pytest tests/unit/ -q -n auto` — 2337 passed