### PR TITLE
fix(k8s): Always set image explicitly in deploy scripts

### DIFF
--- a/k8s/scripts/deploy-api.sh
+++ b/k8s/scripts/deploy-api.sh
@@ -163,14 +163,26 @@ update_deployment() {
 
     local tag="${DOCKER_IMAGE}:${VERSION}"
 
-    # Si es "latest", usar rollout restart (fuerza a usar nueva imagen)
-    if [ "$VERSION" == "latest" ]; then
-        print_info "Reiniciando deployment (usando nueva imagen)..."
+    # Imagen que el deployment tiene configurada ahora mismo
+    local current_image
+    current_image=$(kubectl get deployment/$DEPLOYMENT_NAME -n $NAMESPACE \
+        -o jsonpath="{.spec.template.spec.containers[?(@.name=='${CONTAINER_NAME}')].image}")
+
+    # Siempre fijamos la imagen explícitamente: si el deployment se quedó apuntando
+    # a una imagen ad-hoc de alguna prueba manual (p.ej. rydercup-api:localtest),
+    # un simple 'rollout restart' relanzaría esa imagen vieja en lugar de la recién construida
+    if [ -n "$current_image" ] && [ "$current_image" != "$tag" ]; then
+        print_warning "El deployment apuntaba a otra imagen: $current_image"
+    fi
+
+    print_info "Fijando imagen a: $tag"
+    kubectl set image deployment/$DEPLOYMENT_NAME $CONTAINER_NAME=$tag -n $NAMESPACE
+
+    # Si la imagen ya era la correcta, 'set image' no modifica el spec y no dispara
+    # ningún rollout: hace falta un restart para que los pods recojan la build nueva
+    if [ "$current_image" == "$tag" ]; then
+        print_info "La imagen ya estaba fijada; reiniciando para recoger la nueva build..."
         kubectl rollout restart deployment/$DEPLOYMENT_NAME -n $NAMESPACE
-    else
-        # Si es una versión específica, actualizar la imagen
-        print_info "Actualizando imagen a: $tag"
-        kubectl set image deployment/$DEPLOYMENT_NAME $CONTAINER_NAME=$tag -n $NAMESPACE
     fi
 
     print_success "Comando de actualización ejecutado"

--- a/k8s/scripts/deploy-front.sh
+++ b/k8s/scripts/deploy-front.sh
@@ -180,14 +180,26 @@ update_deployment() {
 
     local tag="${DOCKER_IMAGE}:${VERSION}"
 
-    # Si es "latest", usar rollout restart (fuerza a usar nueva imagen)
-    if [ "$VERSION" == "latest" ]; then
-        print_info "Reiniciando deployment (usando nueva imagen)..."
+    # Imagen que el deployment tiene configurada ahora mismo
+    local current_image
+    current_image=$(kubectl get deployment/$DEPLOYMENT_NAME -n $NAMESPACE \
+        -o jsonpath="{.spec.template.spec.containers[?(@.name=='${CONTAINER_NAME}')].image}")
+
+    # Siempre fijamos la imagen explícitamente: si el deployment se quedó apuntando
+    # a una imagen ad-hoc de alguna prueba manual, un simple 'rollout restart'
+    # relanzaría esa imagen vieja en lugar de la recién construida
+    if [ -n "$current_image" ] && [ "$current_image" != "$tag" ]; then
+        print_warning "El deployment apuntaba a otra imagen: $current_image"
+    fi
+
+    print_info "Fijando imagen a: $tag"
+    kubectl set image deployment/$DEPLOYMENT_NAME $CONTAINER_NAME=$tag -n $NAMESPACE
+
+    # Si la imagen ya era la correcta, 'set image' no modifica el spec y no dispara
+    # ningún rollout: hace falta un restart para que los pods recojan la build nueva
+    if [ "$current_image" == "$tag" ]; then
+        print_info "La imagen ya estaba fijada; reiniciando para recoger la nueva build..."
         kubectl rollout restart deployment/$DEPLOYMENT_NAME -n $NAMESPACE
-    else
-        # Si es una versión específica, actualizar la imagen
-        print_info "Actualizando imagen a: $tag"
-        kubectl set image deployment/$DEPLOYMENT_NAME $CONTAINER_NAME=$tag -n $NAMESPACE
     fi
 
     print_success "Comando de actualización ejecutado"


### PR DESCRIPTION
## Problem

The API pods in the local Kind cluster were stuck in `CrashLoopBackOff`:

```
ERROR [alembic.util.messaging] Can't locate revision identified by 'c7d1e4f8a2b6'
FAILED: Can't locate revision identified by 'c7d1e4f8a2b6'
❌ Error al ejecutar migraciones
```

The database was **not** the problem — it was at the correct head. The deployment had been left pointing at an ad-hoc image (`rydercup-api:localtest`, built before #155 was merged) by a manual `kubectl set image`, so it did not contain that migration's file at all. The two older pods kept running because their containers had never restarted, which masked the drift until a `kubectl rollout restart` created new ones.

## Root cause in the scripts

`update_deployment()` only ran `kubectl set image` when a specific version was passed. With the default `latest` it ran `kubectl rollout restart`, which relaunches **whatever image the deployment currently points at** — the stale one. So the script could never recover from image drift; it just rebuilt an image nobody was using.

## Fix

In both `deploy-api.sh` and `deploy-front.sh`:

- Always run `kubectl set image` explicitly, whatever the version.
- Warn when the deployment was pointing somewhere else, so the drift is visible instead of silent.
- Keep a `rollout restart` **only** for the case where the image was already correct — there `set image` is a no-op that triggers no rollout, so without the restart the pods would keep running the previous build of the same tag.

## Testing

- `bash -n` clean on both scripts.
- The container-name jsonpath verified against the live cluster for both deployments (`fastapi` → `agustinedev/rydercupam-api:latest`, `nginx` → `agustinedev/rydercupam-web:latest`).
- The cluster itself was already recovered by applying the `set image` this change automates; API pods are healthy and `/health` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployments now consistently apply the requested container version.
  - Deployments warn when the currently running version differs from the requested version.
  - Re-deployments restart services even when the version tag is unchanged, ensuring newly built content is loaded for both the API and front end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->