### PR TITLE
feat(ops): Add real /health endpoint with version and commit

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -284,9 +284,19 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
      ```
 
 3. **Verificar deployment:**
-   - Tu API: `https://rydercup-api.onrender.com`
-   - Health check: `curl https://rydercup-api.onrender.com/`
-   - Swagger UI: `https://rydercup-api.onrender.com/docs`
+   - Tu API: `https://api.rydercupfriends.com`
+   - Health check: `curl https://api.rydercupfriends.com/health`
+   - Swagger UI: `https://api.rydercupfriends.com/docs`
+
+   `/health` devuelve la versión y el commit realmente desplegados, que es lo
+   único que permite confirmar que una release ha llegado a producción:
+
+   ```bash
+   curl -s https://api.rydercupfriends.com/health
+   # {"status":"ok","version":"2.4.0","commit":"abc1234","branch":"main","environment":"production"}
+   ```
+
+   Comparar ese `commit` con el SHA de la release para saber si el deploy ya ocurrió.
 
 ---
 

--- a/docs/MULTI_ENVIRONMENT_SETUP.md
+++ b/docs/MULTI_ENVIRONMENT_SETUP.md
@@ -144,7 +144,7 @@ DOCS_PASSWORD=<secure-password>
 
 **Frontend (Static Site):**
 ```bash
-VITE_API_BASE_URL=https://rydercup-api.onrender.com
+VITE_API_BASE_URL=https://api.rydercupfriends.com
 ```
 
 ### Deployment
@@ -156,9 +156,10 @@ git push origin main
 ```
 
 ### Verification
-- Frontend: https://rydercupfriends.com
-- Backend: https://rydercup-api.onrender.com/docs
-- Email links: `https://rydercupfriends.com/verify-email?token=xxx`
+- Frontend: https://www.rydercupfriends.com
+- Backend: https://api.rydercupfriends.com/docs
+- Qué release está desplegada: `curl -s https://api.rydercupfriends.com/health`
+- Email links: `https://www.rydercupfriends.com/verify-email?token=xxx`
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -30,6 +30,12 @@ from src.config.cors_config import get_cors_config  # noqa: E402
 from src.config.rate_limit import limiter  # noqa: E402
 from src.config.sentry_config import init_sentry  # noqa: E402
 from src.config.settings import settings  # noqa: E402
+from src.config.version import (  # noqa: E402
+    APP_VERSION,
+    get_deployed_branch,
+    get_deployed_commit,
+    get_environment,
+)
 from src.modules.competition.infrastructure.api.v1 import (  # noqa: E402
     competition_crud_routes,
     competition_golf_course_routes,
@@ -152,7 +158,7 @@ def verify_docs_credentials(credentials: HTTPBasicCredentials = Depends(security
 
 
 class HealthResponse(BaseModel):
-    """Response model para el health check."""
+    """Response model para el endpoint raiz."""
 
     message: str
     version: str
@@ -161,12 +167,22 @@ class HealthResponse(BaseModel):
     description: str
 
 
+class DeploymentHealthResponse(BaseModel):
+    """Response model para /health: identifica el despliegue concreto."""
+
+    status: str
+    version: str
+    commit: str
+    branch: str
+    environment: str
+
+
 # Crear la app, registrando el gestor de ciclo de vida 'lifespan'
 # Deshabilitamos docs_url y redoc_url para crear endpoints protegidos manualmente
 app = FastAPI(
     title="Ryder Cup Manager",
     description="API para gestion de torneos tipo Ryder Cup entre amigos",
-    version="1.0.0",
+    version=APP_VERSION,
     docs_url=None,  # Deshabilitado - usaremos endpoint protegido
     redoc_url=None,  # Deshabilitado - usaremos endpoint protegido
     lifespan=lifespan,
@@ -455,10 +471,24 @@ async def get_redoc_documentation(
 async def root() -> HealthResponse:
     return HealthResponse(
         message="Ryder Cup Manager API",
-        version="1.0.0",
+        version=APP_VERSION,
         status="running",
         docs="Visita /docs para la documentacion interactiva",
         description="API para gestion de torneos tipo Ryder Cup entre amigos",
+    )
+
+
+# Health check de despliegue: responde QUE version y QUE commit estan corriendo,
+# que es lo unico que permite verificar si una release ha llegado a produccion.
+# `/` no sirve para eso porque no distingue un despliegue de otro.
+@app.get("/health", response_model=DeploymentHealthResponse)
+async def health() -> DeploymentHealthResponse:
+    return DeploymentHealthResponse(
+        status="ok",
+        version=APP_VERSION,
+        commit=get_deployed_commit(),
+        branch=get_deployed_branch(),
+        environment=get_environment(),
     )
 
 

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -1,0 +1,33 @@
+"""Version de la aplicacion — fuente unica de verdad.
+
+A diferencia del frontend, el backend no tiene `package.json`, asi que la
+version vive aqui. Debe subirse en el commit de preparacion de cada release
+(`CHORE(RELEASE): PREPARE VX.Y.Z`), junto al CHANGELOG.
+
+`GET /health` la expone junto al commit desplegado para poder verificar que
+una release ha llegado realmente a produccion.
+"""
+
+import os
+
+APP_VERSION = "2.4.0"
+
+
+def get_deployed_commit() -> str:
+    """SHA del commit desplegado.
+
+    Render inyecta `RENDER_GIT_COMMIT` automaticamente en cada deploy, asi que
+    identifica el despliegue sin necesidad de mantener nada a mano. Fuera de
+    Render (local, Docker, k8s) no existe y devolvemos "unknown".
+    """
+    return os.getenv("RENDER_GIT_COMMIT", "unknown")
+
+
+def get_deployed_branch() -> str:
+    """Rama desde la que se desplego, inyectada por Render igual que el commit."""
+    return os.getenv("RENDER_GIT_BRANCH", "unknown")
+
+
+def get_environment() -> str:
+    """Entorno de ejecucion (development, staging, production)."""
+    return os.getenv("ENVIRONMENT", "development")

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 from main import app
 from src.config.settings import settings
+from src.config.version import APP_VERSION
 
 # ================================
 # SETUP DE CLIENTE DE PRUEBAS
@@ -97,7 +98,7 @@ class TestHealthEndpoint:
 
         # Assert - Verificar valores específicos
         assert data["message"] == "Ryder Cup Manager API"
-        assert data["version"] == "1.0.0"
+        assert data["version"] == APP_VERSION
         assert data["status"] == "running"
         assert "documentacion" in data["docs"].lower()
         assert "ryder cup" in data["description"].lower()
@@ -119,6 +120,72 @@ class TestHealthEndpoint:
         assert isinstance(data["status"], str)
         assert isinstance(data["docs"], str)
         assert isinstance(data["description"], str)
+
+
+class TestDeploymentHealthEndpoint:
+    """Tests para /health, que identifica el despliegue concreto.
+
+    A diferencia de `/`, este endpoint responde QUE version y QUE commit estan
+    corriendo, que es lo unico que permite verificar si una release ha llegado
+    realmente a produccion (ver #158).
+    """
+
+    def test_health_endpoint_returns_200(self, client):
+        """
+        Test: /health responde 200 sin autenticacion
+        Given: API de FastAPI funcionando
+        When: Se hace GET request a /health sin credenciales
+        Then: Responde 200 (es publico, lo consulta el health check de Render)
+        """
+        response = client.get("/health")
+
+        assert response.status_code == 200
+
+    def test_health_endpoint_response_structure(self, client):
+        """
+        Test: /health expone los campos que identifican el despliegue
+        Given: API de FastAPI funcionando
+        When: Se hace GET request a /health
+        Then: Devuelve status, version, commit, branch y environment
+        """
+        response = client.get("/health")
+        data = response.json()
+
+        assert data["status"] == "ok"
+        assert data["version"] == APP_VERSION
+        for field in ("commit", "branch", "environment"):
+            assert field in data
+            assert isinstance(data[field], str)
+
+    def test_health_endpoint_reports_render_commit(self, client, monkeypatch):
+        """
+        Test: /health refleja el commit inyectado por Render
+        Given: Render inyecta RENDER_GIT_COMMIT y RENDER_GIT_BRANCH en el entorno
+        When: Se hace GET request a /health
+        Then: Los devuelve tal cual, permitiendo comparar con el SHA liberado
+        """
+        monkeypatch.setenv("RENDER_GIT_COMMIT", "abc1234def5678")
+        monkeypatch.setenv("RENDER_GIT_BRANCH", "main")
+
+        data = client.get("/health").json()
+
+        assert data["commit"] == "abc1234def5678"
+        assert data["branch"] == "main"
+
+    def test_health_endpoint_without_render_env(self, client, monkeypatch):
+        """
+        Test: /health degrada limpiamente fuera de Render
+        Given: Un entorno sin las variables de Render (local, Docker, k8s)
+        When: Se hace GET request a /health
+        Then: Devuelve "unknown" en vez de fallar
+        """
+        monkeypatch.delenv("RENDER_GIT_COMMIT", raising=False)
+        monkeypatch.delenv("RENDER_GIT_BRANCH", raising=False)
+
+        data = client.get("/health").json()
+
+        assert data["commit"] == "unknown"
+        assert data["branch"] == "unknown"
 
 
 # ================================


### PR DESCRIPTION
Closes #158

## Problem

There was no reliable way to tell which release was running in production — an open question since v2.2.0.

- **`/health` did not exist.** It was listed as a CSRF-exempt route in `csrf_config.py:43`, but the route was never registered. The deleted `render.yaml` pointed `healthCheckPath` at it, so that check would have failed.
- **The only endpoint that answered reported a fake version.** `GET /` returned `"version": "1.0.0"`, hardcoded in `main.py` twice, while the project is on 2.4.x. It cannot distinguish one deploy from another.
- **The documented URL is dead.** `rydercup-api.onrender.com` returns **404** (verified).

## Solution

`GET /health` now returns what actually identifies a deploy:

```json
{"status":"ok","version":"2.4.0","commit":"abc1234","branch":"main","environment":"production"}
```

`commit` and `branch` come from `RENDER_GIT_COMMIT` / `RENDER_GIT_BRANCH`, which Render injects on every deploy — exact identification at zero maintenance cost, degrading to `"unknown"` outside Render.

Version moves to `src/config/version.py` as a single source of truth, replacing both hardcoded literals. **It has to be bumped in the release preparation commit**, the same way the frontend bumps `package.json`.

`GET /` is kept as is for compatibility, reading the same constant.

## Production verified

While investigating I confirmed against the live API that **v2.4.0 is deployed**:

- `https://api.rydercupfriends.com/` → **200**
- Its `openapi.json` exposes `/api/v1/admin/stats`, `/api/v1/admin/users/{id}/active` and `/api/v1/quick-matches/{id}/hide` — all v2.4.0 features
- `https://rydercup-api.onrender.com/` → **404**, confirming the documented URL is stale

So deployment was working all along; it was simply unverifiable.

## Documentation

`DEPLOYMENT.md` and `docs/MULTI_ENVIRONMENT_SETUP.md` pointed at the dead onrender.com host; both now use `api.rydercupfriends.com` and document how to check the deployed release.

Worth knowing: **there is no `render.yaml` in this repo.** It existed for ten minutes in Dec 2025 (`ee8431b`, reverted by `f45e963`) and all deploy configuration lives only in the Render dashboard. That single fact is the origin of both the phantom `/health` and the stale hostname.

## Test plan

- [x] `pytest tests/unit/ tests/integration/ tests/security/` — 2725 passed, 1 skipped
- [x] 4 new tests covering `/health`: public access, response shape, Render env vars, and graceful degradation without them
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `ruff check` / `ruff format --check` — no new findings

## Follow-ups (not in this PR)

- Restore `render.yaml` as a Blueprint so deploy config is auditable from git again
- Post-deploy smoke test in CI polling `/health` until `commit` matches the released SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)