### PR TITLE
feat(stats): Score differential and estimated handicap index

### DIFF
--- a/src/modules/competition/domain/services/score_differential_calculator.py
+++ b/src/modules/competition/domain/services/score_differential_calculator.py
@@ -1,0 +1,158 @@
+"""
+Domain Service: ScoreDifferentialCalculator.
+
+Score Differential del WHS: el hándicap al que un jugador jugó una vuelta
+concreta, y el índice estimado que sale de sus últimas vueltas. Puro, sin IO.
+
+Vive junto a `PlayingHandicapCalculator` porque son la misma familia de reglas
+WHS y comparten `TeeRating`, aunque ninguno de los dos sea exclusivo del módulo
+de competición.
+
+**Este índice no es el oficial de la federación.** Falta el PCC (Playing
+Conditions Calculation), que ajusta los diferenciales por cómo estaba el campo
+ese día y que solo puede calcular quien tiene todas las tarjetas de la jornada.
+Aquí se asume PCC = 0.
+"""
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from src.modules.competition.domain.services.playing_handicap_calculator import (
+    NEUTRAL_SLOPE,
+    TeeRating,
+)
+
+# Ventana de vueltas del WHS: el índice mira las 20 últimas, no la carrera
+# entera. Un jugador que mejora no arrastra sus vueltas de hace tres años.
+SCORING_RECORD_SIZE = 20
+
+# Sin al menos estas vueltas no se publica índice. El WHS pide 54 hoyos, que
+# son tres vueltas: con dos, el número es ruido con aspecto de dato.
+MIN_ROUNDS_FOR_INDEX = 3
+
+# Cuántas vueltas se promedian y qué ajuste se les aplica, según cuántas hay
+# disponibles (Regla WHS 5.2). Con pocas vueltas se coge solo la mejor y se le
+# resta un margen: la muestra es tan pequeña que sin ese ajuste el índice
+# saldría optimista. Cada entrada es (mínimo de vueltas, cuántas se promedian,
+# ajuste), ordenada de más a menos vueltas.
+_INDEX_TABLE: tuple[tuple[int, int, Decimal], ...] = (
+    (20, 8, Decimal("0")),
+    (19, 7, Decimal("0")),
+    (17, 6, Decimal("0")),
+    (15, 5, Decimal("0")),
+    (12, 4, Decimal("0")),
+    (9, 3, Decimal("0")),
+    (7, 2, Decimal("0")),
+    (6, 2, Decimal("-1.0")),
+    (5, 1, Decimal("0")),
+    (4, 1, Decimal("-1.0")),
+    (3, 1, Decimal("-2.0")),
+)
+
+# Cuántas vueltas entran en cada mitad de la comparación de tendencia. Cinco es
+# suficiente para que una vuelta mala no dicte la tendencia, y bastante poco
+# para que la tendencia hable del presente.
+TREND_WINDOW = 5
+
+
+@dataclass(frozen=True)
+class PlayedRound:
+    """
+    Una vuelta ya reducida a lo que el WHS necesita de ella.
+
+    `adjusted_gross_score` son los golpes de la vuelta con cada hoyo topado en
+    su net double bogey; el tope se aplica antes, al leer la tarjeta, porque
+    depende de los golpes que el jugador recibía en cada hoyo.
+    """
+
+    adjusted_gross_score: int
+    tee_rating: TeeRating
+
+
+class ScoreDifferentialCalculator:
+    """Diferenciales de vuelta e índice estimado, según el WHS."""
+
+    @staticmethod
+    def differential(played_round: PlayedRound) -> Decimal:
+        """
+        A qué hándicap se jugó esa vuelta.
+
+        `(113 / Slope) x (Golpes ajustados - Course Rating)`: la resta dice
+        cuánto peor (o mejor) se jugó que un scratch desde ese tee, y el factor
+        de slope traduce ese margen a la escala neutra del sistema, para que una
+        vuelta en un campo durísimo y otra en uno fácil sean comparables.
+        """
+        rating = played_round.tee_rating
+        raw = (Decimal(NEUTRAL_SLOPE) / Decimal(rating.slope_rating)) * (
+            Decimal(played_round.adjusted_gross_score) - rating.course_rating
+        )
+        return raw.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
+    @classmethod
+    def differentials(cls, played_rounds: list[PlayedRound]) -> list[Decimal]:
+        """Diferenciales en el mismo orden en que llegan las vueltas."""
+        return [cls.differential(played_round) for played_round in played_rounds]
+
+    @staticmethod
+    def estimated_index(differentials: list[Decimal]) -> Decimal | None:
+        """
+        Índice estimado a partir de los diferenciales, del más reciente al más
+        antiguo.
+
+        Se queda con los 20 más recientes y promedia los mejores según la tabla
+        del WHS. Devuelve None por debajo de tres vueltas: no es un índice de
+        cero, es que todavía no hay con qué calcularlo.
+        """
+        window = differentials[:SCORING_RECORD_SIZE]
+        if len(window) < MIN_ROUNDS_FOR_INDEX:
+            return None
+
+        count, adjustment = next(
+            (used, adjust) for minimum, used, adjust in _INDEX_TABLE if len(window) >= minimum
+        )
+        best = sorted(window)[:count]
+        average = sum(best, Decimal("0")) / Decimal(count)
+        return (average + adjustment).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
+    @staticmethod
+    def playing_average(differentials: list[Decimal]) -> Decimal | None:
+        """
+        Media de los diferenciales recientes, buenos y malos.
+
+        El índice mira solo las mejores vueltas, que es su regla y su virtud:
+        dice de lo que un jugador es capaz. Esta media dice a qué juega de
+        media, incluidos los días malos, y suele ser varios golpes peor.
+        """
+        window = differentials[:SCORING_RECORD_SIZE]
+        if not window:
+            return None
+        average = sum(window, Decimal("0")) / Decimal(len(window))
+        return average.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
+    @staticmethod
+    def best_differential(differentials: list[Decimal]) -> Decimal | None:
+        """La mejor vuelta del registro: el diferencial más bajo."""
+        window = differentials[:SCORING_RECORD_SIZE]
+        return min(window) if window else None
+
+    @staticmethod
+    def trend(differentials: list[Decimal]) -> Decimal | None:
+        """
+        Cuánto ha cambiado el juego, comparando las vueltas recientes con las
+        anteriores.
+
+        **Negativo es mejorar**: los diferenciales bajan cuando se juega mejor,
+        igual que baja un hándicap. Se devuelve la resta cruda, sin invertir el
+        signo, para que el número no contradiga al hándicap que la interfaz
+        enseña a su lado.
+
+        None mientras no haya dos ventanas completas que comparar: con menos
+        vueltas la "tendencia" sería la diferencia entre dos vueltas sueltas.
+        """
+        if len(differentials) < TREND_WINDOW * 2:
+            return None
+
+        recent = differentials[:TREND_WINDOW]
+        previous = differentials[TREND_WINDOW : TREND_WINDOW * 2]
+        change = (sum(recent, Decimal("0")) - sum(previous, Decimal("0"))) / Decimal(TREND_WINDOW)
+        return change.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)

--- a/src/modules/competition/domain/services/score_differential_calculator.py
+++ b/src/modules/competition/domain/services/score_differential_calculator.py
@@ -8,10 +8,18 @@ Vive junto a `PlayingHandicapCalculator` porque son la misma familia de reglas
 WHS y comparten `TeeRating`, aunque ninguno de los dos sea exclusivo del módulo
 de competición.
 
-**Este índice no es el oficial de la federación.** Falta el PCC (Playing
-Conditions Calculation), que ajusta los diferenciales por cómo estaba el campo
-ese día y que solo puede calcular quien tiene todas las tarjetas de la jornada.
-Aquí se asume PCC = 0.
+**Este índice no es el oficial de la federación.** Le faltan dos cosas:
+
+- El **PCC** (Playing Conditions Calculation), el ajuste por cómo estaba el
+  campo ese día, que solo puede calcular quien tiene todas las tarjetas de la
+  jornada, incluidas las de jugadores que no usan esta aplicación. Se asume 0.
+- El **soft cap y el hard cap** (Regla WHS 5.8), que frenan cuánto puede subir
+  un índice respecto al más bajo que el jugador tuvo en los últimos 365 días.
+  Calcularlos exige reconstruir el índice en cada momento de ese año para saber
+  cuál fue el mínimo, que es bastante más que una fórmula. Sin ellos, un
+  jugador que empeora ve aquí un índice más alto que el que le daría el sistema
+  oficial, y esa es justo la dirección en la que un número informativo no
+  engaña: no regala golpes.
 """
 
 from dataclasses import dataclass
@@ -94,6 +102,18 @@ class ScoreDifferentialCalculator:
         return [cls.differential(played_round) for played_round in played_rounds]
 
     @staticmethod
+    def scoring_record(differentials: list[Decimal]) -> list[Decimal]:
+        """
+        Las vueltas que el sistema mira: las 20 más recientes.
+
+        Todas las métricas de aquí trabajan sobre esta ventana, así que quien
+        publique la serie debe publicar esta y no la lista entera. Si no, un
+        cliente que calcule el mínimo por su cuenta encontrará vueltas que
+        ninguna otra cifra está contando.
+        """
+        return differentials[:SCORING_RECORD_SIZE]
+
+    @staticmethod
     def estimated_index(differentials: list[Decimal]) -> Decimal | None:
         """
         Índice estimado a partir de los diferenciales, del más reciente al más
@@ -103,7 +123,7 @@ class ScoreDifferentialCalculator:
         del WHS. Devuelve None por debajo de tres vueltas: no es un índice de
         cero, es que todavía no hay con qué calcularlo.
         """
-        window = differentials[:SCORING_RECORD_SIZE]
+        window = ScoreDifferentialCalculator.scoring_record(differentials)
         if len(window) < MIN_ROUNDS_FOR_INDEX:
             return None
 
@@ -123,7 +143,7 @@ class ScoreDifferentialCalculator:
         dice de lo que un jugador es capaz. Esta media dice a qué juega de
         media, incluidos los días malos, y suele ser varios golpes peor.
         """
-        window = differentials[:SCORING_RECORD_SIZE]
+        window = ScoreDifferentialCalculator.scoring_record(differentials)
         if not window:
             return None
         average = sum(window, Decimal("0")) / Decimal(len(window))
@@ -132,7 +152,7 @@ class ScoreDifferentialCalculator:
     @staticmethod
     def best_differential(differentials: list[Decimal]) -> Decimal | None:
         """La mejor vuelta del registro: el diferencial más bajo."""
-        window = differentials[:SCORING_RECORD_SIZE]
+        window = ScoreDifferentialCalculator.scoring_record(differentials)
         return min(window) if window else None
 
     @staticmethod

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -50,6 +50,7 @@ class ParticipantTotals:
     net_strokes: int
     par_played: int
     holes_played: int
+    adjusted_gross_strokes: int
 
     @property
     def to_par(self) -> int:
@@ -160,6 +161,10 @@ class StablefordCalculator:
         partida enseña los golpes que se dieron, no los que puntúan; lo encienden
         las estadísticas agregadas, donde un hoyo suelto no debe pesar más que
         una temporada.
+
+        `adjusted_gross_strokes` sale siempre topado, mire o no `net_strokes` al
+        tope: es el Adjusted Gross Score del WHS, que por definición lo lleva, y
+        de él sale el Score Differential de la vuelta (BE #167).
         """
         strokes_basis = self.resolve_strokes_basis(handicap, tee_rating, allowance_percentage)
 
@@ -168,6 +173,7 @@ class StablefordCalculator:
         net_strokes = 0
         par_played = 0
         holes_played = 0
+        adjusted_gross_strokes = 0
 
         for hole in holes:
             score = scores_by_hole.get(hole.hole_number)
@@ -177,11 +183,9 @@ class StablefordCalculator:
             strokes_received = self.allocate_strokes(strokes_basis, hole.stroke_index)
             stableford_points += self.hole_points(score, hole.par, strokes_received)
             total_strokes += score
-            computable = (
-                self.adjusted_gross(score, hole.par, strokes_received)
-                if cap_at_net_double_bogey
-                else score
-            )
+            adjusted = self.adjusted_gross(score, hole.par, strokes_received)
+            adjusted_gross_strokes += adjusted
+            computable = adjusted if cap_at_net_double_bogey else score
             net_strokes += computable - strokes_received
             par_played += hole.par
             holes_played += 1
@@ -192,6 +196,7 @@ class StablefordCalculator:
             net_strokes=net_strokes,
             par_played=par_played,
             holes_played=holes_played,
+            adjusted_gross_strokes=adjusted_gross_strokes,
         )
 
     @staticmethod

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -20,20 +20,63 @@ class PlayerStatsResponseDTO(BaseModel):
     Cada hoyo va topado en el net double bogey (Regla WHS 3.1). Va en None
     cuando no hay ninguna vuelta computable, que no es lo mismo que una media
     de cero.
+
+    Los campos de diferencial (BE #167) se calculan sobre un subconjunto de
+    esas vueltas: solo las jugadas desde un tee conocido, porque sin Slope ni
+    Course Rating no hay diferencial. De ahí que `rounds_with_differential`
+    pueda ser menor que `rounds_played`; la interfaz debería decirlo cuando no
+    coincidan, en lugar de dar a entender que el índice mira todas las vueltas.
+
+    **El índice estimado no es el oficial de la federación.** Le falta el PCC,
+    el ajuste por las condiciones de juego de cada jornada, que solo puede
+    calcular quien tiene todas las tarjetas del día. Conviene que la interfaz
+    lo diga para no crear la expectativa equivocada.
     """
 
-    handicap: float | None = None
+    handicap: float | None = Field(
+        default=None, description="El hándicap oficial que el jugador tiene en su perfil"
+    )
     handicap_trend: float | None = Field(
         default=None,
         description=(
-            "Siempre None por ahora: no existe histórico de hándicap, solo la "
-            "fecha del último cambio. Calcularlo exige tabla nueva (BE #128)."
+            "Cambio entre las 5 vueltas más recientes y las 5 anteriores. "
+            "**Negativo es mejorar**, igual que baja un hándicap. None hasta "
+            "que haya 10 vueltas con diferencial que comparar."
         ),
     )
     scoring_avg: float | None = None
     rounds_played: int = 0
     tournaments_total: int = 0
     tournaments_active: int = 0
+    estimated_index: float | None = Field(
+        default=None,
+        description=(
+            "A qué hándicap está jugando: media de sus mejores diferenciales "
+            "recientes según la tabla WHS 5.2. None con menos de 3 vueltas."
+        ),
+    )
+    playing_avg: float | None = Field(
+        default=None,
+        description=(
+            "Media de todos los diferenciales recientes, no solo de los mejores. "
+            "Suele ser varios golpes peor que el índice: ese mira de lo que el "
+            "jugador es capaz, este a lo que juega de media."
+        ),
+    )
+    best_differential: float | None = Field(
+        default=None, description="El mejor diferencial del registro: su mejor vuelta"
+    )
+    rounds_with_differential: int = Field(
+        default=0,
+        description=(
+            "Cuántas de las vueltas computadas tienen diferencial. Menor que "
+            "`rounds_played` cuando alguna se jugó sin registrar el tee."
+        ),
+    )
+    differentials: list[float] = Field(
+        default_factory=list,
+        description="Diferenciales del más reciente al más antiguo, para pintar la tendencia",
+    )
 
 
 class RecentMatchDTO(BaseModel):

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -64,18 +64,27 @@ class PlayerStatsResponseDTO(BaseModel):
         ),
     )
     best_differential: float | None = Field(
-        default=None, description="El mejor diferencial del registro: su mejor vuelta"
+        default=None,
+        description=(
+            "El mejor diferencial del registro: su mejor vuelta entre las 20 "
+            "más recientes, que son las que el WHS mira."
+        ),
     )
     rounds_with_differential: int = Field(
         default=0,
         description=(
             "Cuántas de las vueltas computadas tienen diferencial. Menor que "
-            "`rounds_played` cuando alguna se jugó sin registrar el tee."
+            "`rounds_played` cuando alguna se jugó sin registrar el tee. Puede "
+            "superar los 20 de la ventana: cuenta las que hay, no las que se miran."
         ),
     )
     differentials: list[float] = Field(
         default_factory=list,
-        description="Diferenciales del más reciente al más antiguo, para pintar la tendencia",
+        description=(
+            "Los 20 diferenciales más recientes, del más nuevo al más antiguo, "
+            "para pintar la tendencia. Es la misma ventana sobre la que se "
+            "calculan el índice, la media y la mejor vuelta."
+        ),
     )
 
 

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -166,7 +166,12 @@ class GetPlayerStatsUseCase:
             playing_avg=self._as_float(self._differentials.playing_average(differentials)),
             best_differential=self._as_float(self._differentials.best_differential(differentials)),
             rounds_with_differential=len(differentials),
-            differentials=[float(value) for value in differentials],
+            # La serie que se publica es la misma ventana que miran el índice y
+            # la mejor vuelta: publicar más dejaría que un cliente calculase su
+            # propio mínimo sobre vueltas que ninguna otra cifra está contando
+            differentials=[
+                float(value) for value in self._differentials.scoring_record(differentials)
+            ],
         )
 
     async def _collect_quick_match_rounds(

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -1,7 +1,16 @@
-"""Caso de Uso: resumen de rendimiento de un jugador (BE #128)."""
+"""Caso de Uso: resumen de rendimiento de un jugador (BE #128, BE #167)."""
+
+from dataclasses import dataclass
+from datetime import date as date_type
+from decimal import Decimal
 
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.competition.domain.services.score_differential_calculator import (
+    PlayedRound,
+    ScoreDifferentialCalculator,
 )
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
@@ -26,6 +35,27 @@ from src.modules.user.domain.value_objects.user_id import UserId
 # número, y en torneo cada partido añade además una consulta de tarjeta.
 MAX_ROUNDS_AGGREGATED = 100
 
+# El Score Differential se calcula con el Course Handicap, que es el Playing
+# Handicap sin recortar por formato: el allowance reparte ventaja dentro de una
+# partida, y el WHS mide la vuelta contra el campo, no contra los rivales.
+COURSE_HANDICAP_ALLOWANCE = 100
+
+
+@dataclass(frozen=True)
+class _ComputableRound:
+    """
+    Una vuelta entera ya reducida a lo que las estadísticas necesitan.
+
+    `played_round` va en None cuando la vuelta no se puede convertir en un
+    diferencial (no se sabe desde qué tee se jugó, o sus ratings no son válidos
+    para el WHS). Esa vuelta sigue contando para la media y para el total: lo
+    único que no puede hacer es decir a qué hándicap se jugó.
+    """
+
+    played_on: date_type
+    to_par: int
+    played_round: PlayedRound | None
+
 
 class GetPlayerStatsUseCase:
     """
@@ -36,6 +66,11 @@ class GetPlayerStatsUseCase:
     como del contador de rondas. Media docena de vueltas comparables valen más
     que veinte a medio anotar, y un `rounds_played` que incluyera rondas que no
     entran en la media daría dos números que no cuadran entre sí.
+
+    Sobre esas mismas vueltas se calculan los **Score Differentials** del WHS
+    (BE #167), que dicen a qué hándicap se jugó cada una. Ahí la exigencia es
+    mayor: hace falta saber desde qué tee se jugó, porque sin Slope ni Course
+    Rating no hay diferencial que calcular.
 
     Sigue el patrón de `GetAdminStatsUseCase`: los casos de uso de `user`
     reciben las unidades de trabajo de los módulos que consultan, en lugar de
@@ -53,12 +88,14 @@ class GetPlayerStatsUseCase:
         quick_match_uow: QuickMatchUnitOfWorkInterface,
         golf_course_uow: GolfCourseUnitOfWorkInterface,
         stableford_calculator: StablefordCalculator | None = None,
+        differential_calculator: ScoreDifferentialCalculator | None = None,
     ):
         self._user_uow = user_uow
         self._competition_uow = competition_uow
         self._quick_match_uow = quick_match_uow
         self._golf_course_uow = golf_course_uow
         self._calculator = stableford_calculator or StablefordCalculator()
+        self._differentials = differential_calculator or ScoreDifferentialCalculator()
 
     async def execute(
         self, user_id: UserId, golf_course_id: GolfCourseId | None = None
@@ -74,9 +111,7 @@ class GetPlayerStatsUseCase:
             user = await self._user_uow.users.find_by_id(user_id)
             handicap = float(user.handicap.value) if user and user.handicap else None
 
-        quick_rounds_to_par = await self._collect_quick_match_rounds(
-            user_id, golf_course_id, handicap
-        )
+        quick_rounds = await self._collect_quick_match_rounds(user_id, golf_course_id, handicap)
 
         async with self._competition_uow:
             competition_matches = (
@@ -107,21 +142,31 @@ class GetPlayerStatsUseCase:
                     await self._competition_uow.enrollments.count_active_by_user(user_id)
                 )
 
-        competition_rounds_to_par = await self._collect_competition_rounds(
-            competition_matches, rounds_by_match, scorecards
+        competition_rounds = await self._collect_competition_rounds(
+            user_id, competition_matches, rounds_by_match, scorecards, handicap
         )
 
-        computable_rounds = quick_rounds_to_par + competition_rounds_to_par
-        rounds_played = len(computable_rounds)
-        scoring_avg = self._average_to_par(computable_rounds)
+        # Las dos fuentes llegan ordenadas por su cuenta; el registro del WHS es
+        # cronológico y no distingue de dónde salió cada vuelta
+        computable_rounds = sorted(
+            quick_rounds + competition_rounds, key=lambda item: item.played_on, reverse=True
+        )
+        differentials = self._differentials.differentials(
+            [item.played_round for item in computable_rounds if item.played_round is not None]
+        )
 
         return PlayerStatsResponseDTO(
             handicap=handicap,
-            handicap_trend=None,
-            scoring_avg=scoring_avg,
-            rounds_played=rounds_played,
+            handicap_trend=self._as_float(self._differentials.trend(differentials)),
+            scoring_avg=self._average_to_par([item.to_par for item in computable_rounds]),
+            rounds_played=len(computable_rounds),
             tournaments_total=tournaments_total,
             tournaments_active=tournaments_active,
+            estimated_index=self._as_float(self._differentials.estimated_index(differentials)),
+            playing_avg=self._as_float(self._differentials.playing_average(differentials)),
+            best_differential=self._as_float(self._differentials.best_differential(differentials)),
+            rounds_with_differential=len(differentials),
+            differentials=[float(value) for value in differentials],
         )
 
     async def _collect_quick_match_rounds(
@@ -129,9 +174,9 @@ class GetPlayerStatsUseCase:
         user_id: UserId,
         golf_course_id: GolfCourseId | None,
         profile_handicap: float | None,
-    ) -> list[int]:
+    ) -> list[_ComputableRound]:
         """
-        Neto respecto al par de cada vuelta rápida computable.
+        Vueltas rápidas computables del jugador.
 
         Solo entran las partidas terminadas con la tarjeta entera: una vuelta a
         medias no se puede comparar con una completa, y con el campo borrado no
@@ -141,7 +186,7 @@ class GetPlayerStatsUseCase:
         lo hace por participante: una partida que A ocultó sigue contando para
         B. Esa regla se hereda tal cual en lugar de reimplementarse aquí.
         """
-        results: list[int] = []
+        results: list[_ComputableRound] = []
 
         async with self._quick_match_uow, self._golf_course_uow:
             matches = await self._quick_match_uow.quick_matches.list_for_user(
@@ -175,8 +220,9 @@ class GetPlayerStatsUseCase:
                     HoleSetup(hole.number, hole.par, hole.stroke_index)
                     for hole in course.holes
                 ]
+                handicap = self._effective_handicap(participant, profile_handicap)
                 totals = self._calculator.compute_participant_totals(
-                    handicap=self._effective_handicap(participant, profile_handicap),
+                    handicap=handicap,
                     holes=holes,
                     scores_by_hole=scores_by_hole,
                     allowance_percentage=match.get_effective_allowance(),
@@ -184,9 +230,170 @@ class GetPlayerStatsUseCase:
                     # las dos topara los hoyos malos, no serían comparables
                     cap_at_net_double_bogey=True,
                 )
-                results.append(totals.to_par)
+                results.append(
+                    _ComputableRound(
+                        # No hay campo de cuándo se jugó: la partida rápida se
+                        # crea el mismo día que se juega
+                        played_on=match.created_at.date(),
+                        to_par=totals.to_par,
+                        played_round=self._to_played_round(
+                            course=course,
+                            holes=holes,
+                            scores_by_hole=scores_by_hole,
+                            handicap=handicap,
+                            tee_category=participant.tee_category,
+                            tee_gender=participant.tee_gender,
+                        ),
+                    )
+                )
 
         return results
+
+    async def _collect_competition_rounds(
+        self,
+        user_id: UserId,
+        matches: list,
+        rounds_by_match: dict,
+        scorecards: dict,
+        profile_handicap: float | None,
+    ) -> list[_ComputableRound]:
+        """
+        Vueltas de torneo computables del jugador.
+
+        El formato del partido da igual: en match play también firmas una
+        tarjeta con tus golpes, y esa tarjeta dice a qué nivel jugaste tan bien
+        como la de una vuelta de medal. Solo entran las que estén enteras.
+
+        Se usa `own_score`, no el `net_score` de la entidad: ese solo se calcula
+        cuando el marcador ha validado el hoyo, así que media tarjeta legítima
+        se quedaría fuera por no haberse cerrado la validación cruzada. Los
+        golpes recibidos ya vienen resueltos por hoyo desde que se generó el
+        partido, sin repartirlos aquí otra vez.
+        """
+        results: list[_ComputableRound] = []
+        courses: dict = {}
+
+        async with self._golf_course_uow:
+            for match in matches:
+                round_ = rounds_by_match.get(match.id)
+                course_id = self._match_course(match, rounds_by_match)
+                if round_ is None or course_id is None:
+                    continue
+                if course_id not in courses:
+                    courses[course_id] = await self._golf_course_uow.golf_courses.find_by_id(
+                        course_id
+                    )
+                course = courses[course_id]
+                if course is None:
+                    continue
+
+                hole_scores = scorecards.get(match.id, [])
+                to_par = self._scorecard_to_par(hole_scores, course)
+                if to_par is None:
+                    continue
+
+                player = self._find_match_player(match, user_id)
+                holes = [
+                    HoleSetup(hole.number, hole.par, hole.stroke_index)
+                    for hole in course.holes
+                ]
+                results.append(
+                    _ComputableRound(
+                        played_on=round_.round_date,
+                        to_par=to_par,
+                        played_round=self._to_played_round(
+                            course=course,
+                            holes=holes,
+                            scores_by_hole={
+                                hole_score.hole_number: hole_score.own_score
+                                for hole_score in hole_scores
+                                if hole_score.own_score is not None
+                            },
+                            # El partido guardó el hándicap del jugador cuando
+                            # se generó: una vuelta de hace meses se mide con el
+                            # hándicap que tenía entonces, no con el de hoy
+                            handicap=self._match_player_handicap(player, profile_handicap),
+                            tee_category=player.tee_category if player else None,
+                            tee_gender=player.tee_gender if player else None,
+                        ),
+                    )
+                )
+
+        return results
+
+    # ==================== Diferenciales ====================
+
+    def _to_played_round(
+        self,
+        course,
+        holes: list[HoleSetup],
+        scores_by_hole: dict,
+        handicap: float | None,
+        tee_category,
+        tee_gender,
+    ) -> PlayedRound | None:
+        """
+        La vuelta convertida en materia prima para el diferencial, o None.
+
+        El Adjusted Gross Score se recalcula con el Course Handicap en lugar de
+        reaprovechar el de la media: son dos topes distintos a propósito. La
+        media es una métrica de la casa y usa el hándicap con el que se jugó la
+        partida; el diferencial pretende ser WHS y el WHS ignora el allowance.
+        """
+        tee_rating = self._tee_rating(course, tee_category, tee_gender)
+        if tee_rating is None:
+            return None
+
+        totals = self._calculator.compute_participant_totals(
+            handicap=handicap,
+            holes=holes,
+            scores_by_hole=scores_by_hole,
+            tee_rating=tee_rating,
+            allowance_percentage=COURSE_HANDICAP_ALLOWANCE,
+            cap_at_net_double_bogey=True,
+        )
+        return PlayedRound(
+            adjusted_gross_score=totals.adjusted_gross_strokes, tee_rating=tee_rating
+        )
+
+    @staticmethod
+    def _tee_rating(course, tee_category, tee_gender) -> TeeRating | None:
+        """
+        Ratings del tee que se jugó, o None si no se puede saber.
+
+        El tee se identifica por categoría y género, que es su clave única en el
+        campo: los tees no tienen id propio. El par no vive en el tee, sale de
+        sumar los hoyos.
+
+        Un tee cuyos ratings no entran en los límites del WHS devuelve None en
+        lugar de propagar el error: el catálogo de campos admite un rango de
+        Course Rating más ancho que el que el sistema acepta para calcular, y
+        una estadística no es motivo para tumbar la respuesta entera.
+        """
+        if tee_category is None:
+            return None
+
+        tee = next(
+            (
+                candidate
+                for candidate in course.tees
+                if candidate.category == tee_category and candidate.gender == tee_gender
+            ),
+            None,
+        )
+        if tee is None:
+            return None
+
+        try:
+            return TeeRating(
+                course_rating=Decimal(str(tee.course_rating)),
+                slope_rating=tee.slope_rating,
+                par=sum(hole.par for hole in course.holes),
+            )
+        except ValueError:
+            return None
+
+    # ==================== Lectura de tarjetas ====================
 
     @staticmethod
     def _is_full_scorecard(scores_by_hole: dict, course) -> bool:
@@ -202,8 +409,8 @@ class GetPlayerStatsUseCase:
         """
         La ronda de cada partido, una consulta por ronda distinta.
 
-        Hace falta para dos cosas que el partido no sabe por sí solo: en qué
-        campo se jugó y con qué pares se compara su tarjeta.
+        Hace falta para tres cosas que el partido no sabe por sí solo: en qué
+        campo se jugó, con qué pares se compara su tarjeta y qué día fue.
         """
         rounds: dict = {}
         by_match: dict = {}
@@ -219,44 +426,6 @@ class GetPlayerStatsUseCase:
     def _match_course(match, rounds_by_match: dict) -> GolfCourseId | None:
         round_ = rounds_by_match.get(match.id)
         return round_.golf_course_id if round_ is not None else None
-
-    async def _collect_competition_rounds(
-        self, matches: list, rounds_by_match: dict, scorecards: dict
-    ) -> list[int]:
-        """
-        Neto respecto al par de cada tarjeta de torneo.
-
-        El formato del partido da igual: en match play también firmas una
-        tarjeta con tus golpes, y esa tarjeta dice a qué nivel jugaste tan bien
-        como la de una vuelta de medal. Solo entran las que estén enteras.
-
-        Se usa `own_score`, no el `net_score` de la entidad: ese solo se calcula
-        cuando el marcador ha validado el hoyo, así que media tarjeta legítima
-        se quedaría fuera por no haberse cerrado la validación cruzada. Los
-        golpes recibidos ya vienen resueltos por hoyo desde que se generó el
-        partido, sin repartirlos aquí otra vez.
-        """
-        results: list[int] = []
-        courses: dict = {}
-
-        async with self._golf_course_uow:
-            for match in matches:
-                course_id = self._match_course(match, rounds_by_match)
-                if course_id is None:
-                    continue
-                if course_id not in courses:
-                    courses[course_id] = await self._golf_course_uow.golf_courses.find_by_id(
-                        course_id
-                    )
-                course = courses[course_id]
-                if course is None:
-                    continue
-
-                to_par = self._scorecard_to_par(scorecards.get(match.id, []), course)
-                if to_par is not None:
-                    results.append(to_par)
-
-        return results
 
     def _scorecard_to_par(self, hole_scores: list, course) -> int | None:
         """
@@ -287,10 +456,24 @@ class GetPlayerStatsUseCase:
 
         return to_par
 
+    # ==================== Jugadores y hándicaps ====================
+
     @staticmethod
     def _find_participant(match, user_id: UserId):
         return next(
             (p for p in match.participants if p.user_id is not None and p.user_id == user_id),
+            None,
+        )
+
+    @staticmethod
+    def _find_match_player(match, user_id: UserId):
+        """El jugador dentro del partido, mire en el equipo que mire."""
+        return next(
+            (
+                player
+                for player in (*match.team_a_players, *match.team_b_players)
+                if player.user_id == user_id
+            ),
             None,
         )
 
@@ -309,8 +492,27 @@ class GetPlayerStatsUseCase:
         return profile_handicap
 
     @staticmethod
+    def _match_player_handicap(player, profile_handicap: float | None) -> float | None:
+        """
+        Hándicap del jugador en ese partido de torneo.
+
+        `MatchPlayer.player_handicap` es una foto del hándicap en el momento de
+        generar el partido, que es exactamente lo que el WHS quiere para medir
+        una vuelta antigua. Cuando falta, no queda más que el del perfil.
+        """
+        if player is not None and player.player_handicap is not None:
+            return float(player.player_handicap)
+        return profile_handicap
+
+    # ==================== Agregación ====================
+
+    @staticmethod
     def _average_to_par(rounds_to_par: list[int]) -> float | None:
         """None sin rondas: no hay media que dar, que no es una media de cero."""
         if not rounds_to_par:
             return None
         return round(sum(rounds_to_par) / len(rounds_to_par), 1)
+
+    @staticmethod
+    def _as_float(value: Decimal | None) -> float | None:
+        return float(value) if value is not None else None

--- a/tests/integration/api/v1/test_player_stats_endpoints.py
+++ b/tests/integration/api/v1/test_player_stats_endpoints.py
@@ -31,14 +31,25 @@ async def _approved_golf_course(client: AsyncClient, admin: dict, creator: dict)
 
 
 async def _played_medal_match(
-    client: AsyncClient, player: dict, golf_course_id: str, strokes_per_hole: int = 5
+    client: AsyncClient,
+    player: dict,
+    golf_course_id: str,
+    strokes_per_hole: int = 5,
+    tee_category: str | None = None,
+    tee_gender: str | None = None,
 ) -> str:
-    """Una partida libre MEDAL terminada con la vuelta entera anotada."""
+    """
+    Una partida libre MEDAL terminada con la vuelta entera anotada.
+
+    Sin tee la vuelta cuenta para la media pero no genera diferencial: no hay
+    Slope ni Course Rating con los que calcularlo.
+    """
     set_auth_cookies(client, player["cookies"])
-    create_response = await client.post(
-        "/api/v1/quick-matches",
-        json={"golf_course_id": golf_course_id, "scoring_format": "MEDAL"},
-    )
+    payload: dict = {"golf_course_id": golf_course_id, "scoring_format": "MEDAL"}
+    if tee_category is not None:
+        payload["creator_tee_category"] = tee_category
+        payload["creator_tee_gender"] = tee_gender
+    create_response = await client.post("/api/v1/quick-matches", json=payload)
     assert create_response.status_code == 201, create_response.text
     quick_match_id = create_response.json()["id"]
     participant_id = create_response.json()["participants"][0]["participant_id"]
@@ -237,3 +248,94 @@ class TestHiddenMatches:
         assert stats.json()["rounds_played"] == 0
         assert stats.json()["scoring_avg"] is None
         assert feed.json()["matches"] == []
+
+
+class TestScoreDifferentials:
+    """
+    El hándicap al que el jugador está jugando (BE #167).
+
+    El campo de estas pruebas es par 72, y su tee AMATEUR/MALE tiene Course
+    Rating 70.2 y Slope 128.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_round_from_a_known_tee_yields_its_differential(
+        self, client: AsyncClient
+    ):
+        """
+        18 hoyos a 5 golpes, sin hándicap en el perfil, son 90 golpes ajustados
+        (ningún hoyo llega a doble bogey neto).
+
+        Diferencial = (113 / 128) x (90 - 70.2) = 17.4796... -> 17.5
+        """
+        admin = await create_admin_user(
+            client, "stats_diff_admin@test.com", "P@ssw0rd123!", "Diff", "Admin"
+        )
+        player = await create_authenticated_user(
+            client, "stats_diff@test.com", "P@ssw0rd123!", "Diff", "Player"
+        )
+        course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(
+            client, player, course_id, tee_category="AMATEUR", tee_gender="MALE"
+        )
+
+        set_auth_cookies(client, player["cookies"])
+        body = (await client.get("/api/v1/users/me/stats")).json()
+
+        assert body["differentials"] == [17.5]
+        assert body["best_differential"] == 17.5
+        assert body["playing_avg"] == 17.5
+        assert body["rounds_with_differential"] == 1
+        # Una sola vuelta no da índice: el WHS pide 54 hoyos
+        assert body["estimated_index"] is None
+        assert body["handicap_trend"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_round_without_a_tee_counts_but_has_no_differential(
+        self, client: AsyncClient
+    ):
+        """
+        Las partidas creadas antes de que el frontend exigiera el tee siguen
+        contando para la media. Los dos contadores dejan verlo.
+        """
+        admin = await create_admin_user(
+            client, "stats_notee_admin@test.com", "P@ssw0rd123!", "NoTee", "Admin"
+        )
+        player = await create_authenticated_user(
+            client, "stats_notee@test.com", "P@ssw0rd123!", "NoTee", "Player"
+        )
+        course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        body = (await client.get("/api/v1/users/me/stats")).json()
+
+        assert body["rounds_played"] == 1
+        assert body["scoring_avg"] == 18.0
+        assert body["rounds_with_differential"] == 0
+        assert body["differentials"] == []
+        assert body["estimated_index"] is None
+
+    @pytest.mark.asyncio
+    async def test_three_rounds_publish_an_estimated_index(self, client: AsyncClient):
+        """
+        Con tres vueltas ya hay índice: la mejor menos 2.0, que es lo que manda
+        la tabla del WHS cuando la muestra es tan pequeña.
+        """
+        admin = await create_admin_user(
+            client, "stats_index_admin@test.com", "P@ssw0rd123!", "Index", "Admin"
+        )
+        player = await create_authenticated_user(
+            client, "stats_index@test.com", "P@ssw0rd123!", "Index", "Player"
+        )
+        course_id = await _approved_golf_course(client, admin, player)
+        for _ in range(3):
+            await _played_medal_match(
+                client, player, course_id, tee_category="AMATEUR", tee_gender="MALE"
+            )
+
+        set_auth_cookies(client, player["cookies"])
+        body = (await client.get("/api/v1/users/me/stats")).json()
+
+        assert body["rounds_with_differential"] == 3
+        assert body["estimated_index"] == 15.5

--- a/tests/unit/modules/competition/domain/services/test_score_differential_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_score_differential_calculator.py
@@ -211,3 +211,28 @@ class TestTrend:
         differentials = _differentials(["10.0"] * 5 + ["10.5", "10.0", "10.0", "10.0", "10.0"])
         # 0.5 repartido entre 5 vueltas
         assert ScoreDifferentialCalculator.trend(differentials) == Decimal("-0.1")
+
+
+class TestScoringRecord:
+    """La ventana que todas las demás métricas comparten."""
+
+    def test_keeps_every_round_when_there_are_no_more_than_twenty(self):
+        differentials = _differentials(["10.0"] * 20)
+        assert ScoreDifferentialCalculator.scoring_record(differentials) == differentials
+
+    def test_drops_anything_older_than_the_twentieth_round(self):
+        differentials = _differentials([f"{value}.0" for value in range(1, 26)])
+        record = ScoreDifferentialCalculator.scoring_record(differentials)
+        assert len(record) == 20
+        assert record[-1] == Decimal("20.0")
+
+    def test_is_the_window_the_other_metrics_agree_on(self):
+        """
+        Lo que hace útil el método: una vuelta excelente fuera de la ventana no
+        puede aparecer como la mejor por un lado y ser ignorada por otro.
+        """
+        differentials = _differentials(["10.0"] * 20 + ["1.0"])
+        record = ScoreDifferentialCalculator.scoring_record(differentials)
+
+        assert min(record) == ScoreDifferentialCalculator.best_differential(differentials)
+        assert Decimal("1.0") not in record

--- a/tests/unit/modules/competition/domain/services/test_score_differential_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_score_differential_calculator.py
@@ -1,0 +1,213 @@
+"""
+Tests del ScoreDifferentialCalculator (BE #167).
+
+El diferencial es la única métrica de la app que pretende ser WHS de verdad, así
+que estos tests fijan sobre todo dos cosas: que la fórmula da los números del
+sistema y que la tabla de la Regla 5.2 se aplica escalón a escalón. El resto de
+métricas de jugador son de la casa y pueden cambiar; esta no.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.competition.domain.services.score_differential_calculator import (
+    PlayedRound,
+    ScoreDifferentialCalculator,
+)
+
+
+def _round(adjusted_gross_score: int, slope: int = 113, course_rating: str = "72.0") -> PlayedRound:
+    """Una vuelta desde un tee cualquiera; por defecto, slope neutro."""
+    return PlayedRound(
+        adjusted_gross_score=adjusted_gross_score,
+        tee_rating=TeeRating(
+            course_rating=Decimal(course_rating), slope_rating=slope, par=72
+        ),
+    )
+
+
+def _differentials(values: list[str]) -> list[Decimal]:
+    return [Decimal(value) for value in values]
+
+
+class TestDifferential:
+    """`(113 / Slope) x (AGS - CR)`."""
+
+    def test_slope_neutral_leaves_the_margin_over_the_rating_untouched(self):
+        # 85 golpes en un campo de rating 72 y slope 113: se jugó 13 sobre
+        assert ScoreDifferentialCalculator.differential(_round(85)) == Decimal("13.0")
+
+    def test_playing_to_the_rating_is_a_scratch_round(self):
+        assert ScoreDifferentialCalculator.differential(_round(72)) == Decimal("0.0")
+
+    def test_beating_the_rating_gives_a_plus_differential(self):
+        assert ScoreDifferentialCalculator.differential(_round(70)) == Decimal("-2.0")
+
+    def test_a_hard_course_shrinks_the_differential(self):
+        # Mismos 85 golpes, pero desde un tee más difícil: la vuelta vale más
+        assert ScoreDifferentialCalculator.differential(
+            _round(85, slope=140)
+        ) == Decimal("10.5")
+
+    def test_an_easy_course_stretches_the_differential(self):
+        assert ScoreDifferentialCalculator.differential(
+            _round(85, slope=100)
+        ) == Decimal("14.7")
+
+    def test_the_rating_decimals_carry_into_the_result(self):
+        # 85 - 71.4 = 13.6, en slope neutro
+        assert ScoreDifferentialCalculator.differential(
+            _round(85, course_rating="71.4")
+        ) == Decimal("13.6")
+
+    def test_rounds_to_one_decimal(self):
+        # (113/128) x (85 - 72.3) = 11.212...
+        assert ScoreDifferentialCalculator.differential(
+            _round(85, slope=128, course_rating="72.3")
+        ) == Decimal("11.2")
+
+    def test_keeps_the_order_of_the_rounds_it_receives(self):
+        result = ScoreDifferentialCalculator.differentials([_round(85), _round(72)])
+        assert result == [Decimal("13.0"), Decimal("0.0")]
+
+
+class TestEstimatedIndex:
+    """Tabla de la Regla WHS 5.2: cuántas vueltas se promedian y con qué ajuste."""
+
+    def test_no_index_without_rounds(self):
+        assert ScoreDifferentialCalculator.estimated_index([]) is None
+
+    @pytest.mark.parametrize("count", [1, 2])
+    def test_no_index_below_three_rounds(self, count):
+        assert ScoreDifferentialCalculator.estimated_index(_differentials(["10.0"] * count)) is None
+
+    def test_three_rounds_take_the_best_one_minus_two(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["18.0", "12.0", "15.0"])
+        )
+        assert result == Decimal("10.0")
+
+    def test_four_rounds_take_the_best_one_minus_one(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["18.0", "12.0", "15.0", "20.0"])
+        )
+        assert result == Decimal("11.0")
+
+    def test_five_rounds_take_the_best_one_with_no_adjustment(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["18.0", "12.0", "15.0", "20.0", "17.0"])
+        )
+        assert result == Decimal("12.0")
+
+    def test_six_rounds_average_the_two_best_minus_one(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["18.0", "12.0", "15.0", "20.0", "17.0", "14.0"])
+        )
+        # (12.0 + 14.0) / 2 - 1.0
+        assert result == Decimal("12.0")
+
+    def test_seven_rounds_average_the_two_best_with_no_adjustment(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["18.0", "12.0", "15.0", "20.0", "17.0", "14.0", "19.0"])
+        )
+        assert result == Decimal("13.0")
+
+    def test_twenty_rounds_average_the_eight_best(self):
+        # 1.0 .. 20.0: los ocho mejores son 1..8, media 4.5
+        differentials = _differentials([f"{value}.0" for value in range(1, 21)])
+        assert ScoreDifferentialCalculator.estimated_index(differentials) == Decimal("4.5")
+
+    def test_only_the_twenty_most_recent_rounds_count(self):
+        # Una vuelta excelente muy antigua queda fuera de la ventana
+        differentials = _differentials([f"{value}.0" for value in range(10, 30)])
+        differentials.append(Decimal("0.5"))
+        assert ScoreDifferentialCalculator.estimated_index(differentials) == Decimal("13.5")
+
+    def test_rounds_the_index_to_one_decimal(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["10.1", "10.2", "10.4"])
+        )
+        # mejor 10.1 - 2.0
+        assert result == Decimal("8.1")
+
+    def test_a_plus_player_gets_a_negative_index(self):
+        result = ScoreDifferentialCalculator.estimated_index(
+            _differentials(["-1.0", "0.5", "1.0"])
+        )
+        assert result == Decimal("-3.0")
+
+
+class TestPlayingAverage:
+    """La media de todas las vueltas recientes, no solo de las buenas."""
+
+    def test_no_average_without_rounds(self):
+        assert ScoreDifferentialCalculator.playing_average([]) is None
+
+    def test_a_single_round_is_its_own_average(self):
+        assert ScoreDifferentialCalculator.playing_average(_differentials(["13.0"])) == Decimal(
+            "13.0"
+        )
+
+    def test_averages_the_good_and_the_bad_alike(self):
+        result = ScoreDifferentialCalculator.playing_average(
+            _differentials(["10.0", "20.0", "15.0"])
+        )
+        assert result == Decimal("15.0")
+
+    def test_is_worse_than_the_index_over_the_same_rounds(self):
+        differentials = _differentials(["12.0", "18.0", "20.0", "14.0", "22.0"])
+        index = ScoreDifferentialCalculator.estimated_index(differentials)
+        average = ScoreDifferentialCalculator.playing_average(differentials)
+        assert average > index
+
+    def test_only_the_twenty_most_recent_rounds_count(self):
+        differentials = _differentials(["10.0"] * 20 + ["100.0"])
+        assert ScoreDifferentialCalculator.playing_average(differentials) == Decimal("10.0")
+
+
+class TestBestDifferential:
+    """La mejor vuelta del registro."""
+
+    def test_no_best_without_rounds(self):
+        assert ScoreDifferentialCalculator.best_differential([]) is None
+
+    def test_takes_the_lowest_differential(self):
+        result = ScoreDifferentialCalculator.best_differential(
+            _differentials(["13.0", "8.5", "11.0"])
+        )
+        assert result == Decimal("8.5")
+
+    def test_ignores_rounds_outside_the_window(self):
+        differentials = _differentials(["10.0"] * 20 + ["1.0"])
+        assert ScoreDifferentialCalculator.best_differential(differentials) == Decimal("10.0")
+
+
+class TestTrend:
+    """Vueltas recientes contra las anteriores. Negativo es mejorar."""
+
+    @pytest.mark.parametrize("count", [0, 5, 9])
+    def test_no_trend_without_two_full_windows(self, count):
+        assert ScoreDifferentialCalculator.trend(_differentials(["10.0"] * count)) is None
+
+    def test_improving_gives_a_negative_trend(self):
+        # Cinco vueltas recientes a 10, cinco anteriores a 14
+        differentials = _differentials(["10.0"] * 5 + ["14.0"] * 5)
+        assert ScoreDifferentialCalculator.trend(differentials) == Decimal("-4.0")
+
+    def test_getting_worse_gives_a_positive_trend(self):
+        differentials = _differentials(["16.0"] * 5 + ["12.0"] * 5)
+        assert ScoreDifferentialCalculator.trend(differentials) == Decimal("4.0")
+
+    def test_steady_play_gives_no_change(self):
+        assert ScoreDifferentialCalculator.trend(_differentials(["13.0"] * 10)) == Decimal("0.0")
+
+    def test_ignores_anything_older_than_the_two_windows(self):
+        differentials = _differentials(["10.0"] * 5 + ["14.0"] * 5 + ["99.0"] * 10)
+        assert ScoreDifferentialCalculator.trend(differentials) == Decimal("-4.0")
+
+    def test_rounds_the_change_to_one_decimal(self):
+        differentials = _differentials(["10.0"] * 5 + ["10.5", "10.0", "10.0", "10.0", "10.0"])
+        # 0.5 repartido entre 5 vueltas
+        assert ScoreDifferentialCalculator.trend(differentials) == Decimal("-0.1")

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -148,6 +148,8 @@ async def _played_quick_match(
     strokes_per_hole: int = 4,
     others=(),
     holes_played: int = 18,
+    tee_category: TeeCategory | None = None,
+    tee_gender: Gender | None = None,
 ):
     """
     Una partida rápida terminada con la vuelta anotada.
@@ -155,12 +157,18 @@ async def _played_quick_match(
     `create()` mete al creador como primer participante, así que su
     `participant_id` se lee de la entidad en vez de construirlo aquí.
     `holes_played` deja la tarjeta a medias.
+
+    Sin `tee_category` la partida no dice desde dónde se jugó, que es el caso
+    de las partidas anteriores a que el frontend empezara a exigir el tee: esas
+    cuentan para la media pero no generan diferencial.
     """
     match = QuickMatch.create(
         id=QuickMatchId.generate(),
         creator_id=user.id,
         golf_course_id=golf_course.id,
         scoring_format=ScoringFormat.MEDAL,
+        creator_tee_category=tee_category,
+        creator_tee_gender=tee_gender,
     )
     for participant in others:
         match.add_participant(participant)
@@ -677,3 +685,325 @@ class TestHiddenMatches:
 
         assert (await use_case.execute(hider.id)).rounds_played == 0
         assert (await use_case.execute(other.id)).rounds_played == 1
+
+
+class TestScoreDifferentials:
+    """
+    Score Differentials y el índice estimado (BE #167).
+
+    El campo de estas pruebas es par 72 con dos tees: AMATEUR (CR 70.0, slope
+    125) y CHAMPIONSHIP (CR 72.0, slope 130). Los números esperados están
+    calculados a mano con la fórmula del WHS, no copiados de la implementación:
+    son la única defensa real contra que el cálculo se tuerza en silencio.
+    """
+
+    async def test_a_round_from_a_known_tee_yields_its_differential(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        18 hoyos a 5 golpes son 90 brutos. El jugador de 10 recibe un golpe en
+        los nueve hoyos más difíciles, así que ningún hoyo llega a su doble
+        bogey neto y los golpes ajustados siguen siendo 90.
+
+        Diferencial = (113 / 125) x (90 - 70.0) = 18.08 -> 18.1
+        """
+        player = await create_user(user_uow, unique_email("diff"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=5,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.differentials == [18.1]
+        assert stats.rounds_with_differential == 1
+        assert stats.best_differential == 18.1
+
+    async def test_the_same_round_is_worth_more_from_a_harder_tee(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Mismos 90 golpes desde CHAMPIONSHIP (CR 72.0, slope 130):
+        (113 / 130) x (90 - 72.0) = 15.646... -> 15.6
+
+        Es la razón de ser del diferencial: sin él, dos vueltas de 90 en campos
+        distintos parecerían el mismo juego.
+        """
+        player = await create_user(user_uow, unique_email("hardtee"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=5,
+            tee_category=TeeCategory.CHAMPIONSHIP,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.differentials == [15.6]
+
+    async def test_a_disastrous_round_is_capped_at_net_double_bogey(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Ocho golpes en cada hoyo son 144 brutos, pero el WHS solo deja computar
+        hasta el doble bogey neto: 7 en los nueve hoyos donde recibe golpe y 6
+        en el resto, o sea 117 ajustados.
+
+        Diferencial = (113 / 125) x (117 - 70.0) = 42.488 -> 42.5, no el 66.9
+        que saldría sin topar. Ese tope es justo lo que impide que un día
+        horrible marque el hándicap de una temporada.
+        """
+        player = await create_user(user_uow, unique_email("capped"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=8,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.differentials == [42.5]
+
+    async def test_a_round_without_a_known_tee_counts_but_has_no_differential(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Sin tee no hay Slope ni Course Rating, así que no hay diferencial que
+        calcular. La vuelta sigue contando para la media: lo que no puede es
+        decir a qué hándicap se jugó.
+        """
+        player = await create_user(user_uow, unique_email("notee"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(qm_uow, course, player, strokes_per_hole=5)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 1
+        assert stats.rounds_with_differential == 0
+        assert stats.differentials == []
+        assert stats.scoring_avg is not None
+
+    async def test_the_two_counters_diverge_when_only_some_rounds_have_a_tee(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El caso que obliga a publicar los dos números: el índice se calcula
+        sobre menos vueltas de las que el jugador ha jugado, y sin decirlo
+        parecería que las mira todas.
+        """
+        player = await create_user(user_uow, unique_email("mixed"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=5,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+        await _played_quick_match(qm_uow, course, player, strokes_per_hole=5)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 2
+        assert stats.rounds_with_differential == 1
+
+    async def test_no_index_below_three_rounds(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Dos vueltas dan un número, pero sería ruido con aspecto de dato."""
+        player = await create_user(user_uow, unique_email("tworounds"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        for _ in range(2):
+            await _played_quick_match(
+                qm_uow,
+                course,
+                player,
+                strokes_per_hole=5,
+                tee_category=TeeCategory.AMATEUR,
+                tee_gender=Gender.MALE,
+            )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_with_differential == 2
+        assert stats.estimated_index is None
+        assert stats.playing_avg == 18.1
+
+    async def test_three_rounds_give_the_best_one_minus_two(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Tres vueltas de 18.1: la mejor menos el ajuste de la tabla WHS."""
+        player = await create_user(user_uow, unique_email("threerounds"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        for _ in range(3):
+            await _played_quick_match(
+                qm_uow,
+                course,
+                player,
+                strokes_per_hole=5,
+                tee_category=TeeCategory.AMATEUR,
+                tee_gender=Gender.MALE,
+            )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.estimated_index == 16.1
+
+    async def test_a_tournament_round_also_yields_a_differential(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El tee de torneo va en el `MatchPlayer`, no en el participante, pero la
+        vuelta se mide igual: el formato del partido no cambia lo que dice la
+        tarjeta.
+        """
+        player = await create_user(user_uow, unique_email("tourney"), handicap=10.0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.differentials == [18.1]
+
+    async def test_differentials_come_newest_first_across_both_sources(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El registro del WHS es cronológico y no distingue de dónde salió cada
+        vuelta. La partida rápida se juega hoy; el torneo, en junio.
+        """
+        player = await create_user(user_uow, unique_email("ordered"), handicap=10.0)
+        rival = await create_user(user_uow, unique_email("rival2"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow,
+            course,
+            player,
+            rival,
+            strokes_per_hole=5,
+            round_date=date(2026, 6, 1),
+        )
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=6,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        # La de hoy (108 golpes -> 34.4) antes que la de junio (90 -> 18.1)
+        assert stats.differentials == [34.4, 18.1]
+        assert stats.best_differential == 18.1
+
+    async def test_no_trend_without_ten_rounds_to_compare(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Con menos de dos ventanas, la "tendencia" sería la diferencia entre dos
+        vueltas sueltas, que es cualquier cosa menos una tendencia.
+        """
+        player = await create_user(user_uow, unique_email("notrend"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        for _ in range(3):
+            await _played_quick_match(
+                qm_uow,
+                course,
+                player,
+                strokes_per_hole=5,
+                tee_category=TeeCategory.AMATEUR,
+                tee_gender=Gender.MALE,
+            )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.handicap_trend is None
+
+    async def test_a_player_with_no_rounds_gets_nulls_and_empty_series(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Nada que enseñar no es un cero: son huecos, y se dicen como tales."""
+        player = await create_user(user_uow, unique_email("empty"), handicap=10.0)
+        await create_golf_course(golf_course_uow, player.id)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.estimated_index is None
+        assert stats.playing_avg is None
+        assert stats.best_differential is None
+        assert stats.handicap_trend is None
+        assert stats.differentials == []
+        assert stats.rounds_with_differential == 0
+
+    async def test_the_course_filter_also_narrows_the_differentials(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El desglose por campo tiene que ser coherente consigo mismo: si la
+        vuelta no entra en la media de ese campo, tampoco en su índice.
+        """
+        player = await create_user(user_uow, unique_email("bycourse"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        other_course = await create_golf_course(golf_course_uow, player.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            player,
+            strokes_per_hole=5,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+        await _played_quick_match(
+            qm_uow,
+            other_course,
+            player,
+            strokes_per_hole=8,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id, golf_course_id=course.id
+        )
+
+        assert stats.differentials == [18.1]

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -1007,3 +1007,37 @@ class TestScoreDifferentials:
         )
 
         assert stats.differentials == [18.1]
+
+
+class TestScoringRecordWindow:
+    """
+    La serie publicada y las cifras calculadas hablan de las mismas vueltas.
+
+    Sin esto, un cliente que sacara el mínimo de `differentials` por su cuenta
+    obtendría un número que no coincide con `best_differential`.
+    """
+
+    async def test_the_series_is_capped_at_the_twenty_round_record(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, unique_email("window"), handicap=10.0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        for _ in range(21):
+            await _played_quick_match(
+                qm_uow,
+                course,
+                player,
+                strokes_per_hole=5,
+                tee_category=TeeCategory.AMATEUR,
+                tee_gender=Gender.MALE,
+            )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        # Las 21 se cuentan y se promedian, pero solo 20 se publican
+        assert stats.rounds_played == 21
+        assert stats.rounds_with_differential == 21
+        assert len(stats.differentials) == 20
+        assert min(stats.differentials) == stats.best_differential


### PR DESCRIPTION
Closes #167.

Tells a player **what handicap they are actually playing to**, from the rounds they have already played. `handicap_trend`, which BE #128 had to leave `null`, now has an answer — and it needed no handicap history table after all.

## What the API gains

`GET /api/v1/users/me/stats` (and its per-course variant) return five new fields:

| Field | What it says |
|---|---|
| `estimated_index` | The handicap they are playing to. `null` under 3 rounds |
| `playing_avg` | Average of all recent differentials, not just the best ones |
| `best_differential` | Their best round |
| `rounds_with_differential` | How many rounds the index could actually use |
| `differentials` | The series, newest first, for the dashboard to plot |

And `handicap_trend` is finally filled in.

## Decisions worth reviewing

**The Rule 5.2 table, not a flat "best 8 of 20".** The issue described the 20-round case. Applied literally with five rounds it means averaging all of them, which reads several strokes better than the player is. The WHS table takes only the best one and subtracts a margin while the sample is thin, so that is what this implements.

**The differential computes its own Adjusted Gross Score.** It does not reuse the one behind `scoring_avg`. Two caps, on purpose: the average is our own metric and uses the handicap the match was played off, allowance included; the differential means to be WHS, and the WHS ignores the allowance because it measures a round against the course, not against the rivals in it.

**A round from an unknown tee yields no differential.** No Slope, no Course Rating, nothing to compute. It still counts towards the average, so `rounds_with_differential` can be lower than `rounds_played` — otherwise the index would look like it covers every round a player has played. Quick matches created before the frontend started requiring a tee land here.

**`handicap_trend` is negative when the player improves.** It is the raw difference between the last five differentials and the five before them. Differentials fall as you play better, exactly like a handicap falls, so inverting the sign would make the number contradict the handicap shown next to it.

**Tournament rounds use `MatchPlayer.player_handicap`**, the snapshot taken when the match was generated, so a round from months ago is not judged by today's handicap. Quick matches have no such snapshot and fall back to the profile.

## Not the official index

There is no PCC — the playing conditions adjustment needs every card handed in that day. Assumed 0, so this is the app's calculation, not the federation's. The DTO says so, and the UI should too.

## Verification

2473 unit tests, 366 integration, 45 security — all green locally against the Kind cluster database. `ruff` and `mypy` clean.

The expected numbers in the tests were worked out by hand from the WHS formula before running anything, not read back off the implementation: `(113/125) x (90 - 70.0) = 18.1`, `(113/130) x (90 - 72.0) = 15.6`, and a round of eights capped at net double bogey giving `42.5` instead of the `66.9` it would be uncapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WHS score differential calculations, estimated indexes, playing averages, best differentials, and performance trends.
  * Player statistics now include differential history, differential count, estimated index, playing average, and best differential.
  * Differentials are calculated for completed rounds with valid tee information.
  * Adjusted gross scores are now included in participant scoring totals.

* **Bug Fixes**
  * Improved handling of rounds without tee data and insufficient rounds for handicap calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->