### PR TITLE
feat(api): Player statistics and recent matches endpoints

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -318,6 +318,12 @@ from src.modules.user.application.use_cases.get_current_user_use_case import (
 from src.modules.user.application.use_cases.get_my_avatar_upload_image_use_case import (
     GetMyAvatarUploadImageUseCase,
 )
+from src.modules.user.application.use_cases.get_player_stats_use_case import (
+    GetPlayerStatsUseCase,
+)
+from src.modules.user.application.use_cases.get_recent_matches_use_case import (
+    GetRecentMatchesUseCase,
+)
 from src.modules.user.application.use_cases.google_login_use_case import (
     GoogleLoginUseCase,
 )
@@ -1200,6 +1206,26 @@ def get_get_admin_stats_use_case(
 ) -> GetAdminStatsUseCase:
     """Proveedor del caso de uso GetAdminStatsUseCase."""
     return GetAdminStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+
+def get_get_player_stats_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> GetPlayerStatsUseCase:
+    """Proveedor del caso de uso GetPlayerStatsUseCase."""
+    return GetPlayerStatsUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
+
+
+def get_get_recent_matches_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+) -> GetRecentMatchesUseCase:
+    """Proveedor del caso de uso GetRecentMatchesUseCase."""
+    return GetRecentMatchesUseCase(user_uow, competition_uow, quick_match_uow, golf_course_uow)
 
 
 def get_create_quick_match_use_case(

--- a/src/modules/competition/domain/repositories/match_repository_interface.py
+++ b/src/modules/competition/domain/repositories/match_repository_interface.py
@@ -2,6 +2,8 @@
 
 from abc import ABC, abstractmethod
 
+from src.modules.user.domain.value_objects.user_id import UserId
+
 from ..entities.match import Match
 from ..value_objects.match_id import MatchId
 from ..value_objects.round_id import RoundId
@@ -23,6 +25,20 @@ class MatchRepositoryInterface(ABC):
     @abstractmethod
     async def find_by_id(self, match_id: MatchId) -> Match | None:
         """Busca un partido por su ID."""
+        pass
+
+    @abstractmethod
+    @abstractmethod
+    async def find_completed_for_player(
+        self, user_id: UserId, limit: int | None = None
+    ) -> list[Match]:
+        """
+        Partidos terminados en los que el usuario jugó, del más reciente al más
+        antiguo por fecha de la ronda.
+
+        Alimenta las estadísticas e historial del jugador (BE #128). Solo
+        cuenta lo terminado: un partido a medias todavía no dice cómo quedó.
+        """
         pass
 
     @abstractmethod

--- a/src/modules/competition/domain/repositories/match_repository_interface.py
+++ b/src/modules/competition/domain/repositories/match_repository_interface.py
@@ -28,7 +28,6 @@ class MatchRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    @abstractmethod
     async def find_completed_for_player(
         self, user_id: UserId, limit: int | None = None
     ) -> list[Match]:

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -103,24 +103,45 @@ class PlayingHandicapCalculator:
             Playing Handicap redondeado al entero más cercano (>=0), acotado a
             max_playing_handicap si se proporciona
         """
-        # Paso 1: Calcular Course Handicap
-        # CH = HI x (SR / 113) + (CR - Par)
-        slope_factor = Decimal(tee_rating.slope_rating) / Decimal(NEUTRAL_SLOPE)
-        differential = tee_rating.course_rating - Decimal(tee_rating.par)
-        course_handicap = (handicap_index * slope_factor) + differential
-
-        # Paso 2: Aplicar allowance
-        allowance_factor = Decimal(allowance_percentage) / Decimal(100)
-        playing_handicap_raw = course_handicap * allowance_factor
-
-        # Paso 3: Redondear al entero más cercano (0.5 hacia arriba)
-        playing_handicap = int(playing_handicap_raw.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+        playing_handicap = self.calculate_unbounded(
+            handicap_index, tee_rating, allowance_percentage
+        )
 
         # Playing Handicap no puede ser negativo
         result = max(0, playing_handicap)
         if max_playing_handicap is not None:
             result = min(result, max_playing_handicap)
         return result
+
+    def calculate_unbounded(
+        self,
+        handicap_index: Decimal,
+        tee_rating: TeeRating,
+        allowance_percentage: int,
+    ) -> int:
+        """
+        Playing Handicap sin acotar a cero, para jugadores de hándicap plus.
+
+        `calculate()` acota el resultado a >= 0, de modo que un jugador plus no
+        llega a ceder golpes. Eso vale para el flujo de competición, que es
+        donde se usa, pero no para la clasificación Stableford de una partida
+        rápida: ahí un plus sí cede golpes (Regla WHS 8.2), y es lo que el
+        frontend viene calculando y mostrando.
+
+        Se expone como método propio en lugar de cambiar `calculate()` para no
+        alterar el reparto de golpes de las competiciones ya creadas.
+        """
+        # CH = HI x (SR / 113) + (CR - Par)
+        slope_factor = Decimal(tee_rating.slope_rating) / Decimal(NEUTRAL_SLOPE)
+        differential = tee_rating.course_rating - Decimal(tee_rating.par)
+        course_handicap = (handicap_index * slope_factor) + differential
+
+        allowance_factor = Decimal(allowance_percentage) / Decimal(100)
+        playing_handicap_raw = course_handicap * allowance_factor
+
+        # ROUND_HALF_UP de Decimal redondea alejándose del cero (-2.5 -> -3),
+        # que es justo lo que hace `roundHalfAwayFromZero` en el frontend
+        return int(playing_handicap_raw.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
     def calculate_for_singles(
         self,

--- a/src/modules/competition/infrastructure/persistence/in_memory/in_memory_match_repository.py
+++ b/src/modules/competition/infrastructure/persistence/in_memory/in_memory_match_repository.py
@@ -5,7 +5,9 @@ from src.modules.competition.domain.repositories.match_repository_interface impo
     MatchRepositoryInterface,
 )
 from src.modules.competition.domain.value_objects.match_id import MatchId
+from src.modules.competition.domain.value_objects.match_status import MatchStatus
 from src.modules.competition.domain.value_objects.round_id import RoundId
+from src.modules.user.domain.value_objects.user_id import UserId
 
 
 class InMemoryMatchRepository(MatchRepositoryInterface):
@@ -23,6 +25,28 @@ class InMemoryMatchRepository(MatchRepositoryInterface):
 
     async def find_by_id(self, match_id: MatchId) -> Match | None:
         return self._matches.get(match_id)
+
+    async def find_completed_for_player(
+        self, user_id: UserId, limit: int | None = None
+    ) -> list[Match]:
+        """
+        Partidos terminados del jugador, del más reciente al más antiguo.
+
+        Ordena por `created_at` del partido, mientras que la implementación
+        real ordena por la fecha de la ronda: aquí no hay rondas a las que
+        preguntar. Para el orden de verdad están los tests de integración.
+        """
+        played = [
+            match
+            for match in self._matches.values()
+            if match.status == MatchStatus.COMPLETED
+            and any(
+                player.user_id == user_id
+                for player in (*match.team_a_players, *match.team_b_players)
+            )
+        ]
+        played.sort(key=lambda match: match.created_at, reverse=True)
+        return played[:limit] if limit is not None else played
 
     async def find_by_round(self, round_id: RoundId) -> list[Match]:
         return [m for m in self._matches.values() if m.round_id == round_id]

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/match_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/match_repository.py
@@ -1,13 +1,20 @@
 """Match Repository - SQLAlchemy Implementation."""
 
-from sqlalchemy import select
+from sqlalchemy import cast, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.competition.domain.entities.match import Match
 from src.modules.competition.domain.repositories.match_repository_interface import (
     MatchRepositoryInterface,
 )
 from src.modules.competition.domain.value_objects.match_id import MatchId
+from src.modules.competition.domain.value_objects.match_status import MatchStatus
 from src.modules.competition.domain.value_objects.round_id import RoundId
+from src.modules.competition.infrastructure.persistence.sqlalchemy.mappers import (
+    matches_table,
+    rounds_table,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
 
 
 class SQLAlchemyMatchRepository(MatchRepositoryInterface):
@@ -24,6 +31,41 @@ class SQLAlchemyMatchRepository(MatchRepositoryInterface):
 
     async def find_by_id(self, match_id: MatchId) -> Match | None:
         return await self._session.get(Match, match_id)
+
+    async def find_completed_for_player(
+        self, user_id: UserId, limit: int | None = None
+    ) -> list[Match]:
+        """
+        Partidos terminados del jugador, del más reciente al más antiguo.
+
+        Los jugadores viven en dos columnas JSONB (`team_a_players` y
+        `team_b_players`), sin clave ajena, así que se buscan por contención
+        (`@>`) igual que las partidas rápidas buscan a sus participantes.
+
+        Ojo al rendimiento: esas columnas no tienen índice, de modo que esto
+        recorre la tabla entera de partidos. Con el tamaño actual no supone
+        nada; si `matches` crece, el sitio donde poner un índice GIN es este.
+
+        La fecha sale de la ronda, no del partido: `matches` no guarda cuándo
+        se jugó, solo cuándo se creó la fila.
+        """
+        player_in_match = or_(
+            matches_table.c.team_a_players.op("@>")(cast([{"user_id": str(user_id.value)}], JSONB)),
+            matches_table.c.team_b_players.op("@>")(cast([{"user_id": str(user_id.value)}], JSONB)),
+        )
+
+        statement = (
+            select(Match)
+            .join(rounds_table, matches_table.c.round_id == rounds_table.c.id)
+            .where(player_in_match)
+            .where(matches_table.c.status == MatchStatus.COMPLETED)
+            .order_by(rounds_table.c.round_date.desc(), matches_table.c.match_number.asc())
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+
+        result = await self._session.execute(statement)
+        return list(result.scalars().all())
 
     async def find_by_round(self, round_id: RoundId) -> list[Match]:
         statement = (

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -23,6 +23,10 @@ from src.modules.competition.domain.services.playing_handicap_calculator import 
 
 HOLES_PER_ROUND = 18
 
+# Doble bogey neto: el tope por hoyo que el WHS aplica a lo que puntúa para
+# hándicap (Regla 3.1)
+NET_DOUBLE_BOGEY_OVER_PAR = 2
+
 
 @dataclass(frozen=True)
 class HoleSetup:
@@ -118,6 +122,20 @@ class StablefordCalculator:
         net_score = gross_score - strokes_received
         return max(0, 2 - (net_score - par))
 
+    @staticmethod
+    def adjusted_gross(gross_score: int, par: int, strokes_received: int) -> int:
+        """
+        Golpes del hoyo topados en el net double bogey (Regla WHS 3.1).
+
+        Máximo computable: doble bogey neto, o sea `par + 2 + golpes recibidos`.
+        Sin ese tope, un hoyo desastroso mueve la media de una temporada entera,
+        que es justo lo que la regla existe para evitar.
+
+        No afecta a los puntos Stableford: un hoyo en net double bogey ya vale
+        cero puntos, y a partir de ahí sigue valiendo cero.
+        """
+        return min(gross_score, par + NET_DOUBLE_BOGEY_OVER_PAR + strokes_received)
+
     def compute_participant_totals(
         self,
         handicap: float | None,
@@ -125,12 +143,19 @@ class StablefordCalculator:
         scores_by_hole: dict[int, int],
         tee_rating: TeeRating | None = None,
         allowance_percentage: int = 100,
+        cap_at_net_double_bogey: bool = False,
     ) -> ParticipantTotals:
         """
         Agrega puntos y golpes de un participante sobre los hoyos anotados.
 
         Los hoyos sin score no cuentan: una partida a medias puntúa por lo
         jugado, no por lo que falta.
+
+        `cap_at_net_double_bogey` topa cada hoyo en el máximo que el WHS deja
+        computar para hándicap. Va apagado por defecto porque el detalle de la
+        partida enseña los golpes que se dieron, no los que puntúan; lo encienden
+        las estadísticas agregadas, donde un hoyo suelto no debe pesar más que
+        una temporada.
         """
         strokes_basis = self.resolve_strokes_basis(handicap, tee_rating, allowance_percentage)
 
@@ -148,7 +173,12 @@ class StablefordCalculator:
             strokes_received = self.allocate_strokes(strokes_basis, hole.stroke_index)
             stableford_points += self.hole_points(score, hole.par, strokes_received)
             total_strokes += score
-            net_strokes += score - strokes_received
+            computable = (
+                self.adjusted_gross(score, hole.par, strokes_received)
+                if cap_at_net_double_bogey
+                else score
+            )
+            net_strokes += computable - strokes_received
             par_played += hole.par
             holes_played += 1
 

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -21,6 +21,10 @@ from src.modules.competition.domain.services.playing_handicap_calculator import 
     TeeRating,
 )
 
+# El catálogo solo admite campos de 18 hoyos: `GolfCourse` lo valida como
+# invariante y rechaza cualquier otro número. Por eso el reparto de golpes es
+# una constante y no se deriva del campo. El día que se admitan campos de nueve
+# hay que derivarlo de los hoyos recibidos, aquí y en la inversión del 19.
 HOLES_PER_ROUND = 18
 
 # Doble bogey neto: el tope por hoyo que el WHS aplica a lo que puntúa para

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -1,0 +1,168 @@
+"""
+Domain Service: StablefordCalculator.
+
+Calcula puntos Stableford y totales de golpes de los participantes de una
+partida rápida. Puro, sin IO.
+
+Portado del `StablefordCalculator` del frontend (BE #128), que hasta ahora era
+el único sitio donde vivían estas reglas. Mientras las dos implementaciones
+coexistan, `tests/unit/modules/quick_match/domain/services/
+test_stableford_calculator.py` fija la paridad con los valores que el frontend
+produce hoy.
+
+Puntos por hoyo: max(0, 2 - (neto - par)).
+"""
+
+from dataclasses import dataclass
+from decimal import ROUND_FLOOR, Decimal
+
+from src.modules.competition.domain.services.playing_handicap_calculator import (
+    PlayingHandicapCalculator,
+    TeeRating,
+)
+
+HOLES_PER_ROUND = 18
+
+
+@dataclass(frozen=True)
+class HoleSetup:
+    """Un hoyo del campo: su par y su dificultad relativa."""
+
+    hole_number: int
+    par: int
+    stroke_index: int
+
+
+@dataclass(frozen=True)
+class ParticipantTotals:
+    """Totales de un participante sobre los hoyos que ya tienen score."""
+
+    stableford_points: int
+    total_strokes: int
+    net_strokes: int
+    par_played: int
+    holes_played: int
+
+    @property
+    def to_par(self) -> int:
+        """Golpes netos respecto al par de lo jugado."""
+        return self.net_strokes - self.par_played
+
+
+class StablefordCalculator:
+    """Puntuación Stableford y golpes netos de una partida rápida."""
+
+    def __init__(self, playing_handicap_calculator: PlayingHandicapCalculator | None = None):
+        self._playing_handicap_calculator = (
+            playing_handicap_calculator or PlayingHandicapCalculator()
+        )
+
+    def resolve_strokes_basis(
+        self,
+        handicap: float | None,
+        tee_rating: TeeRating | None,
+        allowance_percentage: int,
+    ) -> Decimal | None:
+        """
+        Hándicap con el que se reparten los golpes.
+
+        Si el participante eligió un tee del campo, su Playing Handicap; si no,
+        su hándicap tal cual contra el stroke index. Devuelve None cuando no hay
+        hándicap conocido: ese participante no recibe golpes.
+        """
+        if handicap is None:
+            return None
+        if tee_rating is None:
+            return Decimal(str(handicap))
+
+        # Sin acotar: un jugador plus cede golpes (Regla WHS 8.2)
+        playing_handicap = self._playing_handicap_calculator.calculate_unbounded(
+            Decimal(str(handicap)), tee_rating, allowance_percentage
+        )
+        return Decimal(playing_handicap)
+
+    @staticmethod
+    def allocate_strokes(handicap: Decimal | None, stroke_index: int) -> int:
+        """
+        Golpes que recibe (o cede, si es plus) un participante en un hoyo.
+
+        stroke_index va de 1 (el hoyo más difícil) a 18 (el más fácil).
+        """
+        if handicap is None:
+            return 0
+
+        # floor(x + 0.5), que es lo que hace `Math.round` en el frontend: el
+        # medio va siempre hacia arriba, tambien en negativos (-2.5 -> -2).
+        # ROUND_HALF_UP de Decimal se aleja del cero y daria -3.
+        rounded = int((handicap + Decimal("0.5")).to_integral_value(rounding=ROUND_FLOOR))
+        if rounded == 0:
+            return 0
+
+        if rounded > 0:
+            base = rounded // HOLES_PER_ROUND
+            extra = 1 if (rounded % HOLES_PER_ROUND) >= stroke_index else 0
+            return base + extra
+
+        # Jugador plus: la Regla WHS 8.2 quita golpes empezando por el hoyo más
+        # fácil (stroke index más alto) y hacia atrás
+        magnitude = abs(rounded)
+        base = -(magnitude // HOLES_PER_ROUND)
+        extra = -1 if (magnitude % HOLES_PER_ROUND) >= (19 - stroke_index) else 0
+        return base + extra
+
+    @staticmethod
+    def hole_points(gross_score: int | None, par: int, strokes_received: int) -> int:
+        """Puntos Stableford de un hoyo."""
+        if gross_score is None:
+            return 0
+        net_score = gross_score - strokes_received
+        return max(0, 2 - (net_score - par))
+
+    def compute_participant_totals(
+        self,
+        handicap: float | None,
+        holes: list[HoleSetup],
+        scores_by_hole: dict[int, int],
+        tee_rating: TeeRating | None = None,
+        allowance_percentage: int = 100,
+    ) -> ParticipantTotals:
+        """
+        Agrega puntos y golpes de un participante sobre los hoyos anotados.
+
+        Los hoyos sin score no cuentan: una partida a medias puntúa por lo
+        jugado, no por lo que falta.
+        """
+        strokes_basis = self.resolve_strokes_basis(handicap, tee_rating, allowance_percentage)
+
+        stableford_points = 0
+        total_strokes = 0
+        net_strokes = 0
+        par_played = 0
+        holes_played = 0
+
+        for hole in holes:
+            score = scores_by_hole.get(hole.hole_number)
+            if score is None:
+                continue
+
+            strokes_received = self.allocate_strokes(strokes_basis, hole.stroke_index)
+            stableford_points += self.hole_points(score, hole.par, strokes_received)
+            total_strokes += score
+            net_strokes += score - strokes_received
+            par_played += hole.par
+            holes_played += 1
+
+        return ParticipantTotals(
+            stableford_points=stableford_points,
+            total_strokes=total_strokes,
+            net_strokes=net_strokes,
+            par_played=par_played,
+            holes_played=holes_played,
+        )
+
+    @staticmethod
+    def format_to_par(to_par: int) -> str:
+        """Notación de golf: "PAR" si iguala, y con signo si no ("-3", "+4")."""
+        if to_par == 0:
+            return "PAR"
+        return f"+{to_par}" if to_par > 0 else str(to_par)

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -1,0 +1,65 @@
+"""DTOs de estadísticas de jugador (BE #128)."""
+
+# El DTO expone un campo llamado `date`, que sombrearia al tipo dentro de la
+# clase: de ahi el alias
+from datetime import date as date_type
+
+from pydantic import BaseModel, Field
+
+
+class PlayerStatsResponseDTO(BaseModel):
+    """
+    Resumen de rendimiento de un jugador, para el panel.
+
+    `scoring_avg` es la media de golpes netos respecto al par de lo jugado, no
+    de golpes brutos: comparar brutos entre campos y hándicaps distintos no
+    dice nada. Va en None cuando no hay ninguna ronda terminada, que no es lo
+    mismo que una media de cero.
+    """
+
+    handicap: float | None = None
+    handicap_trend: float | None = Field(
+        default=None,
+        description=(
+            "Siempre None por ahora: no existe histórico de hándicap, solo la "
+            "fecha del último cambio. Calcularlo exige tabla nueva (BE #128)."
+        ),
+    )
+    scoring_avg: float | None = None
+    rounds_played: int = 0
+    tournaments_total: int = 0
+    tournaments_active: int = 0
+
+
+class RecentMatchDTO(BaseModel):
+    """
+    Una entrada del historial de partidas.
+
+    Unifica partidas rápidas y partidos de torneo, que son cosas distintas: de
+    ahí que casi todo sea opcional. `match_format` y `scoring_format` se
+    exponen por separado en lugar de fundirse en un único campo `format`,
+    porque en el dominio son ejes distintos y mutuamente excluyentes.
+    """
+
+    id: str
+    date: date_type | None = None
+    match_format: str | None = None
+    scoring_format: str | None = None
+    golf_course_id: str | None = None
+    golf_course_name: str | None = None
+    tournament_name: str | None = None
+    result: str | None = Field(
+        default=None, description="WON / LOST / HALVED en match play; None si no aplica"
+    )
+    score: str | None = Field(
+        default=None, description='Neto respecto al par ("PAR", "+4") o puntos Stableford'
+    )
+    stableford_points: int | None = None
+    partners: list[str] = Field(default_factory=list)
+    opponents: list[str] = Field(default_factory=list)
+
+
+class RecentMatchesResponseDTO(BaseModel):
+    """Historial de partidas del jugador, de la más reciente a la más antigua."""
+
+    matches: list[RecentMatchDTO] = Field(default_factory=list)

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -11,11 +11,15 @@ class PlayerStatsResponseDTO(BaseModel):
     """
     Resumen de rendimiento de un jugador, para el panel.
 
-    `scoring_avg` es la media de golpes netos respecto al par de lo jugado, no
-    de golpes brutos: comparar brutos entre campos y hándicaps distintos no
-    dice nada. Entran todas las tarjetas, de partida rápida y de torneo, con
-    cada hoyo topado en el net double bogey (Regla WHS 3.1). Va en None cuando
-    no hay ninguna ronda terminada, que no es lo mismo que una media de cero.
+    Solo cuentan las vueltas enteras de partidas terminadas, de partida rápida
+    y de torneo. Una tarjeta a la que le falta un hoyo no entra ni en la media
+    ni en `rounds_played`: los dos números hablan siempre de las mismas rondas.
+
+    `scoring_avg` es la media de golpes netos respecto al par, no de golpes
+    brutos: comparar brutos entre campos y hándicaps distintos no dice nada.
+    Cada hoyo va topado en el net double bogey (Regla WHS 3.1). Va en None
+    cuando no hay ninguna vuelta computable, que no es lo mismo que una media
+    de cero.
     """
 
     handicap: float | None = None

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -13,8 +13,9 @@ class PlayerStatsResponseDTO(BaseModel):
 
     `scoring_avg` es la media de golpes netos respecto al par de lo jugado, no
     de golpes brutos: comparar brutos entre campos y hándicaps distintos no
-    dice nada. Va en None cuando no hay ninguna ronda terminada, que no es lo
-    mismo que una media de cero.
+    dice nada. Entran todas las tarjetas, de partida rápida y de torneo, con
+    cada hoyo topado en el net double bogey (Regla WHS 3.1). Va en None cuando
+    no hay ninguna ronda terminada, que no es lo mismo que una media de cero.
     """
 
     handicap: float | None = None

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -30,6 +30,12 @@ class GetPlayerStatsUseCase:
     """
     Agrega el rendimiento de un jugador a partir de los módulos que lo generan.
 
+    Solo cuentan las **vueltas enteras de partidas terminadas**: partida a
+    medias, tarjeta a medias o hoyo sin anotar quedan fuera, tanto de la media
+    como del contador de rondas. Media docena de vueltas comparables valen más
+    que veinte a medio anotar, y un `rounds_played` que incluyera rondas que no
+    entran en la media daría dos números que no cuadran entre sí.
+
     Sigue el patrón de `GetAdminStatsUseCase`: los casos de uso de `user`
     reciben las unidades de trabajo de los módulos que consultan, en lugar de
     crear un módulo de lectura aparte.
@@ -67,7 +73,7 @@ class GetPlayerStatsUseCase:
             user = await self._user_uow.users.find_by_id(user_id)
             handicap = float(user.handicap.value) if user and user.handicap else None
 
-        quick_rounds_played, quick_rounds_to_par = await self._collect_quick_match_rounds(
+        quick_rounds_to_par = await self._collect_quick_match_rounds(
             user_id, golf_course_id, handicap
         )
 
@@ -102,8 +108,9 @@ class GetPlayerStatsUseCase:
             competition_matches, rounds_by_match, scorecards
         )
 
-        rounds_played = quick_rounds_played + len(competition_matches)
-        scoring_avg = self._average_to_par(quick_rounds_to_par + competition_rounds_to_par)
+        computable_rounds = quick_rounds_to_par + competition_rounds_to_par
+        rounds_played = len(computable_rounds)
+        scoring_avg = self._average_to_par(computable_rounds)
 
         return PlayerStatsResponseDTO(
             handicap=handicap,
@@ -119,19 +126,18 @@ class GetPlayerStatsUseCase:
         user_id: UserId,
         golf_course_id: GolfCourseId | None,
         profile_handicap: float | None,
-    ) -> tuple[int, list[int]]:
+    ) -> list[int]:
         """
-        Rondas rápidas jugadas y su neto respecto al par.
+        Neto respecto al par de cada vuelta rápida computable.
 
-        Se devuelven por separado a propósito: una partida sin scores
-        recuperables (campo borrado, vuelta sin anotar) se jugó igual y cuenta
-        como ronda, aunque no pueda aportar nada a la media.
+        Solo entran las partidas terminadas con la tarjeta entera: una vuelta a
+        medias no se puede comparar con una completa, y con el campo borrado no
+        hay ni pares contra los que medirla.
 
         `list_for_user` ya descarta las que el propio usuario ocultó (#127), y
         lo hace por participante: una partida que A ocultó sigue contando para
         B. Esa regla se hereda tal cual en lugar de reimplementarse aquí.
         """
-        rounds_played = 0
         results: list[int] = []
 
         async with self._quick_match_uow, self._golf_course_uow:
@@ -147,8 +153,6 @@ class GetPlayerStatsUseCase:
                 if participant is None:
                     continue
 
-                rounds_played += 1
-
                 course = await self._golf_course_uow.golf_courses.find_by_id(match.golf_course_id)
                 if course is None:
                     continue
@@ -161,7 +165,7 @@ class GetPlayerStatsUseCase:
                     for score in scores
                     if score.participant_id == participant.participant_id
                 }
-                if not scores_by_hole:
+                if not self._is_full_scorecard(scores_by_hole, course):
                     continue
 
                 holes = [
@@ -179,7 +183,17 @@ class GetPlayerStatsUseCase:
                 )
                 results.append(totals.to_par)
 
-        return rounds_played, results
+        return results
+
+    @staticmethod
+    def _is_full_scorecard(scores_by_hole: dict, course) -> bool:
+        """
+        La tarjeta está entera cuando ningún hoyo del campo se quedó sin anotar.
+
+        Se compara contra los hoyos que tiene el campo y no contra un 18 fijo:
+        el día que se admitan campos de nueve, la regla sigue siendo la misma.
+        """
+        return all(hole.number in scores_by_hole for hole in course.holes)
 
     async def _rounds_by_match(self, matches: list) -> dict:
         """
@@ -211,7 +225,7 @@ class GetPlayerStatsUseCase:
 
         El formato del partido da igual: en match play también firmas una
         tarjeta con tus golpes, y esa tarjeta dice a qué nivel jugaste tan bien
-        como la de una vuelta de medal.
+        como la de una vuelta de medal. Solo entran las que estén enteras.
 
         Se usa `own_score`, no el `net_score` de la entidad: ese solo se calcula
         cuando el marcador ha validado el hoyo, así que media tarjeta legítima
@@ -243,31 +257,32 @@ class GetPlayerStatsUseCase:
 
     def _scorecard_to_par(self, hole_scores: list, course) -> int | None:
         """
-        Neto respecto al par de una tarjeta, o None si no hay nada anotado.
+        Neto respecto al par de una tarjeta entera, o None si le falta un hoyo.
 
-        Los hoyos concedidos o sin anotar (`own_score` a None) se quedan fuera
-        en lugar de rellenarse: en match play te dan hoyos que ibas ganando, y
-        contarlos como doble bogey castigaría por ir por delante. La vuelta se
-        mide contra el par de lo que sí se jugó, igual que en partida rápida.
+        Un hoyo con `own_score` a None no se rellena ni se ignora: invalida la
+        vuelta. En match play es lo normal —te conceden los hoyos que ibas
+        ganando y el partido se cierra antes del 18—, así que un partido
+        decidido en el 15 no entra en las estadísticas por mucho que esté
+        terminado. Es el precio de que la media compare vueltas iguales.
         """
         pars = {hole.number: hole.par for hole in course.holes}
+        scored = {
+            hole_score.hole_number: hole_score
+            for hole_score in hole_scores
+            if hole_score.own_score is not None
+        }
+        if not all(hole_number in scored for hole_number in pars):
+            return None
 
         to_par = 0
-        holes_played = 0
-        for hole_score in hole_scores:
-            if hole_score.own_score is None:
-                continue
-            par = pars.get(hole_score.hole_number)
-            if par is None:
-                continue
-
+        for hole_number, par in pars.items():
+            hole_score = scored[hole_number]
             computable = self._calculator.adjusted_gross(
                 hole_score.own_score, par, hole_score.strokes_received
             )
             to_par += computable - hole_score.strokes_received - par
-            holes_played += 1
 
-        return to_par if holes_played else None
+        return to_par
 
     @staticmethod
     def _find_participant(match, user_id: UserId):

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -21,8 +21,9 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
-# Tope de partidas que se agregan para la media. Sin él, una cuenta con años de
-# historial cargaría todos sus scores para calcular un único número.
+# Tope de partidas que se agregan para la media, por cada fuente. Sin él, una
+# cuenta con años de historial cargaría todos sus scores para calcular un único
+# número, y en torneo cada partido añade además una consulta de tarjeta.
 MAX_ROUNDS_AGGREGATED = 100
 
 
@@ -79,7 +80,9 @@ class GetPlayerStatsUseCase:
 
         async with self._competition_uow:
             competition_matches = (
-                await self._competition_uow.matches.find_completed_for_player(user_id)
+                await self._competition_uow.matches.find_completed_for_player(
+                    user_id, limit=MAX_ROUNDS_AGGREGATED
+                )
             )
             rounds_by_match = await self._rounds_by_match(competition_matches)
             if golf_course_id is not None:

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -260,10 +260,10 @@ class GetPlayerStatsUseCase:
         Neto respecto al par de una tarjeta entera, o None si le falta un hoyo.
 
         Un hoyo con `own_score` a None no se rellena ni se ignora: invalida la
-        vuelta. En match play es lo normal —te conceden los hoyos que ibas
-        ganando y el partido se cierra antes del 18—, así que un partido
-        decidido en el 15 no entra en las estadísticas por mucho que esté
-        terminado. Es el precio de que la media compare vueltas iguales.
+        vuelta. Lo que decide es la tarjeta, no en qué hoyo se ganó el partido:
+        un match play resuelto en el 15 cuenta igual que cualquier otra vuelta
+        si los jugadores siguieron anotando hasta el 18. Lo que deja la ronda
+        fuera es dejar de anotar, no cerrar pronto.
         """
         pars = {hole.number: hole.par for hole in course.holes}
         scored = {

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -75,10 +75,19 @@ class GetPlayerStatsUseCase:
             competition_matches = (
                 await self._competition_uow.matches.find_completed_for_player(user_id)
             )
+            rounds_by_match = await self._rounds_by_match(competition_matches)
             if golf_course_id is not None:
-                competition_matches = await self._filter_matches_by_course(
-                    competition_matches, golf_course_id
+                competition_matches = [
+                    match
+                    for match in competition_matches
+                    if self._match_course(match, rounds_by_match) == golf_course_id
+                ]
+            scorecards = {
+                match.id: await self._competition_uow.hole_scores.find_by_match_and_player(
+                    match.id, user_id
                 )
+                for match in competition_matches
+            }
 
             tournaments_total = 0
             tournaments_active = 0
@@ -89,8 +98,12 @@ class GetPlayerStatsUseCase:
                     await self._competition_uow.enrollments.count_active_by_user(user_id)
                 )
 
+        competition_rounds_to_par = await self._collect_competition_rounds(
+            competition_matches, rounds_by_match, scorecards
+        )
+
         rounds_played = quick_rounds_played + len(competition_matches)
-        scoring_avg = self._average_to_par(quick_rounds_to_par)
+        scoring_avg = self._average_to_par(quick_rounds_to_par + competition_rounds_to_par)
 
         return PlayerStatsResponseDTO(
             handicap=handicap,
@@ -160,19 +173,101 @@ class GetPlayerStatsUseCase:
                     holes=holes,
                     scores_by_hole=scores_by_hole,
                     allowance_percentage=match.get_effective_allowance(),
+                    # La media junta partidas rápidas y torneo: si solo una de
+                    # las dos topara los hoyos malos, no serían comparables
+                    cap_at_net_double_bogey=True,
                 )
                 results.append(totals.to_par)
 
         return rounds_played, results
 
-    async def _filter_matches_by_course(self, matches: list, golf_course_id: GolfCourseId) -> list:
-        """El campo de un partido vive en su ronda, no en el propio partido."""
-        kept = []
+    async def _rounds_by_match(self, matches: list) -> dict:
+        """
+        La ronda de cada partido, una consulta por ronda distinta.
+
+        Hace falta para dos cosas que el partido no sabe por sí solo: en qué
+        campo se jugó y con qué pares se compara su tarjeta.
+        """
+        rounds: dict = {}
+        by_match: dict = {}
         for match in matches:
-            round_ = await self._competition_uow.rounds.find_by_id(match.round_id)
-            if round_ is not None and round_.golf_course_id == golf_course_id:
-                kept.append(match)
-        return kept
+            if match.round_id not in rounds:
+                rounds[match.round_id] = await self._competition_uow.rounds.find_by_id(
+                    match.round_id
+                )
+            by_match[match.id] = rounds[match.round_id]
+        return by_match
+
+    @staticmethod
+    def _match_course(match, rounds_by_match: dict) -> GolfCourseId | None:
+        round_ = rounds_by_match.get(match.id)
+        return round_.golf_course_id if round_ is not None else None
+
+    async def _collect_competition_rounds(
+        self, matches: list, rounds_by_match: dict, scorecards: dict
+    ) -> list[int]:
+        """
+        Neto respecto al par de cada tarjeta de torneo.
+
+        El formato del partido da igual: en match play también firmas una
+        tarjeta con tus golpes, y esa tarjeta dice a qué nivel jugaste tan bien
+        como la de una vuelta de medal.
+
+        Se usa `own_score`, no el `net_score` de la entidad: ese solo se calcula
+        cuando el marcador ha validado el hoyo, así que media tarjeta legítima
+        se quedaría fuera por no haberse cerrado la validación cruzada. Los
+        golpes recibidos ya vienen resueltos por hoyo desde que se generó el
+        partido, sin repartirlos aquí otra vez.
+        """
+        results: list[int] = []
+        courses: dict = {}
+
+        async with self._golf_course_uow:
+            for match in matches:
+                course_id = self._match_course(match, rounds_by_match)
+                if course_id is None:
+                    continue
+                if course_id not in courses:
+                    courses[course_id] = await self._golf_course_uow.golf_courses.find_by_id(
+                        course_id
+                    )
+                course = courses[course_id]
+                if course is None:
+                    continue
+
+                to_par = self._scorecard_to_par(scorecards.get(match.id, []), course)
+                if to_par is not None:
+                    results.append(to_par)
+
+        return results
+
+    def _scorecard_to_par(self, hole_scores: list, course) -> int | None:
+        """
+        Neto respecto al par de una tarjeta, o None si no hay nada anotado.
+
+        Los hoyos concedidos o sin anotar (`own_score` a None) se quedan fuera
+        en lugar de rellenarse: en match play te dan hoyos que ibas ganando, y
+        contarlos como doble bogey castigaría por ir por delante. La vuelta se
+        mide contra el par de lo que sí se jugó, igual que en partida rápida.
+        """
+        pars = {hole.number: hole.par for hole in course.holes}
+
+        to_par = 0
+        holes_played = 0
+        for hole_score in hole_scores:
+            if hole_score.own_score is None:
+                continue
+            par = pars.get(hole_score.hole_number)
+            if par is None:
+                continue
+
+            computable = self._calculator.adjusted_gross(
+                hole_score.own_score, par, hole_score.strokes_received
+            )
+            to_par += computable - hole_score.strokes_received - par
+            holes_played += 1
+
+        return to_par if holes_played else None
 
     @staticmethod
     def _find_participant(match, user_id: UserId):

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -1,0 +1,203 @@
+"""Caso de Uso: resumen de rendimiento de un jugador (BE #128)."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.services.stableford_calculator import (
+    HoleSetup,
+    StablefordCalculator,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
+from src.modules.user.application.dto.player_stats_dto import PlayerStatsResponseDTO
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# Tope de partidas que se agregan para la media. Sin él, una cuenta con años de
+# historial cargaría todos sus scores para calcular un único número.
+MAX_ROUNDS_AGGREGATED = 100
+
+
+class GetPlayerStatsUseCase:
+    """
+    Agrega el rendimiento de un jugador a partir de los módulos que lo generan.
+
+    Sigue el patrón de `GetAdminStatsUseCase`: los casos de uso de `user`
+    reciben las unidades de trabajo de los módulos que consultan, en lugar de
+    crear un módulo de lectura aparte.
+
+    Se calcula al vuelo, sin precomputar: el historial de un jugador son unas
+    pocas partidas, cambian con cada score anotado, y una estrategia de
+    invalidación costaría más que la consulta que ahorra.
+    """
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+        stableford_calculator: StablefordCalculator | None = None,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+        self._calculator = stableford_calculator or StablefordCalculator()
+
+    async def execute(
+        self, user_id: UserId, golf_course_id: GolfCourseId | None = None
+    ) -> PlayerStatsResponseDTO:
+        """
+        Resumen del jugador, opcionalmente restringido a un campo.
+
+        Con `golf_course_id` solo entran las rondas de ese campo, y los
+        contadores de torneos se dejan a cero: son globales del jugador y
+        repetirlos en un desglose por campo induciría a error.
+        """
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            handicap = float(user.handicap.value) if user and user.handicap else None
+
+        quick_rounds_played, quick_rounds_to_par = await self._collect_quick_match_rounds(
+            user_id, golf_course_id, handicap
+        )
+
+        async with self._competition_uow:
+            competition_matches = (
+                await self._competition_uow.matches.find_completed_for_player(user_id)
+            )
+            if golf_course_id is not None:
+                competition_matches = await self._filter_matches_by_course(
+                    competition_matches, golf_course_id
+                )
+
+            tournaments_total = 0
+            tournaments_active = 0
+            if golf_course_id is None:
+                enrollments = await self._competition_uow.enrollments.find_by_user(user_id)
+                tournaments_total = len(enrollments)
+                tournaments_active = (
+                    await self._competition_uow.enrollments.count_active_by_user(user_id)
+                )
+
+        rounds_played = quick_rounds_played + len(competition_matches)
+        scoring_avg = self._average_to_par(quick_rounds_to_par)
+
+        return PlayerStatsResponseDTO(
+            handicap=handicap,
+            handicap_trend=None,
+            scoring_avg=scoring_avg,
+            rounds_played=rounds_played,
+            tournaments_total=tournaments_total,
+            tournaments_active=tournaments_active,
+        )
+
+    async def _collect_quick_match_rounds(
+        self,
+        user_id: UserId,
+        golf_course_id: GolfCourseId | None,
+        profile_handicap: float | None,
+    ) -> tuple[int, list[int]]:
+        """
+        Rondas rápidas jugadas y su neto respecto al par.
+
+        Se devuelven por separado a propósito: una partida sin scores
+        recuperables (campo borrado, vuelta sin anotar) se jugó igual y cuenta
+        como ronda, aunque no pueda aportar nada a la media.
+
+        `list_for_user` ya descarta las que el propio usuario ocultó (#127), y
+        lo hace por participante: una partida que A ocultó sigue contando para
+        B. Esa regla se hereda tal cual en lugar de reimplementarse aquí.
+        """
+        rounds_played = 0
+        results: list[int] = []
+
+        async with self._quick_match_uow, self._golf_course_uow:
+            matches = await self._quick_match_uow.quick_matches.list_for_user(
+                user_id, status=QuickMatchStatus.COMPLETED, limit=MAX_ROUNDS_AGGREGATED
+            )
+
+            for match in matches:
+                if golf_course_id is not None and match.golf_course_id != golf_course_id:
+                    continue
+
+                participant = self._find_participant(match, user_id)
+                if participant is None:
+                    continue
+
+                rounds_played += 1
+
+                course = await self._golf_course_uow.golf_courses.find_by_id(match.golf_course_id)
+                if course is None:
+                    continue
+
+                scores = await self._quick_match_uow.quick_match_hole_scores.find_by_match(
+                    match.id
+                )
+                scores_by_hole = {
+                    score.hole_number: score.score
+                    for score in scores
+                    if score.participant_id == participant.participant_id
+                }
+                if not scores_by_hole:
+                    continue
+
+                holes = [
+                    HoleSetup(hole.number, hole.par, hole.stroke_index)
+                    for hole in course.holes
+                ]
+                totals = self._calculator.compute_participant_totals(
+                    handicap=self._effective_handicap(participant, profile_handicap),
+                    holes=holes,
+                    scores_by_hole=scores_by_hole,
+                    allowance_percentage=match.get_effective_allowance(),
+                )
+                results.append(totals.to_par)
+
+        return rounds_played, results
+
+    async def _filter_matches_by_course(self, matches: list, golf_course_id: GolfCourseId) -> list:
+        """El campo de un partido vive en su ronda, no en el propio partido."""
+        kept = []
+        for match in matches:
+            round_ = await self._competition_uow.rounds.find_by_id(match.round_id)
+            if round_ is not None and round_.golf_course_id == golf_course_id:
+                kept.append(match)
+        return kept
+
+    @staticmethod
+    def _find_participant(match, user_id: UserId):
+        return next(
+            (p for p in match.participants if p.user_id is not None and p.user_id == user_id),
+            None,
+        )
+
+    @staticmethod
+    def _effective_handicap(participant, profile_handicap: float | None) -> float | None:
+        """
+        Hándicap con el que jugó, por orden: el override manual que puso el
+        creador, y si no el del perfil.
+
+        Un participante registrado lleva `handicap` a None a propósito: el suyo
+        vive en su perfil, no copiado en la partida. Solo los invitados, que no
+        tienen cuenta, lo traen dentro.
+        """
+        if participant.custom_handicap is not None:
+            return participant.custom_handicap
+        return profile_handicap
+
+    @staticmethod
+    def _average_to_par(rounds_to_par: list[int]) -> float | None:
+        """None sin rondas: no hay media que dar, que no es una media de cero."""
+        if not rounds_to_par:
+            return None
+        return round(sum(rounds_to_par) / len(rounds_to_par), 1)

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -1,0 +1,488 @@
+"""Caso de Uso: historial reciente de partidas de un jugador (BE #128)."""
+
+from dataclasses import dataclass, field
+from datetime import date as date_type
+
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.entities.round import Round
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.services.scoring_service import ScoringService
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.services.stableford_calculator import (
+    HoleSetup,
+    StablefordCalculator,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
+from src.modules.user.application.dto.player_stats_dto import (
+    RecentMatchDTO,
+    RecentMatchesResponseDTO,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+DEFAULT_LIMIT = 10
+TOTAL_HOLES = 18
+
+# Cómo queda el partido para quien pregunta, no para el equipo A
+RESULT_WON = "WON"
+RESULT_LOST = "LOST"
+RESULT_HALVED = "HALVED"
+HALVED_WINNER = "HALVED"
+
+
+@dataclass
+class _QuickMatchRaw:
+    """Lo leído de una partida rápida antes de resolver nombres y campo."""
+
+    match: QuickMatch
+    participant: QuickMatchParticipant
+    scores_by_participant: dict = field(default_factory=dict)
+
+
+@dataclass
+class _CompetitionMatchRaw:
+    """Lo leído de un partido de torneo antes de resolver nombres y campo."""
+
+    match: Match
+    round_: Round
+    tournament_name: str | None
+
+
+class GetRecentMatchesUseCase:
+    """
+    Historial de partidas del jugador, unificando torneo y partida rápida.
+
+    Son dos cosas distintas puestas en una misma lista: un partido de torneo se
+    juega por hoyos contra un rival y termina en "3&2"; una partida rápida libre
+    se juega contra el par y termina en "+4" o en puntos Stableford. El DTO deja
+    en `None` lo que no aplica a cada una en lugar de inventar equivalencias.
+
+    Cada fuente se lee en su propia unidad de trabajo y solo después se resuelven
+    nombres de jugadores y campos, en bloque: así una lista de diez partidas no
+    dispara una consulta por participante.
+    """
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+        stableford_calculator: StablefordCalculator | None = None,
+        scoring_service: ScoringService | None = None,
+    ):
+        self._user_uow = user_uow
+        self._competition_uow = competition_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+        self._calculator = stableford_calculator or StablefordCalculator()
+        self._scoring_service = scoring_service or ScoringService()
+
+    async def execute(
+        self, user_id: UserId, limit: int = DEFAULT_LIMIT
+    ) -> RecentMatchesResponseDTO:
+        """
+        Últimas `limit` partidas del jugador, de la más reciente a la más antigua.
+
+        Se piden `limit` de cada fuente y se recorta después de mezclarlas: no se
+        sabe de qué lado caen las más recientes hasta tenerlas todas.
+        """
+        quick_raws = await self._read_quick_matches(user_id, limit)
+        competition_raws = await self._read_competition_matches(user_id, limit)
+
+        users_by_id = await self._load_users(user_id, quick_raws, competition_raws)
+        courses_by_id = await self._load_golf_courses(quick_raws, competition_raws)
+
+        player = users_by_id.get(user_id)
+        profile_handicap = float(player.handicap.value) if player and player.handicap else None
+
+        entries = [
+            self._to_quick_match_dto(raw, users_by_id, courses_by_id, profile_handicap)
+            for raw in quick_raws
+        ] + [
+            self._to_competition_match_dto(raw, user_id, users_by_id, courses_by_id)
+            for raw in competition_raws
+        ]
+
+        # Una partida sin fecha resoluble se va al final en lugar de romper el orden
+        entries.sort(key=lambda entry: entry.date or date_type.min, reverse=True)
+        return RecentMatchesResponseDTO(matches=entries[:limit])
+
+    # ==================== Lectura ====================
+
+    async def _read_quick_matches(self, user_id: UserId, limit: int) -> list[_QuickMatchRaw]:
+        """
+        Partidas rápidas terminadas del jugador, con sus scores.
+
+        `list_for_user` ya descarta las que este jugador ocultó (#127), y solo
+        para él: una partida que A ocultó sigue en el historial de B.
+        """
+        raws: list[_QuickMatchRaw] = []
+
+        async with self._quick_match_uow:
+            matches = await self._quick_match_uow.quick_matches.list_for_user(
+                user_id, status=QuickMatchStatus.COMPLETED, limit=limit
+            )
+
+            for match in matches:
+                participant = self._find_participant(match, user_id)
+                if participant is None:
+                    continue
+
+                hole_scores = await self._quick_match_uow.quick_match_hole_scores.find_by_match(
+                    match.id
+                )
+                scores_by_participant: dict = {}
+                for hole_score in hole_scores:
+                    scores_by_participant.setdefault(hole_score.participant_id, {})[
+                        hole_score.hole_number
+                    ] = hole_score.score
+
+                raws.append(
+                    _QuickMatchRaw(
+                        match=match,
+                        participant=participant,
+                        scores_by_participant=scores_by_participant,
+                    )
+                )
+
+        return raws
+
+    async def _read_competition_matches(
+        self, user_id: UserId, limit: int
+    ) -> list[_CompetitionMatchRaw]:
+        """
+        Partidos de torneo terminados del jugador, con su ronda y su torneo.
+
+        La fecha y el campo viven en la ronda, y el nombre del torneo en la
+        competición: un partido por sí solo no sabe cuándo ni dónde se jugó.
+        """
+        raws: list[_CompetitionMatchRaw] = []
+        rounds_cache: dict = {}
+        competition_names: dict = {}
+
+        async with self._competition_uow:
+            matches = await self._competition_uow.matches.find_completed_for_player(
+                user_id, limit=limit
+            )
+
+            for match in matches:
+                if match.round_id not in rounds_cache:
+                    rounds_cache[match.round_id] = await self._competition_uow.rounds.find_by_id(
+                        match.round_id
+                    )
+                round_ = rounds_cache[match.round_id]
+                if round_ is None:
+                    continue
+
+                if round_.competition_id not in competition_names:
+                    competition = await self._competition_uow.competitions.find_by_id(
+                        round_.competition_id
+                    )
+                    competition_names[round_.competition_id] = (
+                        competition.name.value if competition else None
+                    )
+
+                raws.append(
+                    _CompetitionMatchRaw(
+                        match=match,
+                        round_=round_,
+                        tournament_name=competition_names[round_.competition_id],
+                    )
+                )
+
+        return raws
+
+    async def _load_users(
+        self,
+        user_id: UserId,
+        quick_raws: list[_QuickMatchRaw],
+        competition_raws: list[_CompetitionMatchRaw],
+    ) -> dict[UserId, User]:
+        """Todos los jugadores que aparecen en el historial, en una sola consulta."""
+        user_ids = {user_id}
+        for quick_raw in quick_raws:
+            user_ids.update(
+                p.user_id for p in quick_raw.match.participants if p.user_id is not None
+            )
+        for competition_raw in competition_raws:
+            user_ids.update(
+                player.user_id
+                for player in (
+                    *competition_raw.match.team_a_players,
+                    *competition_raw.match.team_b_players,
+                )
+            )
+
+        async with self._user_uow:
+            users = await self._user_uow.users.find_by_ids(list(user_ids))
+        return {user.id: user for user in users if user.id is not None}
+
+    async def _load_golf_courses(
+        self,
+        quick_raws: list[_QuickMatchRaw],
+        competition_raws: list[_CompetitionMatchRaw],
+    ) -> dict[GolfCourseId, GolfCourse]:
+        """Campos jugados, uno por id distinto y no uno por partida."""
+        course_ids = {raw.match.golf_course_id for raw in quick_raws}
+        course_ids.update(raw.round_.golf_course_id for raw in competition_raws)
+
+        courses: dict[GolfCourseId, GolfCourse] = {}
+        async with self._golf_course_uow:
+            for course_id in course_ids:
+                course = await self._golf_course_uow.golf_courses.find_by_id(course_id)
+                if course is not None:
+                    courses[course_id] = course
+        return courses
+
+    # ==================== Mapeo ====================
+
+    def _to_quick_match_dto(
+        self,
+        raw: _QuickMatchRaw,
+        users_by_id: dict[UserId, User],
+        courses_by_id: dict[GolfCourseId, GolfCourse],
+        profile_handicap: float | None,
+    ) -> RecentMatchDTO:
+        match = raw.match
+        course = courses_by_id.get(match.golf_course_id)
+        partners, opponents = self._quick_match_rivals(match, raw.participant, users_by_id)
+
+        result = None
+        score = None
+        stableford_points = None
+
+        if match.match_format is not None:
+            result, score = self._quick_match_play_outcome(raw)
+        else:
+            totals = self._participant_totals(raw, course, profile_handicap)
+            if totals is not None:
+                if match.scoring_format == ScoringFormat.STABLEFORD:
+                    stableford_points = totals.stableford_points
+                    score = f"{totals.stableford_points} pts"
+                else:
+                    score = self._calculator.format_to_par(totals.to_par)
+
+        return RecentMatchDTO(
+            id=str(match.id.value),
+            # Una partida rápida no guarda cuándo se jugó, solo cuándo se creó:
+            # se juegan del tirón, así que la fecha de creación es la del juego
+            date=match.created_at.date(),
+            match_format=match.match_format.value if match.match_format else None,
+            scoring_format=match.scoring_format.value if match.scoring_format else None,
+            golf_course_id=str(match.golf_course_id.value),
+            golf_course_name=course.name if course else None,
+            tournament_name=None,
+            result=result,
+            score=score,
+            stableford_points=stableford_points,
+            partners=partners,
+            opponents=opponents,
+        )
+
+    def _to_competition_match_dto(
+        self,
+        raw: _CompetitionMatchRaw,
+        user_id: UserId,
+        users_by_id: dict[UserId, User],
+        courses_by_id: dict[GolfCourseId, GolfCourse],
+    ) -> RecentMatchDTO:
+        match = raw.match
+        course = courses_by_id.get(raw.round_.golf_course_id)
+
+        in_team_a = any(player.user_id == user_id for player in match.team_a_players)
+        own_team, rival_team = (
+            (match.team_a_players, match.team_b_players)
+            if in_team_a
+            else (match.team_b_players, match.team_a_players)
+        )
+        partners = [
+            self._user_name(player.user_id, users_by_id)
+            for player in own_team
+            if player.user_id != user_id
+        ]
+        opponents = [self._user_name(player.user_id, users_by_id) for player in rival_team]
+
+        return RecentMatchDTO(
+            id=str(match.id.value),
+            date=raw.round_.round_date,
+            match_format=raw.round_.match_format.value,
+            # Un partido de torneo se juega siempre por hoyos: el eje MEDAL /
+            # STABLEFORD es de las partidas rápidas y aquí no aplica
+            scoring_format=None,
+            golf_course_id=str(raw.round_.golf_course_id.value),
+            golf_course_name=course.name if course else None,
+            tournament_name=raw.tournament_name,
+            result=self._result_for_team(match.get_winner(), "A" if in_team_a else "B"),
+            score=match.result.get("score") if match.result else None,
+            stableford_points=None,
+            partners=partners,
+            opponents=opponents,
+        )
+
+    # ==================== Cálculo ====================
+
+    def _quick_match_play_outcome(self, raw: _QuickMatchRaw) -> tuple[str | None, str | None]:
+        """
+        Cómo quedó una partida rápida por equipos, desde el lado del jugador.
+
+        El resultado no está guardado en ningún sitio: se recalcula hoyo a hoyo
+        con el mismo motor que usa el detalle de la partida. Solo cuentan los
+        hoyos donde anotaron los dos bandos, porque un hoyo a medias no se puede
+        adjudicar.
+        """
+        rosters = raw.match.team_rosters()
+        if rosters is None:
+            return None, None
+        team_a_ids, team_b_ids = rosters
+
+        hole_results = []
+        for hole_number in range(1, TOTAL_HOLES + 1):
+            scores = {
+                participant_id: holes[hole_number]
+                for participant_id, holes in raw.scores_by_participant.items()
+                if hole_number in holes
+            }
+            if not all(pid in scores for pid in team_a_ids | team_b_ids):
+                continue
+            hole_results.append(
+                self._scoring_service.calculate_hole_winner(
+                    [scores[pid] for pid in team_a_ids],
+                    [scores[pid] for pid in team_b_ids],
+                    raw.match.match_format,
+                )
+            )
+
+        if not hole_results:
+            return None, None
+
+        own_team = "A" if raw.participant.participant_id in team_a_ids else "B"
+        standing = self._scoring_service.calculate_match_standing(hole_results)
+
+        if self._scoring_service.is_match_decided(standing):
+            # Se cerró antes del 18: el resultado va en "3&2", ventaja y hoyos
+            # que quedaban
+            outcome = self._scoring_service.format_decided_result(hole_results)
+            return self._result_for_team(outcome["winner"], own_team), outcome["score"]
+
+        if standing["leading_team"] is None:
+            return RESULT_HALVED, "AS"
+
+        # Terminado sin decidirse antes de tiempo: la ventaja tal cual ("2UP").
+        # No vale `format_decided_result` aquí: inventaría un "2&7" con los hoyos
+        # que quedaban sin anotar, como si el partido se hubiera cerrado en ellos
+        return (
+            self._result_for_team(standing["leading_team"], own_team),
+            standing["status"],
+        )
+
+    def _participant_totals(
+        self,
+        raw: _QuickMatchRaw,
+        course: GolfCourse | None,
+        profile_handicap: float | None,
+    ):
+        """Puntos y golpes del jugador en una partida libre; None si no hay con qué."""
+        if course is None:
+            return None
+
+        scores_by_hole = raw.scores_by_participant.get(raw.participant.participant_id)
+        if not scores_by_hole:
+            return None
+
+        holes = [HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in course.holes]
+        return self._calculator.compute_participant_totals(
+            handicap=self._effective_handicap(raw.participant, profile_handicap),
+            holes=holes,
+            scores_by_hole=scores_by_hole,
+            allowance_percentage=raw.match.get_effective_allowance(),
+        )
+
+    def _quick_match_rivals(
+        self,
+        match: QuickMatch,
+        participant: QuickMatchParticipant,
+        users_by_id: dict[UserId, User],
+    ) -> tuple[list[str], list[str]]:
+        """
+        Con quién jugó y contra quién.
+
+        En partido libre no hay bandos: se juega la clasificación individual, de
+        modo que los demás son rivales y no compañeros.
+        """
+        others = [p for p in match.participants if p.participant_id != participant.participant_id]
+        if match.match_format is None:
+            return [], [self._participant_name(p, users_by_id) for p in others]
+
+        rosters = match.team_rosters()
+        if rosters is None:
+            return [], [self._participant_name(p, users_by_id) for p in others]
+        team_a_ids, _ = rosters
+
+        in_team_a = participant.participant_id in team_a_ids
+        partners: list[str] = []
+        opponents: list[str] = []
+        for other in others:
+            same_team = (other.participant_id in team_a_ids) == in_team_a
+            (partners if same_team else opponents).append(
+                self._participant_name(other, users_by_id)
+            )
+        return partners, opponents
+
+    # ==================== Helpers ====================
+
+    @staticmethod
+    def _result_for_team(winner: str | None, own_team: str) -> str | None:
+        """Traduce el ganador del partido ("A"/"B"/"HALVED") al lado del jugador."""
+        if winner is None:
+            return None
+        if winner == HALVED_WINNER:
+            return RESULT_HALVED
+        return RESULT_WON if winner == own_team else RESULT_LOST
+
+    @staticmethod
+    def _find_participant(match: QuickMatch, user_id: UserId) -> QuickMatchParticipant | None:
+        return next(
+            (p for p in match.participants if p.user_id is not None and p.user_id == user_id),
+            None,
+        )
+
+    @staticmethod
+    def _user_name(user_id: UserId, users_by_id: dict[UserId, User]) -> str:
+        user = users_by_id.get(user_id)
+        return f"{user.first_name} {user.last_name}" if user else "Unknown"
+
+    @classmethod
+    def _participant_name(
+        cls, participant: QuickMatchParticipant, users_by_id: dict[UserId, User]
+    ) -> str:
+        """Un invitado trae su nombre dentro de la partida; un registrado, en su perfil."""
+        if participant.is_guest:
+            return f"{participant.first_name} {participant.last_name}"
+        return cls._user_name(participant.user_id, users_by_id)
+
+    @staticmethod
+    def _effective_handicap(
+        participant: QuickMatchParticipant, profile_handicap: float | None
+    ) -> float | None:
+        """Override manual del creador si lo hay, y si no el hándicap del perfil."""
+        if participant.custom_handicap is not None:
+            return participant.custom_handicap
+        return profile_handicap

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -38,6 +38,10 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 from src.modules.user.domain.value_objects.user_id import UserId
 
 DEFAULT_LIMIT = 10
+
+# `GolfCourse` valida exactamente 18 hoyos como invariante, así que recorrer el
+# rango fijo equivale a recorrer los hoyos del campo. Si algún día se admiten
+# campos de nueve, hay que iterar los hoyos anotados en lugar de este rango.
 TOTAL_HOLES = 18
 
 # Cómo queda el partido para quien pregunta, no para el equipo A

--- a/src/modules/user/infrastructure/api/v1/user_routes.py
+++ b/src/modules/user/infrastructure/api/v1/user_routes.py
@@ -6,6 +6,8 @@ from src.config.dependencies import (
     get_competition_uow,
     get_current_user,
     get_find_user_use_case,
+    get_get_player_stats_use_case,
+    get_get_recent_matches_use_case,
     get_search_users_use_case,
     get_update_profile_use_case,
     get_update_security_use_case,
@@ -15,6 +17,11 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.user.application.dto.player_stats_dto import (
+    PlayerStatsResponseDTO,
+    RecentMatchesResponseDTO,
+)
 from src.modules.user.application.dto.user_dto import (
     FindUserRequestDTO,
     FindUserResponseDTO,
@@ -27,6 +34,12 @@ from src.modules.user.application.dto.user_dto import (
     UserRolesResponseDTO,
 )
 from src.modules.user.application.use_cases.find_user_use_case import FindUserUseCase
+from src.modules.user.application.use_cases.get_player_stats_use_case import (
+    GetPlayerStatsUseCase,
+)
+from src.modules.user.application.use_cases.get_recent_matches_use_case import (
+    GetRecentMatchesUseCase,
+)
 from src.modules.user.application.use_cases.search_users_use_case import SearchUsersUseCase
 from src.modules.user.application.use_cases.update_profile_use_case import (
     UpdateProfileUseCase,
@@ -310,3 +323,78 @@ async def get_my_roles_in_competition(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Internal server error: {e!s}",
         ) from e
+
+
+@router.get(
+    "/me/stats",
+    response_model=PlayerStatsResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Estadísticas del jugador",
+    description="Resumen de rendimiento del usuario actual para el panel.",
+    tags=["Users"],
+)
+async def get_my_stats(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetPlayerStatsUseCase = Depends(get_get_player_stats_use_case),
+):
+    """
+    Resumen agregado del jugador: hándicap, media respecto al par, rondas y
+    torneos.
+
+    Una cuenta sin historial devuelve ceros y `null`, no un 404: el panel de un
+    usuario nuevo es un caso normal, no un error.
+
+    `handicap_trend` va siempre a `null` mientras no exista histórico de
+    hándicap; el campo está para no cambiar el contrato cuando lo haya.
+    """
+    return await use_case.execute(UserId(str(current_user.id)))
+
+
+@router.get(
+    "/me/stats/golf-courses/{golf_course_id}",
+    response_model=PlayerStatsResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Estadísticas del jugador en un campo",
+    description="Mismo resumen, restringido a las rondas jugadas en un campo concreto.",
+    tags=["Users"],
+)
+async def get_my_stats_for_golf_course(
+    golf_course_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetPlayerStatsUseCase = Depends(get_get_player_stats_use_case),
+):
+    """
+    Desglose por campo.
+
+    Los contadores de torneos vienen a cero: son globales del jugador y
+    repetirlos dentro de un campo daría a entender que jugó ahí esos torneos.
+    """
+    return await use_case.execute(
+        UserId(str(current_user.id)), golf_course_id=GolfCourseId(golf_course_id)
+    )
+
+
+@router.get(
+    "/me/matches",
+    response_model=RecentMatchesResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Historial de partidas del jugador",
+    description="Últimas partidas del usuario, mezclando torneo y partida rápida.",
+    tags=["Users"],
+)
+async def get_my_recent_matches(
+    limit: int = Query(default=10, ge=1, le=50, description="Número de partidas a devolver"),
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetRecentMatchesUseCase = Depends(get_get_recent_matches_use_case),
+):
+    """
+    Historial unificado, de la partida más reciente a la más antigua.
+
+    Partidos de torneo y partidas rápidas conviven en la misma lista, y cada
+    entrada deja en `null` lo que no le aplica: un partido de torneo no tiene
+    `scoring_format`, y una partida libre no tiene `result` de match play.
+
+    Las partidas que el propio jugador ocultó (#127) no aparecen aquí, pero
+    siguen apareciendo en el historial de los demás participantes.
+    """
+    return await use_case.execute(UserId(str(current_user.id)), limit=limit)

--- a/tests/integration/api/v1/test_player_stats_endpoints.py
+++ b/tests/integration/api/v1/test_player_stats_endpoints.py
@@ -1,0 +1,239 @@
+"""
+Tests E2E de las estadísticas e historial del jugador (BE #128).
+
+Cubren los tres endpoints de un tirón (`/me/stats`, `/me/stats/golf-courses/{id}`
+y `/me/matches`) sobre una partida rápida jugada de verdad por la API: crear el
+campo, crear la partida, anotar los 18 hoyos y terminarla. Es la única forma de
+comprobar que la agregación entre módulos funciona con las unidades de trabajo
+reales y no solo con las de memoria.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import (
+    approve_golf_course,
+    create_admin_user,
+    create_authenticated_user,
+    create_golf_course,
+    set_auth_cookies,
+)
+
+# El campo por defecto del helper son 18 hoyos de par 4
+COURSE_PAR = 72
+HOLES = range(1, 19)
+
+
+async def _approved_golf_course(client: AsyncClient, admin: dict, creator: dict) -> str:
+    course = await create_golf_course(client, creator["cookies"])
+    await approve_golf_course(client, admin["cookies"], course["id"])
+    return course["id"]
+
+
+async def _played_medal_match(
+    client: AsyncClient, player: dict, golf_course_id: str, strokes_per_hole: int = 5
+) -> str:
+    """Una partida libre MEDAL terminada con la vuelta entera anotada."""
+    set_auth_cookies(client, player["cookies"])
+    create_response = await client.post(
+        "/api/v1/quick-matches",
+        json={"golf_course_id": golf_course_id, "scoring_format": "MEDAL"},
+    )
+    assert create_response.status_code == 201, create_response.text
+    quick_match_id = create_response.json()["id"]
+    participant_id = create_response.json()["participants"][0]["participant_id"]
+
+    start_response = await client.post(
+        f"/api/v1/quick-matches/{quick_match_id}/start",
+        json={"scorer_ids": [participant_id]},
+    )
+    assert start_response.status_code == 200, start_response.text
+
+    for hole_number in HOLES:
+        score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/{hole_number}/score",
+            json={"score": strokes_per_hole},
+        )
+        assert score_response.status_code == 200, score_response.text
+
+    complete_response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/complete")
+    assert complete_response.status_code == 200, complete_response.text
+    return quick_match_id
+
+
+class TestEmptyAccount:
+    """Una cuenta nueva es un caso normal del panel, no un error."""
+
+    @pytest.mark.asyncio
+    async def test_stats_are_zero_and_null_not_a_404(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "stats_empty@test.com", "P@ssw0rd123!", "Empty", "Account"
+        )
+        set_auth_cookies(client, user["cookies"])
+
+        response = await client.get("/api/v1/users/me/stats")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["rounds_played"] == 0
+        assert body["tournaments_total"] == 0
+        assert body["scoring_avg"] is None
+        assert body["handicap_trend"] is None
+
+    @pytest.mark.asyncio
+    async def test_feed_is_an_empty_list(self, client: AsyncClient):
+        user = await create_authenticated_user(
+            client, "feed_empty@test.com", "P@ssw0rd123!", "Empty", "Feed"
+        )
+        set_auth_cookies(client, user["cookies"])
+
+        response = await client.get("/api/v1/users/me/matches")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["matches"] == []
+
+
+class TestAuthentication:
+    """Son datos personales: sin sesión no se ven."""
+
+    @pytest.mark.asyncio
+    async def test_stats_require_a_session(self, client: AsyncClient):
+        client.cookies.clear()
+
+        response = await client.get("/api/v1/users/me/stats")
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_feed_requires_a_session(self, client: AsyncClient):
+        client.cookies.clear()
+
+        response = await client.get("/api/v1/users/me/matches")
+
+        assert response.status_code == 401
+
+
+class TestPlayedQuickMatch:
+    """Una partida jugada de verdad, vista desde los tres endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_stats_count_the_round_and_average_the_net_score(self, client: AsyncClient):
+        """
+        Jugador sin hándicap en par 72, 5 golpes por hoyo: 90 brutos, +18. La
+        media es el neto respecto al par, no los golpes brutos.
+        """
+        admin = await create_admin_user(
+            client, "stats_admin1@test.com", "P@ssw0rd123!", "Admin", "Stats"
+        )
+        player = await create_authenticated_user(
+            client, "stats_player1@test.com", "P@ssw0rd123!", "Played", "Round"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        response = await client.get("/api/v1/users/me/stats")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["rounds_played"] == 1
+        assert body["scoring_avg"] == 18.0
+
+    @pytest.mark.asyncio
+    async def test_feed_returns_the_match_with_its_course_and_score(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "stats_admin2@test.com", "P@ssw0rd123!", "Admin", "Feed"
+        )
+        player = await create_authenticated_user(
+            client, "stats_player2@test.com", "P@ssw0rd123!", "Feed", "Player"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        quick_match_id = await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        response = await client.get("/api/v1/users/me/matches")
+
+        assert response.status_code == 200, response.text
+        matches = response.json()["matches"]
+        assert len(matches) == 1
+        entry = matches[0]
+        assert entry["id"] == quick_match_id
+        assert entry["golf_course_id"] == golf_course_id
+        assert entry["golf_course_name"] is not None
+        assert entry["scoring_format"] == "MEDAL"
+        assert entry["score"] == "+18"
+        # Un partido libre no se juega contra un rival ni pertenece a un torneo
+        assert entry["match_format"] is None
+        assert entry["result"] is None
+        assert entry["tournament_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_per_course_breakdown_counts_only_that_course(self, client: AsyncClient):
+        """
+        La partida se jugó en un campo: aparece en el desglose de ese campo y no
+        en el de otro.
+        """
+        admin = await create_admin_user(
+            client, "stats_admin3@test.com", "P@ssw0rd123!", "Admin", "Course"
+        )
+        player = await create_authenticated_user(
+            client, "stats_player3@test.com", "P@ssw0rd123!", "Course", "Player"
+        )
+        played_course_id = await _approved_golf_course(client, admin, player)
+        other_course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, played_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        played = await client.get(f"/api/v1/users/me/stats/golf-courses/{played_course_id}")
+        other = await client.get(f"/api/v1/users/me/stats/golf-courses/{other_course_id}")
+
+        assert played.status_code == 200, played.text
+        assert played.json()["rounds_played"] == 1
+        assert played.json()["scoring_avg"] == 18.0
+        assert other.status_code == 200, other.text
+        assert other.json()["rounds_played"] == 0
+        assert other.json()["scoring_avg"] is None
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_the_feed(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "stats_admin4@test.com", "P@ssw0rd123!", "Admin", "Limit"
+        )
+        player = await create_authenticated_user(
+            client, "stats_player4@test.com", "P@ssw0rd123!", "Limit", "Player"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, golf_course_id)
+        await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        response = await client.get("/api/v1/users/me/matches?limit=1")
+
+        assert response.status_code == 200, response.text
+        assert len(response.json()["matches"]) == 1
+
+
+class TestHiddenMatches:
+    """Regla de #127: ocultar una partida solo la retira para quien la oculta."""
+
+    @pytest.mark.asyncio
+    async def test_a_hidden_match_leaves_both_the_stats_and_the_feed(self, client: AsyncClient):
+        admin = await create_admin_user(
+            client, "stats_admin5@test.com", "P@ssw0rd123!", "Admin", "Hidden"
+        )
+        player = await create_authenticated_user(
+            client, "stats_player5@test.com", "P@ssw0rd123!", "Hidden", "Player"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        quick_match_id = await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        hide_response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/hide")
+        assert hide_response.status_code == 200, hide_response.text
+
+        stats = await client.get("/api/v1/users/me/stats")
+        feed = await client.get("/api/v1/users/me/matches")
+
+        assert stats.json()["rounds_played"] == 0
+        assert stats.json()["scoring_avg"] is None
+        assert feed.json()["matches"] == []

--- a/tests/integration/modules/competition/infrastructure/persistence/sqlalchemy/test_match_repository_player_history.py
+++ b/tests/integration/modules/competition/infrastructure/persistence/sqlalchemy/test_match_repository_player_history.py
@@ -1,0 +1,277 @@
+"""
+Tests de integración de `find_completed_for_player` (BE #128).
+
+Esta consulta no se puede verificar de verdad en memoria: busca al jugador con
+contención JSONB (`@>`) sobre dos columnas sin clave ajena, y ordena por la
+fecha de la ronda, que vive en otra tabla. La implementación en memoria ordena
+por `created_at` a falta de rondas, así que el orden real solo se comprueba
+aquí, contra PostgreSQL.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from src.modules.competition.domain.entities.competition import Competition
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.entities.round import Round
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_name import CompetitionName
+from src.modules.competition.domain.value_objects.date_range import DateRange
+from src.modules.competition.domain.value_objects.location import Location
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.match_player import MatchPlayer
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.competition.domain.value_objects.session_type import SessionType
+from src.modules.competition.infrastructure.persistence.sqlalchemy.competition_repository import (
+    SQLAlchemyCompetitionRepository,
+)
+from src.modules.competition.infrastructure.persistence.sqlalchemy.match_repository import (
+    SQLAlchemyMatchRepository,
+)
+from src.modules.competition.infrastructure.persistence.sqlalchemy.round_repository import (
+    SQLAlchemyRoundRepository,
+)
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.repositories.golf_course_repository import (
+    GolfCourseRepository,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+pytestmark = [pytest.mark.integration]
+
+BASE_DATE = date(2026, 6, 1)
+
+
+async def _insert_user(db_session, user_id: UserId) -> None:
+    """Fila mínima de usuario: las claves ajenas de competitions la exigen."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    await db_session.execute(
+        text(
+            "INSERT INTO users (id, first_name, last_name, email, password, "
+            "created_at, updated_at, email_verified, failed_login_attempts, is_admin) "
+            "VALUES (:id, :fn, :ln, :email, :pw, :ca, :ua, :ev, :fla, :ia)"
+        ),
+        {
+            "id": str(user_id.value),
+            "fn": "Test",
+            "ln": "Player",
+            "email": f"match-history-{user_id.value}@example.com",
+            "pw": "$2b$04$placeholder",
+            "ca": now,
+            "ua": now,
+            "ev": False,
+            "fla": 0,
+            "ia": False,
+        },
+    )
+
+
+@pytest_asyncio.fixture
+async def player_id(db_session) -> UserId:
+    user_id = UserId.generate()
+    await _insert_user(db_session, user_id)
+    return user_id
+
+
+@pytest_asyncio.fixture
+async def rival_id(db_session) -> UserId:
+    user_id = UserId.generate()
+    await _insert_user(db_session, user_id)
+    return user_id
+
+
+@pytest_asyncio.fixture
+async def golf_course_id(db_session, player_id) -> object:
+    course = GolfCourse.create(
+        name=f"History Club {uuid4().hex[:6]}",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=player_id,
+        tees=[
+            Tee(
+                category=TeeCategory.AMATEUR,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+            ),
+            Tee(
+                category=TeeCategory.CHAMPIONSHIP,
+                gender=Gender.MALE,
+                identifier="White",
+                course_rating=72.0,
+                slope_rating=130,
+            ),
+        ],
+        holes=[Hole(number=i, par=4, stroke_index=i) for i in range(1, 19)],
+    )
+    course.approve()
+    await GolfCourseRepository(db_session).save(course)
+    await db_session.commit()
+    return course.id
+
+
+async def _create_competition(db_session, creator_id) -> Competition:
+    competition = Competition.create(
+        id=CompetitionId(uuid4()),
+        creator_id=creator_id,
+        name=CompetitionName(f"History Cup {uuid4().hex[:6]}"),
+        dates=DateRange(start_date=BASE_DATE, end_date=BASE_DATE + timedelta(days=5)),
+        location=Location(main_country=CountryCode("ES")),
+        play_mode=PlayMode.SCRATCH,
+        team_1_name="Team A",
+        team_2_name="Team B",
+    )
+    await SQLAlchemyCompetitionRepository(db_session).add(competition)
+    await db_session.commit()
+    return competition
+
+
+async def _create_round(db_session, competition, golf_course_id, round_date: date) -> Round:
+    round_ = Round.create(
+        competition_id=competition.id,
+        golf_course_id=golf_course_id,
+        round_date=round_date,
+        session_type=SessionType.MORNING,
+        match_format=MatchFormat.SINGLES,
+    )
+    await SQLAlchemyRoundRepository(db_session).add(round_)
+    await db_session.commit()
+    return round_
+
+
+def _player(user_id: UserId) -> MatchPlayer:
+    return MatchPlayer(
+        user_id=user_id,
+        playing_handicap=10,
+        tee_category=TeeCategory.AMATEUR,
+        tee_gender=Gender.MALE,
+        strokes_received=tuple(range(1, 11)),
+        player_handicap=Decimal("10.0"),
+    )
+
+
+async def _create_match(
+    db_session,
+    round_: Round,
+    team_a: list[UserId],
+    team_b: list[UserId],
+    *,
+    completed: bool = True,
+    match_number: int = 1,
+) -> Match:
+    match = Match.create(
+        round_id=round_.id,
+        match_number=match_number,
+        team_a_players=[_player(uid) for uid in team_a],
+        team_b_players=[_player(uid) for uid in team_b],
+    )
+    if completed:
+        match.start()
+        match.complete({"winner": "A", "score": "3&2"})
+
+    await SQLAlchemyMatchRepository(db_session).add(match)
+    await db_session.commit()
+    return match
+
+
+async def test_finds_a_completed_match_where_the_player_is_in_team_a(
+    db_session, player_id, rival_id, golf_course_id
+):
+    competition = await _create_competition(db_session, player_id)
+    round_ = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    match = await _create_match(db_session, round_, [player_id], [rival_id])
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(player_id)
+
+    assert [m.id for m in found] == [match.id]
+
+
+async def test_finds_the_same_match_from_the_other_side_of_the_draw(
+    db_session, player_id, rival_id, golf_course_id
+):
+    """Los jugadores viven en dos columnas JSONB distintas: hay que mirar en las dos."""
+    competition = await _create_competition(db_session, player_id)
+    round_ = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    match = await _create_match(db_session, round_, [player_id], [rival_id])
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(rival_id)
+
+    assert [m.id for m in found] == [match.id]
+
+
+async def test_ignores_matches_the_player_did_not_play(
+    db_session, player_id, rival_id, golf_course_id
+):
+    """La contención JSONB no puede colar partidos ajenos del mismo torneo."""
+    outsider_id = UserId.generate()
+    await _insert_user(db_session, outsider_id)
+    competition = await _create_competition(db_session, player_id)
+    round_ = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    await _create_match(db_session, round_, [player_id], [rival_id])
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(outsider_id)
+
+    assert found == []
+
+
+async def test_ignores_matches_that_have_not_finished(
+    db_session, player_id, rival_id, golf_course_id
+):
+    """Un partido a medias todavía no dice cómo quedó: no es historial."""
+    competition = await _create_competition(db_session, player_id)
+    round_ = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    await _create_match(db_session, round_, [player_id], [rival_id], completed=False)
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(player_id)
+
+    assert found == []
+
+
+async def test_orders_by_round_date_most_recent_first(
+    db_session, player_id, rival_id, golf_course_id
+):
+    """
+    El orden sale de la fecha de la ronda, no de cuándo se creó la fila: los
+    partidos se crean al planificar el torneo, en el orden que quiera el creador.
+    """
+    competition = await _create_competition(db_session, player_id)
+    early_round = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    late_round = await _create_round(
+        db_session, competition, golf_course_id, BASE_DATE + timedelta(days=2)
+    )
+    # Se crea antes el de la ronda temprana, para que el orden por fecha no
+    # coincida con el orden de inserción
+    early_match = await _create_match(db_session, early_round, [player_id], [rival_id])
+    late_match = await _create_match(db_session, late_round, [player_id], [rival_id])
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(player_id)
+
+    assert [m.id for m in found] == [late_match.id, early_match.id]
+
+
+async def test_limit_keeps_the_most_recent_ones(db_session, player_id, rival_id, golf_course_id):
+    competition = await _create_competition(db_session, player_id)
+    early_round = await _create_round(db_session, competition, golf_course_id, BASE_DATE)
+    late_round = await _create_round(
+        db_session, competition, golf_course_id, BASE_DATE + timedelta(days=2)
+    )
+    await _create_match(db_session, early_round, [player_id], [rival_id])
+    late_match = await _create_match(db_session, late_round, [player_id], [rival_id])
+
+    found = await SQLAlchemyMatchRepository(db_session).find_completed_for_player(
+        player_id, limit=1
+    )
+
+    assert [m.id for m in found] == [late_match.id]

--- a/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
@@ -176,6 +176,65 @@ class TestComputeParticipantTotals:
         assert totals.to_par == 0
 
 
+class TestNetDoubleBogeyCap:
+    """Regla WHS 3.1: lo que puntúa para hándicap tiene techo por hoyo."""
+
+    def test_a_normal_hole_is_left_alone(self):
+        assert StablefordCalculator.adjusted_gross(5, par=4, strokes_received=0) == 5
+
+    def test_a_disaster_hole_is_capped_at_net_double_bogey(self):
+        """Un 11 en un par 4 sin golpes cuenta como 6, no como 11."""
+        assert StablefordCalculator.adjusted_gross(11, par=4, strokes_received=0) == 6
+
+    def test_the_cap_rises_with_the_strokes_received(self):
+        """Con dos golpes en el hoyo, el techo sube a par + 2 + 2."""
+        assert StablefordCalculator.adjusted_gross(11, par=4, strokes_received=2) == 8
+
+    def test_the_cap_is_off_by_default_so_the_scorecard_shows_real_strokes(self):
+        calculator = StablefordCalculator()
+        scores = {**dict.fromkeys(range(1, 18), 4), 18: 11}
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole=scores
+        )
+
+        assert totals.total_strokes == 79
+        assert totals.to_par == 7
+
+    def test_the_cap_limits_what_a_single_hole_can_do_to_the_average(self):
+        """Los mismos 11 golpes, ya topados: el hoyo aporta +2 y no +7."""
+        calculator = StablefordCalculator()
+        scores = {**dict.fromkeys(range(1, 18), 4), 18: 11}
+
+        totals = calculator.compute_participant_totals(
+            handicap=0,
+            holes=_course(),
+            scores_by_hole=scores,
+            cap_at_net_double_bogey=True,
+        )
+
+        # Los golpes de verdad no se tocan; lo que baja es lo computable
+        assert totals.total_strokes == 79
+        assert totals.to_par == 2
+
+    def test_capping_does_not_move_the_stableford_points(self):
+        """Un hoyo en net double bogey ya vale cero; peor sigue valiendo cero."""
+        calculator = StablefordCalculator()
+        scores = {**dict.fromkeys(range(1, 18), 4), 18: 11}
+
+        raw = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole=scores
+        )
+        capped = calculator.compute_participant_totals(
+            handicap=0,
+            holes=_course(),
+            scores_by_hole=scores,
+            cap_at_net_double_bogey=True,
+        )
+
+        assert raw.stableford_points == capped.stableford_points
+
+
 class TestResolveStrokesBasis:
     """De qué hándicap salen los golpes."""
 

--- a/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
@@ -1,0 +1,283 @@
+"""
+Tests del StablefordCalculator (BE #128).
+
+Estas reglas vivían solo en el frontend (`StablefordCalculator.js`) y ahora
+existen por duplicado. Mientras las dos implementaciones coexistan, el riesgo
+real es que se separen sin que nadie se entere, así que buena parte de estos
+tests fija la paridad: mismos datos, mismos números que el frontend produce hoy.
+"""
+
+from decimal import Decimal
+from typing import ClassVar
+
+import pytest
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.quick_match.domain.services.stableford_calculator import (
+    HoleSetup,
+    StablefordCalculator,
+)
+
+
+def _course(pars: list[int] | None = None) -> list[HoleSetup]:
+    """18 hoyos con stroke index 1..18 en orden."""
+    pars = pars or [4] * 18
+    return [
+        HoleSetup(hole_number=i + 1, par=pars[i], stroke_index=i + 1) for i in range(18)
+    ]
+
+
+class TestAllocateStrokes:
+    """Reparto de golpes por hoyo."""
+
+    def test_no_handicap_receives_no_strokes(self):
+        assert StablefordCalculator.allocate_strokes(None, 1) == 0
+
+    def test_scratch_receives_no_strokes(self):
+        assert StablefordCalculator.allocate_strokes(Decimal("0"), 1) == 0
+
+    @pytest.mark.parametrize(
+        ("handicap", "stroke_index", "expected"),
+        [
+            (Decimal("10"), 1, 1),  # entra en los 10 hoyos más difíciles
+            (Decimal("10"), 10, 1),  # justo el último que recibe
+            (Decimal("10"), 11, 0),  # ya no
+            (Decimal("18"), 18, 1),  # uno en cada hoyo
+            (Decimal("20"), 1, 2),  # vuelta completa más dos
+            (Decimal("20"), 2, 2),
+            (Decimal("20"), 3, 1),
+            (Decimal("36"), 18, 2),  # dos vueltas exactas
+        ],
+    )
+    def test_allocates_by_difficulty(self, handicap, stroke_index, expected):
+        assert StablefordCalculator.allocate_strokes(handicap, stroke_index) == expected
+
+    @pytest.mark.parametrize(
+        ("handicap", "stroke_index", "expected"),
+        [
+            (Decimal("-2"), 18, -1),  # el plus cede en el hoyo más fácil
+            (Decimal("-2"), 17, -1),
+            (Decimal("-2"), 16, 0),  # y no en el resto
+            (Decimal("-1"), 18, -1),
+            (Decimal("-1"), 17, 0),
+        ],
+    )
+    def test_plus_handicap_gives_strokes_from_the_easiest_hole(
+        self, handicap, stroke_index, expected
+    ):
+        """Regla WHS 8.2: al plus se le quitan golpes empezando por el más fácil."""
+        assert StablefordCalculator.allocate_strokes(handicap, stroke_index) == expected
+
+    @pytest.mark.parametrize(
+        ("handicap", "expected_rounded_effect"),
+        [
+            (Decimal("2.5"), 1),  # Math.round(2.5) = 3 -> recibe en SI 1
+            (Decimal("-2.5"), 0),  # Math.round(-2.5) = -2 -> no cede en SI 1
+        ],
+    )
+    def test_rounds_the_half_the_same_way_the_frontend_does(
+        self, handicap, expected_rounded_effect
+    ):
+        """
+        El frontend usa Math.round, que manda el medio hacia arriba también en
+        negativos. ROUND_HALF_UP de Decimal se aleja del cero y daría otro
+        resultado para -2.5, con un golpe de diferencia.
+        """
+        assert (
+            StablefordCalculator.allocate_strokes(handicap, 1) == expected_rounded_effect
+        )
+
+
+class TestHolePoints:
+    """Puntos de un hoyo."""
+
+    @pytest.mark.parametrize(
+        ("gross", "par", "strokes", "expected"),
+        [
+            (4, 4, 0, 2),  # par
+            (3, 4, 0, 3),  # birdie
+            (2, 4, 0, 4),  # eagle
+            (5, 4, 0, 1),  # bogey
+            (6, 4, 0, 0),  # doble
+            (7, 4, 0, 0),  # nunca negativo
+            (5, 4, 1, 2),  # bogey bruto con golpe = par neto
+            (6, 4, 2, 2),
+        ],
+    )
+    def test_points_follow_net_score_against_par(self, gross, par, strokes, expected):
+        assert StablefordCalculator.hole_points(gross, par, strokes) == expected
+
+    def test_hole_without_score_gives_no_points(self):
+        assert StablefordCalculator.hole_points(None, 4, 0) == 0
+
+
+class TestComputeParticipantTotals:
+    """Agregación sobre la vuelta."""
+
+    def test_only_counts_holes_with_a_score(self):
+        """Una partida a medias puntúa por lo jugado, no por lo que falta."""
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: 4, 2: 4, 3: 4}
+        )
+
+        assert totals.holes_played == 3
+        assert totals.total_strokes == 12
+        assert totals.par_played == 12
+        assert totals.stableford_points == 6
+
+    def test_scratch_round_at_par(self):
+        calculator = StablefordCalculator()
+        scores = dict.fromkeys(range(1, 19), 4)
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole=scores
+        )
+
+        assert totals.stableford_points == 36
+        assert totals.to_par == 0
+        assert calculator.format_to_par(totals.to_par) == "PAR"
+
+    def test_handicap_player_gets_net_credit(self):
+        """18 de hándicap: un golpe por hoyo, así que 5 brutos son par neto."""
+        calculator = StablefordCalculator()
+        scores = dict.fromkeys(range(1, 19), 5)
+
+        totals = calculator.compute_participant_totals(
+            handicap=18, holes=_course(), scores_by_hole=scores
+        )
+
+        assert totals.stableford_points == 36
+        assert totals.total_strokes == 90
+        assert totals.net_strokes == 72
+        assert totals.to_par == 0
+
+    def test_participant_without_handicap_gets_no_strokes(self):
+        calculator = StablefordCalculator()
+        scores = dict.fromkeys(range(1, 19), 5)
+
+        totals = calculator.compute_participant_totals(
+            handicap=None, holes=_course(), scores_by_hole=scores
+        )
+
+        assert totals.net_strokes == totals.total_strokes
+        assert totals.stableford_points == 18  # bogey en todos: 1 punto por hoyo
+
+    def test_no_scores_at_all_is_an_empty_round_not_an_error(self):
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=10, holes=_course(), scores_by_hole={}
+        )
+
+        assert totals.holes_played == 0
+        assert totals.stableford_points == 0
+        assert totals.to_par == 0
+
+
+class TestResolveStrokesBasis:
+    """De qué hándicap salen los golpes."""
+
+    def test_without_a_tee_the_raw_handicap_is_used(self):
+        """Quien no eligió tee juega su hándicap directamente."""
+        calculator = StablefordCalculator()
+
+        assert calculator.resolve_strokes_basis(12.4, None, 100) == Decimal("12.4")
+
+    def test_with_a_tee_the_playing_handicap_is_used(self):
+        calculator = StablefordCalculator()
+        tee = TeeRating(course_rating=Decimal("71.8"), slope_rating=133, par=72)
+
+        basis = calculator.resolve_strokes_basis(12.4, tee, 100)
+
+        # PH = 12.4 x (133/113) + (71.8 - 72) = 14.594 - 0.2 = 14.394 -> 14
+        assert basis == Decimal("14")
+
+    def test_a_plus_player_keeps_a_negative_basis(self):
+        """
+        `calculate()` acota a cero y dejaría al plus sin ceder golpes; el
+        frontend no acota, y es su resultado el que se ve hoy en la app.
+        """
+        calculator = StablefordCalculator()
+        tee = TeeRating(course_rating=Decimal("71.8"), slope_rating=133, par=72)
+
+        basis = calculator.resolve_strokes_basis(-2.0, tee, 100)
+
+        assert basis < 0
+
+    def test_no_handicap_gives_no_basis(self):
+        calculator = StablefordCalculator()
+
+        assert calculator.resolve_strokes_basis(None, None, 100) is None
+
+    def test_allowance_reduces_the_basis(self):
+        """El allowance recorta el hándicap de juego (Fourball 90 %, Foursomes 50 %)."""
+        calculator = StablefordCalculator()
+        tee = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        full = calculator.resolve_strokes_basis(20.0, tee, 100)
+        reduced = calculator.resolve_strokes_basis(20.0, tee, 50)
+
+        assert full == Decimal("20")
+        assert reduced == Decimal("10")
+
+
+class TestFormatToPar:
+    """Notación de golf."""
+
+    @pytest.mark.parametrize(
+        ("to_par", "expected"), [(0, "PAR"), (3, "+3"), (-2, "-2"), (1, "+1")]
+    )
+    def test_formats_like_a_scoreboard(self, to_par, expected):
+        assert StablefordCalculator.format_to_par(to_par) == expected
+
+
+class TestParityWithTheFrontend:
+    """
+    Vuelta completa contrastada contra el motor del frontend.
+
+    Los valores esperados no están calculados a mano: salen de pasar estos
+    mismos datos por `StablefordCalculator.js` y comprobar que ambos motores
+    coinciden. Si alguien cambia las reglas en un solo lado, esto se cae, que
+    es exactamente para lo que está.
+
+    Campo con pares y stroke indexes irregulares a propósito: un campo de
+    pares 4 y stroke index en orden esconde justo los errores de reparto.
+    """
+
+    PARS: ClassVar[list[int]] = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4]
+    STROKE_INDEXES: ClassVar[list[int]] = [7, 3, 15, 1, 11, 17, 5, 9, 13, 8, 16, 2, 10, 6, 18, 12, 4, 14]
+    SCORES: ClassVar[dict[int, int]] = {
+        1: 5, 2: 6, 3: 4, 4: 6, 5: 5, 6: 3, 7: 6, 8: 5, 9: 4,
+        10: 5, 11: 4, 12: 7, 13: 5, 14: 4, 15: 3, 16: 5, 17: 6, 18: 5,
+    }
+
+    def _holes(self) -> list[HoleSetup]:
+        return [
+            HoleSetup(i + 1, self.PARS[i], self.STROKE_INDEXES[i]) for i in range(18)
+        ]
+
+    @pytest.mark.parametrize(
+        ("handicap", "points", "gross", "net", "to_par"),
+        [
+            (0, 20, 88, 88, 16),
+            (12.4, 32, 88, 76, 4),
+            (18, 38, 88, 70, -2),
+            (28, 48, 88, 60, -12),
+            (-2, 18, 88, 90, 18),  # plus: cede golpes, juega peor que su bruto
+        ],
+    )
+    def test_matches_the_values_the_frontend_produces(
+        self, handicap, points, gross, net, to_par
+    ):
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=handicap, holes=self._holes(), scores_by_hole=self.SCORES
+        )
+
+        assert totals.stableford_points == points
+        assert totals.total_strokes == gross
+        assert totals.net_strokes == net
+        assert totals.to_par == to_par

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -7,10 +7,23 @@ contando para el resto de participantes. El ocultado es por persona, no de la
 partida entera.
 """
 
+from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest
 
+from src.modules.competition.domain.entities.competition import Competition
+from src.modules.competition.domain.entities.hole_score import HoleScore
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.entities.round import Round
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_name import CompetitionName
+from src.modules.competition.domain.value_objects.date_range import DateRange
+from src.modules.competition.domain.value_objects.location import Location
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.match_player import MatchPlayer
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.competition.domain.value_objects.session_type import SessionType
 from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork as InMemoryCompetitionUnitOfWork,
 )
@@ -165,6 +178,79 @@ async def _played_quick_match(qm_uow, golf_course, user, *, strokes_per_hole: in
     return match
 
 
+async def _played_competition_match(
+    competition_uow,
+    golf_course,
+    player,
+    rival,
+    *,
+    strokes_per_hole: int | None = 4,
+    strokes_received_per_hole: int = 0,
+    holes_played: int = 18,
+    round_date: date = date(2026, 6, 1),
+):
+    """
+    Un partido de torneo terminado con la tarjeta del jugador anotada.
+
+    `strokes_per_hole=None` deja los hoyos sin anotar, que es como queda un
+    hoyo concedido en match play.
+    """
+    competition = Competition.create(
+        id=CompetitionId(uuid4()),
+        creator_id=player.id,
+        name=CompetitionName("Ryder Cup Test"),
+        dates=DateRange(start_date=round_date, end_date=round_date + timedelta(days=2)),
+        location=Location(main_country=CountryCode("ES")),
+        play_mode=PlayMode.SCRATCH,
+        team_1_name="Team A",
+        team_2_name="Team B",
+    )
+    round_ = Round.create(
+        competition_id=competition.id,
+        golf_course_id=golf_course.id,
+        round_date=round_date,
+        session_type=SessionType.MORNING,
+        match_format=MatchFormat.SINGLES,
+    )
+
+    def match_player(user_id):
+        return MatchPlayer(
+            user_id=user_id,
+            playing_handicap=strokes_received_per_hole * 18,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=tuple(range(1, 19)) * max(strokes_received_per_hole, 1),
+        )
+
+    match = Match.create(
+        round_id=round_.id,
+        match_number=1,
+        team_a_players=[match_player(player.id)],
+        team_b_players=[match_player(rival.id)],
+    )
+    match.start()
+    match.complete({"winner": "A", "score": "2UP"})
+
+    async with competition_uow:
+        await competition_uow.competitions.add(competition)
+        await competition_uow.rounds.add(round_)
+        await competition_uow.matches.add(match)
+        for hole_number in range(1, holes_played + 1):
+            hole_score = HoleScore.create(
+                match_id=match.id,
+                hole_number=hole_number,
+                player_user_id=player.id,
+                team="A",
+                strokes_received=strokes_received_per_hole,
+            )
+            if strokes_per_hole is not None:
+                hole_score.set_own_score(strokes_per_hole)
+            await competition_uow.hole_scores.add(hole_score)
+        await competition_uow.commit()
+
+    return match
+
+
 @pytest.mark.asyncio
 class TestEmptyAccount:
     """Una cuenta recién creada no puede reventar el panel."""
@@ -273,6 +359,158 @@ class TestRoundsAndAverage:
         )
 
         assert stats.scoring_avg == 0.0
+
+
+@pytest.mark.asyncio
+class TestCompetitionScorecards:
+    """
+    Los partidos de torneo también entran en la media.
+
+    Da igual el formato: en match play también firmas una tarjeta con tus
+    golpes, y esa tarjeta dice a qué nivel jugaste igual que la de una vuelta
+    de medal. Cuando existan torneos Stableford esto ya estará resuelto.
+    """
+
+    async def test_a_tournament_scorecard_counts_towards_the_average(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Par 72, 5 golpes por hoyo sin recibir ninguno: +18."""
+        player = await create_user(user_uow, unique_email("comp"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 18.0
+
+    async def test_strokes_received_count_against_the_par(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Un golpe recibido por hoyo: los mismos 5 brutos son par neto."""
+        player = await create_user(user_uow, unique_email("comp"), handicap=18)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=18)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow,
+            course,
+            player,
+            rival,
+            strokes_per_hole=5,
+            strokes_received_per_hole=1,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.scoring_avg == 0.0
+
+    async def test_averages_both_sources_together(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Una partida rápida a +18 y un torneo al par dan una media de +9."""
+        player = await create_user(user_uow, unique_email("both"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(qm_uow, course, player, strokes_per_hole=5)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=4
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 2
+        assert stats.scoring_avg == 9.0
+
+    async def test_conceded_holes_do_not_count_as_played(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        En match play te conceden hoyos que ibas ganando. Rellenarlos con un
+        doble bogey castigaría por ir por delante, así que se dejan fuera y la
+        vuelta se mide contra el par de lo que sí se jugó.
+        """
+        player = await create_user(user_uow, unique_email("conceded"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5, holes_played=9
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        # Nueve hoyos a +1: la vuelta cuenta como +9, no como +18
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 9.0
+
+    async def test_a_match_without_a_single_hole_scored_is_not_averaged(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Se jugó (cuenta como ronda) pero no dice nada: no hay media que sacar."""
+        player = await create_user(user_uow, unique_email("noscore"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=None
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg is None
+
+    async def test_a_disaster_hole_is_capped_at_net_double_bogey(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Regla WHS 3.1. Con 10 golpes en todos los hoyos de un par 4, la media
+        se queda en +2 por hoyo (+36) en vez de en +6 (+108).
+        """
+        player = await create_user(user_uow, unique_email("disaster"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=10
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.scoring_avg == 36.0
+
+    async def test_the_per_course_breakdown_also_filters_tournament_rounds(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, unique_email("bycourse"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        played_course = await create_golf_course(golf_course_uow, player.id)
+        other_course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, played_course, player, rival, strokes_per_hole=5
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        played = await use_case.execute(player.id, golf_course_id=played_course.id)
+        other = await use_case.execute(player.id, golf_course_id=other_course.id)
+
+        assert played.rounds_played == 1
+        assert played.scoring_avg == 18.0
+        assert other.rounds_played == 0
+        assert other.scoring_avg is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -1,0 +1,327 @@
+"""
+Tests del resumen de rendimiento de un jugador (BE #128).
+
+Lo que más importa aquí es la regla de #127: una partida rápida que alguien
+ocultó de su historial tampoco cuenta para SUS estadísticas, pero sigue
+contando para el resto de participantes. El ocultado es por persona, no de la
+partida entera.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryCompetitionUnitOfWork,
+)
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.in_memory.in_memory_golf_course_unit_of_work import (
+    InMemoryGolfCourseUnitOfWork,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
+from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
+    QuickMatchHoleScoreId,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
+from src.modules.quick_match.infrastructure.persistence.in_memory.in_memory_quick_match_unit_of_work import (
+    InMemoryQuickMatchUnitOfWork,
+)
+from src.modules.user.application.use_cases.get_player_stats_use_case import (
+    GetPlayerStatsUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+
+@pytest.fixture
+def competition_uow():
+    return InMemoryCompetitionUnitOfWork()
+
+
+@pytest.fixture
+def qm_uow():
+    return InMemoryQuickMatchUnitOfWork()
+
+
+@pytest.fixture
+def golf_course_uow():
+    return InMemoryGolfCourseUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+def unique_email(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:8]}@test.com"
+
+
+async def create_user(user_uow, email: str, handicap: float | None = None):
+    user = User.create(
+        first_name="Test",
+        last_name="User",
+        email_str=email,
+        plain_password="SecureP@ssw0rd123",
+    )
+    if handicap is not None:
+        user.update_handicap(handicap)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def create_golf_course(golf_course_uow, creator_id):
+    """Campo de par 72: 18 hoyos de par 4, stroke index 1 a 18."""
+    tees = [
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            identifier="Yellow",
+            course_rating=70.0,
+            slope_rating=125,
+        ),
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            identifier="White",
+            course_rating=72.0,
+            slope_rating=130,
+        ),
+    ]
+    holes = [Hole(number=i, par=4, stroke_index=i) for i in range(1, 19)]
+
+    golf_course = GolfCourse.create(
+        name="Test Golf Club",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=tees,
+        holes=holes,
+    )
+    golf_course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(golf_course)
+    return golf_course
+
+
+def _use_case(user_uow, competition_uow, qm_uow, golf_course_uow):
+    return GetPlayerStatsUseCase(
+        user_uow=user_uow,
+        competition_uow=competition_uow,
+        quick_match_uow=qm_uow,
+        golf_course_uow=golf_course_uow,
+    )
+
+
+async def _played_quick_match(qm_uow, golf_course, user, *, strokes_per_hole: int = 4, others=()):
+    """
+    Una partida rápida terminada con la vuelta entera anotada.
+
+    `create()` mete al creador como primer participante, así que su
+    `participant_id` se lee de la entidad en vez de construirlo aquí.
+    """
+    match = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=user.id,
+        golf_course_id=golf_course.id,
+        scoring_format=ScoringFormat.MEDAL,
+    )
+    for participant in others:
+        match.add_participant(participant)
+
+    creator_participant_id = match.participants[0].participant_id
+    match.start(scorer_ids=[creator_participant_id])
+    match.complete()
+
+    async with qm_uow:
+        await qm_uow.quick_matches.add(match)
+        for hole_number in range(1, 19):
+            await qm_uow.quick_match_hole_scores.add(
+                QuickMatchHoleScore(
+                    id=QuickMatchHoleScoreId.generate(),
+                    quick_match_id=match.id,
+                    hole_number=hole_number,
+                    participant_id=creator_participant_id,
+                    score=strokes_per_hole,
+                    recorded_by_participant_id=creator_participant_id,
+                )
+            )
+        await qm_uow.commit()
+
+    return match
+
+
+@pytest.mark.asyncio
+class TestEmptyAccount:
+    """Una cuenta recién creada no puede reventar el panel."""
+
+    async def test_new_account_returns_zeros_not_errors(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("empty"))
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.tournaments_total == 0
+        assert stats.tournaments_active == 0
+
+    async def test_average_is_none_without_rounds_rather_than_zero(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Sin rondas no hay media que dar; cero significaría jugar al par."""
+        user = await create_user(user_uow, unique_email("empty"))
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.scoring_avg is None
+
+
+@pytest.mark.asyncio
+class TestHandicap:
+    """El hándicap sale del perfil."""
+
+    async def test_reports_the_profile_handicap(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("hcp"), handicap=12.4)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.handicap == 12.4
+
+    async def test_trend_is_none_because_there_is_no_history(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        No existe histórico de hándicap, solo la fecha del último cambio.
+        Devolver None es deliberado, no un dato que falte por rellenar.
+        """
+        user = await create_user(user_uow, unique_email("trend"), handicap=10.0)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.handicap_trend is None
+
+
+@pytest.mark.asyncio
+class TestRoundsAndAverage:
+    """Rondas jugadas y media respecto al par."""
+
+    async def test_counts_a_completed_quick_match(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("rounds"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 1
+
+    async def test_average_is_net_against_par_not_gross_strokes(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Campo de par 72 (18 hoyos de par 4), jugador scratch, 5 golpes por
+        hoyo: 90 brutos, +18 respecto al par. La media es esa, no los 90.
+        """
+        user = await create_user(user_uow, unique_email("avg"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.scoring_avg == 18.0
+
+    async def test_handicap_strokes_count_towards_the_average(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Con 18 de hándicap, 5 brutos por hoyo son par neto: media 0."""
+        user = await create_user(user_uow, unique_email("net"), handicap=18.0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.scoring_avg == 0.0
+
+
+@pytest.mark.asyncio
+class TestHiddenMatches:
+    """Regla de #127: ocultar es por persona, no por partida."""
+
+    async def test_a_match_hidden_by_the_caller_does_not_count_for_them(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("hider"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        match = await _played_quick_match(qm_uow, course, user)
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.hide_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
+
+    async def test_the_same_match_still_counts_for_the_other_participant(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Lo que hace útil la regla: si ocultar una partida la borrase para todos,
+        cualquiera podría alterar las estadísticas de los demás.
+        """
+        hider = await create_user(user_uow, unique_email("hider"), handicap=0)
+        other = await create_user(user_uow, unique_email("other"), handicap=0)
+        course = await create_golf_course(golf_course_uow, hider.id)
+
+        other_participant = QuickMatchParticipant.for_user(other.id)
+        match = await _played_quick_match(
+            qm_uow, course, hider, others=[other_participant]
+        )
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.hide_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        assert (await use_case.execute(hider.id)).rounds_played == 0
+        assert (await use_case.execute(other.id)).rounds_played == 1

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -140,12 +140,21 @@ def _use_case(user_uow, competition_uow, qm_uow, golf_course_uow):
     )
 
 
-async def _played_quick_match(qm_uow, golf_course, user, *, strokes_per_hole: int = 4, others=()):
+async def _played_quick_match(
+    qm_uow,
+    golf_course,
+    user,
+    *,
+    strokes_per_hole: int = 4,
+    others=(),
+    holes_played: int = 18,
+):
     """
-    Una partida rápida terminada con la vuelta entera anotada.
+    Una partida rápida terminada con la vuelta anotada.
 
     `create()` mete al creador como primer participante, así que su
     `participant_id` se lee de la entidad en vez de construirlo aquí.
+    `holes_played` deja la tarjeta a medias.
     """
     match = QuickMatch.create(
         id=QuickMatchId.generate(),
@@ -162,17 +171,19 @@ async def _played_quick_match(qm_uow, golf_course, user, *, strokes_per_hole: in
 
     async with qm_uow:
         await qm_uow.quick_matches.add(match)
-        for hole_number in range(1, 19):
-            await qm_uow.quick_match_hole_scores.add(
-                QuickMatchHoleScore(
-                    id=QuickMatchHoleScoreId.generate(),
-                    quick_match_id=match.id,
-                    hole_number=hole_number,
-                    participant_id=creator_participant_id,
-                    score=strokes_per_hole,
-                    recorded_by_participant_id=creator_participant_id,
+        # Todos firman su vuelta: una tarjeta a medias no computa
+        for participant in match.participants:
+            for hole_number in range(1, holes_played + 1):
+                await qm_uow.quick_match_hole_scores.add(
+                    QuickMatchHoleScore(
+                        id=QuickMatchHoleScoreId.generate(),
+                        quick_match_id=match.id,
+                        hole_number=hole_number,
+                        participant_id=participant.participant_id,
+                        score=strokes_per_hole,
+                        recorded_by_participant_id=creator_participant_id,
+                    )
                 )
-            )
         await qm_uow.commit()
 
     return match
@@ -187,13 +198,15 @@ async def _played_competition_match(
     strokes_per_hole: int | None = 4,
     strokes_received_per_hole: int = 0,
     holes_played: int = 18,
+    unscored_holes: list[int] | None = None,
     round_date: date = date(2026, 6, 1),
 ):
     """
     Un partido de torneo terminado con la tarjeta del jugador anotada.
 
-    `strokes_per_hole=None` deja los hoyos sin anotar, que es como queda un
-    hoyo concedido en match play.
+    `strokes_per_hole=None` deja la tarjeta entera sin anotar; `holes_played`
+    la corta antes del 18 (partido cerrado antes de tiempo) y `unscored_holes`
+    deja huecos sueltos, que es como queda un hoyo concedido en match play.
     """
     competition = Competition.create(
         id=CompetitionId(uuid4()),
@@ -243,7 +256,7 @@ async def _played_competition_match(
                 team="A",
                 strokes_received=strokes_received_per_hole,
             )
-            if strokes_per_hole is not None:
+            if strokes_per_hole is not None and hole_number not in (unscored_holes or []):
                 hole_score.set_own_score(strokes_per_hole)
             await competition_uow.hole_scores.add(hole_score)
         await competition_uow.commit()
@@ -362,6 +375,62 @@ class TestRoundsAndAverage:
 
 
 @pytest.mark.asyncio
+class TestIncompleteQuickMatchCards:
+    """Media vuelta no es una vuelta, tampoco en partida rápida."""
+
+    async def test_a_partial_card_counts_for_nothing(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("partial"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5, holes_played=9)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
+
+    async def test_a_match_still_in_progress_counts_for_nothing(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """La vuelta está entera, pero la partida sigue abierta."""
+        user = await create_user(user_uow, unique_email("open"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        match = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=user.id,
+            golf_course_id=course.id,
+            scoring_format=ScoringFormat.MEDAL,
+        )
+        participant_id = match.participants[0].participant_id
+        match.start(scorer_ids=[participant_id])
+
+        async with qm_uow:
+            await qm_uow.quick_matches.add(match)
+            for hole_number in range(1, 19):
+                await qm_uow.quick_match_hole_scores.add(
+                    QuickMatchHoleScore(
+                        id=QuickMatchHoleScoreId.generate(),
+                        quick_match_id=match.id,
+                        hole_number=hole_number,
+                        participant_id=participant_id,
+                        score=5,
+                        recorded_by_participant_id=participant_id,
+                    )
+                )
+            await qm_uow.commit()
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
+
+
+@pytest.mark.asyncio
 class TestCompetitionScorecards:
     """
     Los partidos de torneo también entran en la media.
@@ -430,33 +499,52 @@ class TestCompetitionScorecards:
         assert stats.rounds_played == 2
         assert stats.scoring_avg == 9.0
 
-    async def test_conceded_holes_do_not_count_as_played(
+    async def test_a_match_closed_before_the_18th_does_not_count(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
     ):
         """
-        En match play te conceden hoyos que ibas ganando. Rellenarlos con un
-        doble bogey castigaría por ir por delante, así que se dejan fuera y la
-        vuelta se mide contra el par de lo que sí se jugó.
+        Un partido decidido en el hoyo 15 está terminado, pero su tarjeta no:
+        faltan hoyos, y media vuelta no se puede comparar con una entera. Es el
+        precio de que la media hable siempre de rondas iguales.
         """
         player = await create_user(user_uow, unique_email("conceded"), handicap=0)
         rival = await create_user(user_uow, unique_email("rival"), handicap=0)
         course = await create_golf_course(golf_course_uow, player.id)
         await _played_competition_match(
-            competition_uow, course, player, rival, strokes_per_hole=5, holes_played=9
+            competition_uow, course, player, rival, strokes_per_hole=5, holes_played=15
         )
 
         stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
             player.id
         )
 
-        # Nueve hoyos a +1: la vuelta cuenta como +9, no como +18
-        assert stats.rounds_played == 1
-        assert stats.scoring_avg == 9.0
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
 
-    async def test_a_match_without_a_single_hole_scored_is_not_averaged(
+    async def test_a_single_conceded_hole_invalidates_the_card(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
     ):
-        """Se jugó (cuenta como ronda) pero no dice nada: no hay media que sacar."""
+        """
+        Los 18 hoyos existen en la tarjeta, pero uno se quedó sin anotar. No se
+        rellena con un doble bogey ni se ignora: la vuelta no computa.
+        """
+        player = await create_user(user_uow, unique_email("gap"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5, unscored_holes=[7]
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
+
+    async def test_a_match_without_a_single_hole_scored_does_not_count(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
         player = await create_user(user_uow, unique_email("noscore"), handicap=0)
         rival = await create_user(user_uow, unique_email("rival"), handicap=0)
         course = await create_golf_course(golf_course_uow, player.id)
@@ -468,7 +556,7 @@ class TestCompetitionScorecards:
             player.id
         )
 
-        assert stats.rounds_played == 1
+        assert stats.rounds_played == 0
         assert stats.scoring_avg is None
 
     async def test_a_disaster_hole_is_capped_at_net_double_bogey(

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -199,6 +199,7 @@ async def _played_competition_match(
     strokes_received_per_hole: int = 0,
     holes_played: int = 18,
     unscored_holes: list[int] | None = None,
+    decided_early: bool = False,
     round_date: date = date(2026, 6, 1),
 ):
     """
@@ -242,7 +243,10 @@ async def _played_competition_match(
         team_b_players=[match_player(rival.id)],
     )
     match.start()
-    match.complete({"winner": "A", "score": "2UP"})
+    if decided_early:
+        # Matemáticamente ganado en el 15: 4 arriba y 3 por jugar
+        match.mark_decided({"winner": "A", "score": "4&3"})
+    match.complete({"winner": "A", "score": "4&3" if decided_early else "2UP"})
 
     async with competition_uow:
         await competition_uow.competitions.add(competition)
@@ -499,13 +503,35 @@ class TestCompetitionScorecards:
         assert stats.rounds_played == 2
         assert stats.scoring_avg == 9.0
 
+    async def test_a_match_decided_early_counts_if_the_card_was_finished_anyway(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Lo que decide es la tarjeta, no en qué hoyo se ganó el partido. Si el
+        partido se resolvió en el 15 pero los jugadores siguieron anotando
+        hasta el 18, la vuelta está entera y computa como cualquier otra.
+        """
+        player = await create_user(user_uow, unique_email("decided"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5, decided_early=True
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 18.0
+
     async def test_a_match_closed_before_the_18th_does_not_count(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
     ):
         """
-        Un partido decidido en el hoyo 15 está terminado, pero su tarjeta no:
-        faltan hoyos, y media vuelta no se puede comparar con una entera. Es el
-        precio de que la media hable siempre de rondas iguales.
+        El mismo partido resuelto pronto, pero dejando de anotar al cerrarse:
+        la tarjeta se queda sin hoyos, y media vuelta no se puede comparar con
+        una entera. Es el precio de que la media hable de rondas iguales.
         """
         player = await create_user(user_uow, unique_email("conceded"), handicap=0)
         rival = await create_user(user_uow, unique_email("rival"), handicap=0)

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -1,0 +1,633 @@
+"""
+Tests del historial de partidas de un jugador (BE #128).
+
+El feed mete en una misma lista dos cosas que no se parecen: un partido de
+torneo, que se juega por hoyos contra un rival y acaba en "3&2", y una partida
+rápida libre, que se juega contra el par y acaba en "+18" o en puntos. Estos
+tests fijan qué campos rellena cada una y, sobre todo, cuáles deja en None en
+lugar de inventar una equivalencia.
+"""
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.entities.competition import Competition
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.entities.round import Round
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_name import CompetitionName
+from src.modules.competition.domain.value_objects.date_range import DateRange
+from src.modules.competition.domain.value_objects.location import Location
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.match_player import MatchPlayer
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.competition.domain.value_objects.session_type import SessionType
+from src.modules.competition.domain.value_objects.team_assignment import TeamAssignment
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryCompetitionUnitOfWork,
+)
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.in_memory.in_memory_golf_course_unit_of_work import (
+    InMemoryGolfCourseUnitOfWork,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
+from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
+    QuickMatchHoleScoreId,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
+from src.modules.quick_match.infrastructure.persistence.in_memory.in_memory_quick_match_unit_of_work import (
+    InMemoryQuickMatchUnitOfWork,
+)
+from src.modules.user.application.use_cases.get_recent_matches_use_case import (
+    GetRecentMatchesUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+HOLES = range(1, 19)
+
+
+@pytest.fixture
+def competition_uow():
+    return InMemoryCompetitionUnitOfWork()
+
+
+@pytest.fixture
+def qm_uow():
+    return InMemoryQuickMatchUnitOfWork()
+
+
+@pytest.fixture
+def golf_course_uow():
+    return InMemoryGolfCourseUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+def unique_email(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:8]}@test.com"
+
+
+async def create_user(user_uow, first_name: str, handicap: float | None = None):
+    user = User.create(
+        first_name=first_name,
+        last_name="Player",
+        email_str=unique_email(first_name.lower()),
+        plain_password="SecureP@ssw0rd123",
+    )
+    if handicap is not None:
+        user.update_handicap(handicap)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def create_golf_course(golf_course_uow, creator_id, name: str = "Test Golf Club"):
+    """Campo de par 72: 18 hoyos de par 4, stroke index 1 a 18."""
+    tees = [
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            identifier="Yellow",
+            course_rating=70.0,
+            slope_rating=125,
+        ),
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            identifier="White",
+            course_rating=72.0,
+            slope_rating=130,
+        ),
+    ]
+    golf_course = GolfCourse.create(
+        name=name,
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=tees,
+        holes=[Hole(number=i, par=4, stroke_index=i) for i in HOLES],
+    )
+    golf_course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(golf_course)
+    return golf_course
+
+
+def _use_case(user_uow, competition_uow, qm_uow, golf_course_uow):
+    return GetRecentMatchesUseCase(
+        user_uow=user_uow,
+        competition_uow=competition_uow,
+        quick_match_uow=qm_uow,
+        golf_course_uow=golf_course_uow,
+    )
+
+
+async def played_quick_match(
+    qm_uow,
+    golf_course,
+    creator,
+    *,
+    scoring_format: ScoringFormat | None = ScoringFormat.MEDAL,
+    match_format: MatchFormat | None = None,
+    others=(),
+    strokes_by_participant_index: dict[int, int] | None = None,
+    strokes_per_hole: int = 4,
+    holes_played: int = 18,
+):
+    """
+    Una partida rápida terminada con la vuelta anotada.
+
+    `strokes_by_participant_index` permite dar golpes distintos a cada
+    participante por su posición en el roster (0 = creador); sin él todos
+    firman los mismos. `holes_played` deja la vuelta a medias, que es como
+    acaba un match play que se cierra antes del 18.
+    """
+    match = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator.id,
+        golf_course_id=golf_course.id,
+        match_format=match_format,
+        scoring_format=scoring_format,
+    )
+    for participant in others:
+        match.add_participant(participant)
+
+    participant_ids = [p.participant_id for p in match.participants]
+    match.start(scorer_ids=[participant_ids[0]])
+    match.complete()
+
+    async with qm_uow:
+        await qm_uow.quick_matches.add(match)
+        for index, participant_id in enumerate(participant_ids):
+            strokes = (strokes_by_participant_index or {}).get(index, strokes_per_hole)
+            for hole_number in range(1, holes_played + 1):
+                await qm_uow.quick_match_hole_scores.add(
+                    QuickMatchHoleScore(
+                        id=QuickMatchHoleScoreId.generate(),
+                        quick_match_id=match.id,
+                        hole_number=hole_number,
+                        participant_id=participant_id,
+                        score=strokes,
+                        recorded_by_participant_id=participant_ids[0],
+                    )
+                )
+        await qm_uow.commit()
+
+    return match
+
+
+async def played_competition_match(
+    competition_uow,
+    golf_course,
+    *,
+    team_a_user_ids,
+    team_b_user_ids,
+    round_date: date,
+    result: dict,
+    match_format: MatchFormat = MatchFormat.SINGLES,
+):
+    """Un partido de torneo terminado, con su ronda y su competición."""
+    creator_id = team_a_user_ids[0]
+    competition = Competition.create(
+        id=CompetitionId(uuid4()),
+        creator_id=creator_id,
+        name=CompetitionName("Ryder Cup Test"),
+        dates=DateRange(start_date=round_date, end_date=round_date + timedelta(days=2)),
+        location=Location(main_country=CountryCode("ES")),
+        play_mode=PlayMode.SCRATCH,
+        team_1_name="Team A",
+        team_2_name="Team B",
+        team_assignment=TeamAssignment.MANUAL,
+    )
+    round_ = Round.create(
+        competition_id=competition.id,
+        golf_course_id=golf_course.id,
+        round_date=round_date,
+        session_type=SessionType.MORNING,
+        match_format=match_format,
+    )
+
+    def player(user_id):
+        return MatchPlayer(
+            user_id=user_id,
+            playing_handicap=10,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            strokes_received=tuple(range(1, 11)),
+        )
+
+    match = Match.create(
+        round_id=round_.id,
+        match_number=1,
+        team_a_players=[player(uid) for uid in team_a_user_ids],
+        team_b_players=[player(uid) for uid in team_b_user_ids],
+    )
+    match.start()
+    match.complete(result)
+
+    async with competition_uow:
+        await competition_uow.competitions.add(competition)
+        await competition_uow.rounds.add(round_)
+        await competition_uow.matches.add(match)
+        await competition_uow.commit()
+
+    return match
+
+
+@pytest.mark.asyncio
+class TestEmptyHistory:
+    """Una cuenta sin historial devuelve una lista vacía, no un error."""
+
+    async def test_new_account_has_no_matches(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, "Empty")
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches == []
+
+
+@pytest.mark.asyncio
+class TestFreePlayQuickMatch:
+    """Partido libre: se juega contra el par, no contra un rival."""
+
+    async def test_medal_reports_net_strokes_against_par(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Par 72, jugador scratch, 5 golpes por hoyo: +18, no los 90 brutos."""
+        user = await create_user(user_uow, "Medal", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        entry = feed.matches[0]
+        assert entry.score == "+18"
+        assert entry.scoring_format == "MEDAL"
+        assert entry.match_format is None
+        assert entry.stableford_points is None
+
+    async def test_stableford_reports_points(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Scratch en par 72 firmando el par: 2 puntos por hoyo, 36 en total."""
+        user = await create_user(user_uow, "Stable", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await played_quick_match(
+            qm_uow, course, user, scoring_format=ScoringFormat.STABLEFORD, strokes_per_hole=4
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        entry = feed.matches[0]
+        assert entry.stableford_points == 36
+        assert entry.score == "36 pts"
+
+    async def test_has_no_match_play_result(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """WON/LOST es de match play: en partido libre no hay a quién ganarle."""
+        user = await create_user(user_uow, "NoResult", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await played_quick_match(qm_uow, course, user)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches[0].result is None
+
+    async def test_the_others_are_rivals_not_partners(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Sin bandos, la clasificación es individual: nadie es compañero."""
+        user = await create_user(user_uow, "Solo", handicap=0)
+        rival = await create_user(user_uow, "Rival", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await played_quick_match(
+            qm_uow, course, user, others=[QuickMatchParticipant.for_user(rival.id)]
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches[0].partners == []
+        assert feed.matches[0].opponents == ["Rival Player"]
+
+    async def test_a_guest_shows_the_name_typed_in_the_match(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """El invitado no tiene perfil: su nombre vive dentro de la partida."""
+        user = await create_user(user_uow, "Host", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            user,
+            others=[QuickMatchParticipant.for_guest("Seve", "Ballesteros", handicap=0)],
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches[0].opponents == ["Seve Ballesteros"]
+
+    async def test_reports_the_golf_course_played(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, "Course", handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id, name="Valderrama")
+        await played_quick_match(qm_uow, course, user)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches[0].golf_course_name == "Valderrama"
+        assert feed.matches[0].golf_course_id == str(course.id.value)
+
+
+@pytest.mark.asyncio
+class TestTeamQuickMatch:
+    """Partida rápida por equipos: sí se juega por hoyos contra un rival."""
+
+    async def test_winner_gets_won_and_the_loser_the_same_score(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        SINGLES, el creador firma 4 y el rival 5 en los 18 hoyos: los gana todos.
+        Con la vuelta entera anotada la ventaja es de 18 y no quedan hoyos, así
+        que el resultado es "18UP" para los dos, con el signo cambiado.
+        """
+        winner = await create_user(user_uow, "Winner", handicap=0)
+        loser = await create_user(user_uow, "Loser", handicap=0)
+        course = await create_golf_course(golf_course_uow, winner.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            winner,
+            scoring_format=None,
+            match_format=MatchFormat.SINGLES,
+            others=[QuickMatchParticipant.for_user(loser.id)],
+            strokes_by_participant_index={0: 4, 1: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        won = (await use_case.execute(winner.id)).matches[0]
+        lost = (await use_case.execute(loser.id)).matches[0]
+
+        assert won.result == "WON"
+        assert lost.result == "LOST"
+        assert won.score == lost.score == "18UP"
+
+    async def test_a_match_closed_early_reports_the_holes_that_were_left(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Diez hoyos anotados y ganados todos: 10 de ventaja con 8 por jugar. Eso
+        se escribe "10&8", la notación de un match play que no llega al 18.
+        """
+        winner = await create_user(user_uow, "Early", handicap=0)
+        loser = await create_user(user_uow, "Late", handicap=0)
+        course = await create_golf_course(golf_course_uow, winner.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            winner,
+            scoring_format=None,
+            match_format=MatchFormat.SINGLES,
+            others=[QuickMatchParticipant.for_user(loser.id)],
+            strokes_by_participant_index={0: 4, 1: 5},
+            holes_played=10,
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            winner.id
+        )
+
+        assert feed.matches[0].score == "10&8"
+        assert feed.matches[0].result == "WON"
+
+    async def test_all_holes_halved_ends_as_halved(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Nunca se decide: el resultado es la ventaja real (ninguna), no un "N&M"."""
+        one = await create_user(user_uow, "One", handicap=0)
+        two = await create_user(user_uow, "Two", handicap=0)
+        course = await create_golf_course(golf_course_uow, one.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            one,
+            scoring_format=None,
+            match_format=MatchFormat.SINGLES,
+            others=[QuickMatchParticipant.for_user(two.id)],
+            strokes_per_hole=4,
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(one.id)
+
+        assert feed.matches[0].result == "HALVED"
+        assert feed.matches[0].score == "AS"
+
+    async def test_the_rival_is_an_opponent(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        one = await create_user(user_uow, "One", handicap=0)
+        two = await create_user(user_uow, "Two", handicap=0)
+        course = await create_golf_course(golf_course_uow, one.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            one,
+            scoring_format=None,
+            match_format=MatchFormat.SINGLES,
+            others=[QuickMatchParticipant.for_user(two.id)],
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(one.id)
+
+        assert feed.matches[0].opponents == ["Two Player"]
+        assert feed.matches[0].partners == []
+
+
+@pytest.mark.asyncio
+class TestCompetitionMatch:
+    """Partido de torneo: fecha, campo y nombre del torneo salen de la ronda."""
+
+    async def test_reports_tournament_date_and_result_from_the_player_side(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Home")
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id, name="Real Club")
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "B", "score": "3&2"},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        home = (await use_case.execute(player.id)).matches[0]
+        away = (await use_case.execute(rival.id)).matches[0]
+
+        assert home.date == date(2026, 6, 1)
+        assert home.tournament_name == "Ryder Cup Test"
+        assert home.golf_course_name == "Real Club"
+        assert home.match_format == "SINGLES"
+        assert home.score == "3&2"
+        assert home.result == "LOST"
+        assert away.result == "WON"
+
+    async def test_has_no_scoring_format(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """MEDAL/STABLEFORD es el eje de las partidas rápidas; aquí no aplica."""
+        player = await create_user(user_uow, "Home")
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].scoring_format is None
+        assert feed.matches[0].stableford_points is None
+
+    async def test_separates_partners_from_opponents_in_fourball(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Home")
+        partner = await create_user(user_uow, "Partner")
+        rival_one = await create_user(user_uow, "Rivalone")
+        rival_two = await create_user(user_uow, "Rivaltwo")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id, partner.id],
+            team_b_user_ids=[rival_one.id, rival_two.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+            match_format=MatchFormat.FOURBALL,
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].partners == ["Partner Player"]
+        assert sorted(feed.matches[0].opponents) == ["Rivalone Player", "Rivaltwo Player"]
+
+
+@pytest.mark.asyncio
+class TestFeedOrderAndLimit:
+    """El feed mezcla ambas fuentes en una única lista ordenada."""
+
+    async def test_most_recent_first_across_both_sources(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        La partida rápida se fecha hoy y el torneo en 2026-06-01: la rápida va
+        primero aunque venga de la otra fuente.
+        """
+        player = await create_user(user_uow, "Mixed", handicap=0)
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+        )
+        await played_quick_match(qm_uow, course, player)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert len(feed.matches) == 2
+        assert feed.matches[0].tournament_name is None
+        assert feed.matches[1].tournament_name == "Ryder Cup Test"
+
+    async def test_limit_applies_after_merging_both_sources(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Recortar antes de mezclar dejaría fuera partidas más recientes de una
+        fuente por culpa de las de la otra.
+        """
+        player = await create_user(user_uow, "Limited", handicap=0)
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+        )
+        await played_quick_match(qm_uow, course, player)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id, limit=1
+        )
+
+        assert len(feed.matches) == 1
+        assert feed.matches[0].tournament_name is None
+
+
+@pytest.mark.asyncio
+class TestHiddenMatches:
+    """Regla de #127: ocultar es por persona, no por partida."""
+
+    async def test_a_hidden_match_leaves_the_feed_of_whoever_hid_it(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        hider = await create_user(user_uow, "Hider", handicap=0)
+        other = await create_user(user_uow, "Other", handicap=0)
+        course = await create_golf_course(golf_course_uow, hider.id)
+        match = await played_quick_match(
+            qm_uow, course, hider, others=[QuickMatchParticipant.for_user(other.id)]
+        )
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.hide_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        assert (await use_case.execute(hider.id)).matches == []
+        assert len((await use_case.execute(other.id)).matches) == 1


### PR DESCRIPTION
Closes #128

Adds the aggregated player performance the dashboard redesign needs (RyderCupWeb #306). Everything is computed on the fly — a player's history is a handful of rounds, it changes with every score recorded, and an invalidation strategy would cost more than the query it saves.

## Endpoints

- `GET /api/v1/users/me/stats` — global summary
- `GET /api/v1/users/me/stats/golf-courses/{id}` — same summary, one course only
- `GET /api/v1/users/me/matches?limit=N` — recent match feed

Responses stay snake_case like the rest of the API; the camelCase contract in the issue came from an external audit document, not from this project. An account with no history returns zeros, nulls and an empty list rather than a 404: an empty dashboard is a normal state, not an error.

## What reaches the statistics

**Only complete scorecards from finished matches.** A match still in progress, a card left half scored or a single unscored hole keeps the round out of `scoring_avg` *and* of `rounds_played` — the two numbers must always talk about the same rounds, and half a round cannot be compared with a full one. Completeness is measured against the holes the course actually has, not a hardcoded 18.

What decides is the scorecard, not the hole the match was won on: a match play resolved on the 15th counts like any other round as long as the players kept scoring to the 18th. The statistics never look at `is_decided`. What leaves a round out is giving up on the card, which in match play is the common case.

The feed (`/me/matches`) does not apply this filter — it is history, not a statistic, so a finished match with a partial card still shows up there.

## Design decisions

**Stableford moved into the backend.** The scoring rules only lived in the frontend. `StablefordCalculator` ports them, reusing `PlayingHandicapCalculator` — which gained `calculate_unbounded()`, without the `max(0, ...)`, so a plus player gives strokes as WHS Rule 8.2 says. Parity with the frontend engine is pinned by tests over the same data across five handicaps, one of them a plus.

**Both sources feed the average.** A tournament match is played hole by hole against a rival, but the player still signs a card with their own strokes, and that card says how well they played just as much as a medal round does — so Stableford tournaments will work for free when we add them. It reads `own_score`, not the entity's `net_score`: the latter is only filled in once the marker has validated the hole, so good cards would silently drop out of the average.

**Each hole is capped at net double bogey** (WHS Rule 3.1), on both sources so they stay comparable — one blow-up hole should not move a whole season's average.

**The feed unifies two different things.** Each entry leaves as null whatever does not apply: a tournament match has no `scoring_format`, a free-play match has no match-play `result`. `match_format` and `scoring_format` are not merged into a single `format` field because in the domain they are distinct, mutually exclusive axes.

**Use cases live in the `user` module**, taking the units of work of the modules they read, following the existing `GetAdminStatsUseCase` pattern.

## Out of scope

`handicap_trend` returns `null`: there is no handicap history, only the date of the last change. Follow-ups opened from this work: #167 (score differentials and an estimated index, which also gets the trend without a new table) and #168 (breakdown by par, hole type and nines).

## Tests

2425 unit tests plus 15 integration tests. `find_completed_for_player` is verified against PostgreSQL, since it looks the player up with JSONB containment over two columns with no foreign key and orders by the round date from another table — the in-memory implementation cannot show that. The endpoint tests play a full quick match through the API and then read the three endpoints, including the #127 rule: hiding a match removes it from the stats and the feed of whoever hid it, and only for them.