### PR TITLE
feat(stats): Count half rounds and report comparable figures

### DIFF
--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -111,7 +111,20 @@ class RecentMatchDTO(BaseModel):
     score: str | None = Field(
         default=None, description='Neto respecto al par ("PAR", "+4") o puntos Stableford'
     )
-    stableford_points: int | None = None
+    stableford_points: int | None = Field(
+        default=None,
+        description=(
+            "Puntos Stableford de la vuelta, **calculados en cualquier formato**: "
+            "36 puntos es jugar a tu hándicap, así que es la única cifra que "
+            "compara vueltas de medal, Stableford y match play entre sí."
+        ),
+    )
+    total_strokes: int | None = Field(
+        default=None, description="Golpes brutos de los hoyos anotados"
+    )
+    holes_played: int | None = Field(
+        default=None, description="Cuántos hoyos se anotaron: 18 en vuelta entera, 9 en media"
+    )
     partners: list[str] = Field(default_factory=list)
     opponents: list[str] = Field(default_factory=list)
 

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -40,6 +40,11 @@ MAX_ROUNDS_AGGREGATED = 100
 # partida, y el WHS mide la vuelta contra el campo, no contra los rivales.
 COURSE_HANDICAP_ALLOWANCE = 100
 
+# Media vuelta: los nueve de ida o los nueve de vuelta. Cuenta como vuelta
+# terminada, siempre que la partida esté cerrada, pero sus cifras se llevan a la
+# escala de 18 antes de mezclarlas con las demás.
+HALF_ROUND_HOLES = 9
+
 
 @dataclass(frozen=True)
 class _ComputableRound:
@@ -61,11 +66,15 @@ class GetPlayerStatsUseCase:
     """
     Agrega el rendimiento de un jugador a partir de los módulos que lo generan.
 
-    Solo cuentan las **vueltas enteras de partidas terminadas**: partida a
-    medias, tarjeta a medias o hoyo sin anotar quedan fuera, tanto de la media
-    como del contador de rondas. Media docena de vueltas comparables valen más
-    que veinte a medio anotar, y un `rounds_played` que incluyera rondas que no
+    Solo cuentan las **vueltas terminadas y sin huecos** de partidas cerradas:
+    vale la vuelta entera y valen los nueve de ida o los de vuelta, pero una
+    tarjeta a la que le faltan hoyos sueltos queda fuera, tanto de la media como
+    del contador de rondas. Media docena de vueltas comparables valen más que
+    veinte a medio anotar, y un `rounds_played` que incluyera rondas que no
     entran en la media daría dos números que no cuadran entre sí.
+
+    Media vuelta se lleva a la escala de 18 antes de mezclarla con el resto: sin
+    eso, jugar nueve hoyos parecería mejorar el juego.
 
     Sobre esas mismas vueltas se calculan los **Score Differentials** del WHS
     (BE #167), que dicen a qué hándicap se jugó cada una. Ahí la exigencia es
@@ -218,12 +227,12 @@ class GetPlayerStatsUseCase:
                     for score in scores
                     if score.participant_id == participant.participant_id
                 }
-                if not self._is_full_scorecard(scores_by_hole, course):
+                played = self._computable_holes(scores_by_hole, course)
+                if played is None:
                     continue
 
                 holes = [
-                    HoleSetup(hole.number, hole.par, hole.stroke_index)
-                    for hole in course.holes
+                    HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in played
                 ]
                 handicap = self._effective_handicap(participant, profile_handicap)
                 totals = self._calculator.compute_participant_totals(
@@ -240,7 +249,7 @@ class GetPlayerStatsUseCase:
                         # No hay campo de cuándo se jugó: la partida rápida se
                         # crea el mismo día que se juega
                         played_on=match.created_at.date(),
-                        to_par=totals.to_par,
+                        to_par=self._to_eighteen(totals.to_par, len(played)),
                         played_round=self._to_played_round(
                             course=course,
                             holes=holes,
@@ -297,10 +306,17 @@ class GetPlayerStatsUseCase:
                 if to_par is None:
                     continue
 
+                scores_by_hole = {
+                    hole_score.hole_number: hole_score.own_score
+                    for hole_score in hole_scores
+                    if hole_score.own_score is not None
+                }
+                # El diferencial mide los mismos hoyos que la media, no el campo
+                # entero: en media vuelta, los otros nueve no se jugaron
+                played = self._computable_holes(scores_by_hole, course) or []
                 player = self._find_match_player(match, user_id)
                 holes = [
-                    HoleSetup(hole.number, hole.par, hole.stroke_index)
-                    for hole in course.holes
+                    HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in played
                 ]
                 results.append(
                     _ComputableRound(
@@ -309,11 +325,7 @@ class GetPlayerStatsUseCase:
                         played_round=self._to_played_round(
                             course=course,
                             holes=holes,
-                            scores_by_hole={
-                                hole_score.hole_number: hole_score.own_score
-                                for hole_score in hole_scores
-                                if hole_score.own_score is not None
-                            },
+                            scores_by_hole=scores_by_hole,
                             # El partido guardó el hándicap del jugador cuando
                             # se generó: una vuelta de hace meses se mide con el
                             # hándicap que tenía entonces, no con el de hoy
@@ -357,8 +369,17 @@ class GetPlayerStatsUseCase:
             allowance_percentage=COURSE_HANDICAP_ALLOWANCE,
             cap_at_net_double_bogey=True,
         )
+        # Media vuelta se lleva a 18 duplicando los golpes ajustados, y se mide
+        # contra el rating de 18 tal cual. Es lo mismo que medir los nueve
+        # contra la mitad del rating y luego doblar el diferencial —
+        # `2 x (113/S) x (AGS9 - CR/2)` es `(113/S) x (2·AGS9 - CR)`— pero sin
+        # construir un `TeeRating` con un CR de 35.9 y un par de 36, que su
+        # propia validación rechaza por estar fuera de los límites del WHS.
+        # La aproximación está en dar por hecho que los nueve jugados valen la
+        # mitad del campo; sin ratings de nueve hoyos no hay forma de afinarlo.
         return PlayedRound(
-            adjusted_gross_score=totals.adjusted_gross_strokes, tee_rating=tee_rating
+            adjusted_gross_score=self._to_eighteen(totals.adjusted_gross_strokes, len(holes)),
+            tee_rating=tee_rating,
         )
 
     @staticmethod
@@ -401,14 +422,46 @@ class GetPlayerStatsUseCase:
     # ==================== Lectura de tarjetas ====================
 
     @staticmethod
-    def _is_full_scorecard(scores_by_hole: dict, course) -> bool:
+    def _computable_holes(scores_by_hole: dict, course) -> list | None:
         """
-        La tarjeta está entera cuando ningún hoyo del campo se quedó sin anotar.
+        Los hoyos que forman una vuelta computable, o None si no forman ninguna.
 
-        Se compara contra los hoyos que tiene el campo y no contra un 18 fijo:
-        el día que se admitan campos de nueve, la regla sigue siendo la misma.
+        Vale la vuelta entera y vale media: los nueve de ida o los nueve de
+        vuelta, que es como se juega media vuelta de verdad. Lo que no vale es
+        una tarjeta a la que le falten hoyos sueltos, porque eso no es media
+        vuelta sino una vuelta abandonada — y son justo las malas las que se
+        abandonan.
+
+        De ahí que a la media vuelta se le exija tener **exactamente** sus
+        nueve: con diez anotados no hay ni vuelta entera ni mitad limpia.
         """
-        return all(hole.number in scores_by_hole for hole in course.holes)
+        holes = sorted(course.holes, key=lambda hole: hole.number)
+
+        def all_scored(subset: list) -> bool:
+            return all(hole.number in scores_by_hole for hole in subset)
+
+        if all_scored(holes):
+            return holes
+
+        if len(scores_by_hole) == HALF_ROUND_HOLES:
+            for half in (holes[:HALF_ROUND_HOLES], holes[HALF_ROUND_HOLES:]):
+                if len(half) == HALF_ROUND_HOLES and all_scored(half):
+                    return half
+
+        return None
+
+    @staticmethod
+    def _to_eighteen(value: int, holes_played: int) -> int:
+        """
+        Lleva a la escala de 18 lo que se jugó en media vuelta.
+
+        Sin esto, mezclar un +3 de nueve hoyos con un +6 de dieciocho daría una
+        media que no significa nada, y jugar medias vueltas parecería mejorar el
+        juego. Duplicar es una aproximación —los nueve de ida y los de vuelta no
+        tienen por qué ser igual de difíciles—, pero es la que mantiene todas
+        las vueltas hablando en la misma escala.
+        """
+        return value * 2 if holes_played == HALF_ROUND_HOLES else value
 
     async def _rounds_by_match(self, matches: list) -> dict:
         """
@@ -434,7 +487,7 @@ class GetPlayerStatsUseCase:
 
     def _scorecard_to_par(self, hole_scores: list, course) -> int | None:
         """
-        Neto respecto al par de una tarjeta entera, o None si le falta un hoyo.
+        Neto respecto al par de la tarjeta, o None si no forma una vuelta.
 
         Un hoyo con `own_score` a None no se rellena ni se ignora: invalida la
         vuelta. Lo que decide es la tarjeta, no en qué hoyo se ganó el partido:
@@ -442,24 +495,24 @@ class GetPlayerStatsUseCase:
         si los jugadores siguieron anotando hasta el 18. Lo que deja la ronda
         fuera es dejar de anotar, no cerrar pronto.
         """
-        pars = {hole.number: hole.par for hole in course.holes}
         scored = {
             hole_score.hole_number: hole_score
             for hole_score in hole_scores
             if hole_score.own_score is not None
         }
-        if not all(hole_number in scored for hole_number in pars):
+        played = self._computable_holes(scored, course)
+        if played is None:
             return None
 
         to_par = 0
-        for hole_number, par in pars.items():
-            hole_score = scored[hole_number]
+        for hole in played:
+            hole_score = scored[hole.number]
             computable = self._calculator.adjusted_gross(
-                hole_score.own_score, par, hole_score.strokes_received
+                hole_score.own_score, hole.par, hole_score.strokes_received
             )
-            to_par += computable - hole_score.strokes_received - par
+            to_par += computable - hole_score.strokes_received - hole.par
 
-        return to_par
+        return self._to_eighteen(to_par, len(played))
 
     # ==================== Jugadores y hándicaps ====================
 

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -67,6 +67,9 @@ class _CompetitionMatchRaw:
     match: Match
     round_: Round
     tournament_name: str | None
+    # La tarjeta del jugador, para poder dar sus golpes y sus puntos: el
+    # partido guarda quién ganó, no cómo jugó cada uno
+    hole_scores: list
 
 
 class GetRecentMatchesUseCase:
@@ -209,6 +212,9 @@ class GetRecentMatchesUseCase:
                         match=match,
                         round_=round_,
                         tournament_name=competition_names[round_.competition_id],
+                        hole_scores=await self._competition_uow.hole_scores.find_by_match_and_player(
+                            match.id, user_id
+                        ),
                     )
                 )
 
@@ -271,18 +277,19 @@ class GetRecentMatchesUseCase:
 
         result = None
         score = None
-        stableford_points = None
+
+        # Los totales se calculan siempre, sea cual sea el formato: los puntos
+        # Stableford son la única cifra que compara vueltas entre sí, porque 36
+        # puntos es jugar a tu hándicap en cualquier campo y cualquier formato
+        totals = self._participant_totals(raw, course, profile_handicap)
 
         if match.match_format is not None:
             result, score = self._quick_match_play_outcome(raw)
-        else:
-            totals = self._participant_totals(raw, course, profile_handicap)
-            if totals is not None:
-                if match.scoring_format == ScoringFormat.STABLEFORD:
-                    stableford_points = totals.stableford_points
-                    score = f"{totals.stableford_points} pts"
-                else:
-                    score = self._calculator.format_to_par(totals.to_par)
+        elif totals is not None:
+            if match.scoring_format == ScoringFormat.STABLEFORD:
+                score = f"{totals.stableford_points} pts"
+            else:
+                score = self._calculator.format_to_par(totals.to_par)
 
         return RecentMatchDTO(
             id=str(match.id.value),
@@ -296,7 +303,9 @@ class GetRecentMatchesUseCase:
             tournament_name=None,
             result=result,
             score=score,
-            stableford_points=stableford_points,
+            stableford_points=totals.stableford_points if totals else None,
+            total_strokes=totals.total_strokes if totals else None,
+            holes_played=totals.holes_played if totals else None,
             partners=partners,
             opponents=opponents,
         )
@@ -323,6 +332,7 @@ class GetRecentMatchesUseCase:
             if player.user_id != user_id
         ]
         opponents = [self._user_name(player.user_id, users_by_id) for player in rival_team]
+        total_strokes, holes_played, points = self._scorecard_totals(raw, course)
 
         return RecentMatchDTO(
             id=str(match.id.value),
@@ -336,7 +346,9 @@ class GetRecentMatchesUseCase:
             tournament_name=raw.tournament_name,
             result=self._result_for_team(match.get_winner(), "A" if in_team_a else "B"),
             score=match.result.get("score") if match.result else None,
-            stableford_points=None,
+            stableford_points=points,
+            total_strokes=total_strokes,
+            holes_played=holes_played,
             partners=partners,
             opponents=opponents,
         )
@@ -418,6 +430,39 @@ class GetRecentMatchesUseCase:
             scores_by_hole=scores_by_hole,
             allowance_percentage=raw.match.get_effective_allowance(),
         )
+
+    def _scorecard_totals(self, raw: _CompetitionMatchRaw, course) -> tuple:
+        """
+        Golpes, hoyos y puntos Stableford de una tarjeta de torneo.
+
+        Los golpes recibidos ya vienen resueltos por hoyo desde que se generó el
+        partido, así que no hay que repartirlos otra vez. Se usa `own_score` y
+        no `net_score` porque este último solo existe cuando el marcador validó
+        el hoyo, y una tarjeta legítima sin validar cerrar se quedaría sin
+        cifras que enseñar.
+        """
+        if course is None:
+            return None, None, None
+
+        pars = {hole.number: hole.par for hole in course.holes}
+        scored = [
+            hole_score
+            for hole_score in raw.hole_scores
+            if hole_score.own_score is not None and hole_score.hole_number in pars
+        ]
+        if not scored:
+            return None, None, None
+
+        total_strokes = sum(hole_score.own_score for hole_score in scored)
+        points = sum(
+            self._calculator.hole_points(
+                hole_score.own_score,
+                pars[hole_score.hole_number],
+                hole_score.strokes_received,
+            )
+            for hole_score in scored
+        )
+        return total_strokes, len(scored), points
 
     def _quick_match_rivals(
         self,

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -148,6 +148,7 @@ async def _played_quick_match(
     strokes_per_hole: int = 4,
     others=(),
     holes_played: int = 18,
+    holes: list[int] | None = None,
     tee_category: TeeCategory | None = None,
     tee_gender: Gender | None = None,
 ):
@@ -180,8 +181,9 @@ async def _played_quick_match(
     async with qm_uow:
         await qm_uow.quick_matches.add(match)
         # Todos firman su vuelta: una tarjeta a medias no computa
+        scored_holes = holes if holes is not None else list(range(1, holes_played + 1))
         for participant in match.participants:
-            for hole_number in range(1, holes_played + 1):
+            for hole_number in scored_holes:
                 await qm_uow.quick_match_hole_scores.add(
                     QuickMatchHoleScore(
                         id=QuickMatchHoleScoreId.generate(),
@@ -388,12 +390,24 @@ class TestRoundsAndAverage:
 
 @pytest.mark.asyncio
 class TestIncompleteQuickMatchCards:
-    """Media vuelta no es una vuelta, tampoco en partida rápida."""
+    """
+    Qué es una vuelta y qué es una tarjeta abandonada.
 
-    async def test_a_partial_card_counts_for_nothing(
+    Cuentan la vuelta entera y las dos mitades limpias —los nueve de ida y los
+    de vuelta—, porque media vuelta es una forma normal de jugar. No cuenta una
+    tarjeta con huecos: eso no es media vuelta, es una vuelta que se dejó a
+    medias, y son justo las malas las que se abandonan.
+    """
+
+    async def test_the_front_nine_count_as_a_round(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
     ):
-        user = await create_user(user_uow, unique_email("partial"), handicap=0)
+        """
+        Nueve hoyos a 5 golpes en un campo de pares 4 son +9, que llevados a la
+        escala de 18 son +18. Sin ese ajuste, jugar media vuelta parecería
+        mejorar el juego.
+        """
+        user = await create_user(user_uow, unique_email("frontnine"), handicap=0)
         course = await create_golf_course(golf_course_uow, user.id)
         await _played_quick_match(qm_uow, course, user, strokes_per_hole=5, holes_played=9)
 
@@ -401,8 +415,78 @@ class TestIncompleteQuickMatchCards:
             user.id
         )
 
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 18.0
+
+    async def test_the_back_nine_count_too(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Quien juega la vuelta de atrás ha jugado media vuelta igualmente."""
+        user = await create_user(user_uow, unique_email("backnine"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(
+            qm_uow, course, user, strokes_per_hole=5, holes=list(range(10, 19))
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 18.0
+
+    async def test_a_half_round_weighs_the_same_as_a_whole_one(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Una media vuelta a +18 de escala y una entera a +18 dan media de +18: la
+        normalización sirve precisamente para que puedan promediarse.
+        """
+        user = await create_user(user_uow, unique_email("mixed"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5, holes_played=9)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 2
+        assert stats.scoring_avg == 18.0
+
+    async def test_ten_holes_are_neither_a_round_nor_a_clean_half(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("tenholes"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5, holes_played=10)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
         assert stats.rounds_played == 0
         assert stats.scoring_avg is None
+
+    async def test_nine_scattered_holes_are_not_half_a_round(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Nueve hoyos sueltos son nueve hoyos sueltos. Exigir que sean una mitad
+        entera es lo que impide que una vuelta abandonada entre por la puerta
+        que se abrió para media vuelta.
+        """
+        user = await create_user(user_uow, unique_email("scattered"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(
+            qm_uow, course, user, strokes_per_hole=5, holes=[1, 2, 3, 4, 5, 6, 7, 8, 18]
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
 
     async def test_a_match_still_in_progress_counts_for_nothing(
         self, user_uow, competition_uow, qm_uow, golf_course_uow

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -285,7 +285,12 @@ class TestFreePlayQuickMatch:
         assert entry.score == "+18"
         assert entry.scoring_format == "MEDAL"
         assert entry.match_format is None
-        assert entry.stableford_points is None
+        # Los puntos se calculan en cualquier formato: son la unica cifra que
+        # compara vueltas entre si, porque 36 es jugar a tu handicap. Un
+        # scratch con bogey en cada hoyo firma 18
+        assert entry.stableford_points == 18
+        assert entry.total_strokes == 90
+        assert entry.holes_played == 18
 
     async def test_stableford_reports_points(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
@@ -631,3 +636,59 @@ class TestHiddenMatches:
 
         assert (await use_case.execute(hider.id)).matches == []
         assert len((await use_case.execute(other.id)).matches) == 1
+
+
+@pytest.mark.asyncio
+class TestComparableFigures:
+    """
+    Golpes, hoyos y puntos Stableford en cualquier formato (FE #306).
+
+    El historial mezclaba notaciones que no se pueden comparar entre sí —"1UP"
+    de match play, "+18" de medal, "26 pts" de Stableford— y obligaba a
+    traducir mentalmente antes de saber qué vuelta fue mejor. Los puntos son la
+    vara común: 36 es jugar a tu hándicap, en cualquier campo y formato.
+    """
+
+    async def test_a_match_play_round_also_reports_strokes_and_points(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Matchplay", handicap=0)
+        rival = await create_user(user_uow, "Rival", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            player,
+            scoring_format=None,
+            match_format=MatchFormat.SINGLES,
+            others=[QuickMatchParticipant.for_user(rival.id)],
+            strokes_by_participant_index={0: 5, 1: 6},
+        )
+
+        entry = (
+            await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(player.id)
+        ).matches[0]
+        # Bogey en cada hoyo para un scratch: 90 golpes y 18 puntos
+        assert entry.total_strokes == 90
+        assert entry.holes_played == 18
+        assert entry.stableford_points == 18
+        # El resultado del match play no se pierde, solo deja de ser lo único
+        assert entry.result == "WON"
+
+    async def test_half_a_round_reports_the_holes_it_was_played_over(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Sin este dato, "45 golpes" al lado de "90 golpes" parece un juegazo en
+        vez de media vuelta.
+        """
+        player = await create_user(user_uow, "Halfround", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_quick_match(qm_uow, course, player, strokes_per_hole=5, holes_played=9)
+
+        entry = (
+            await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(player.id)
+        ).matches[0]
+        assert entry.holes_played == 9
+        assert entry.total_strokes == 45
+        assert entry.stableford_points == 9


### PR DESCRIPTION
Two changes that came out of looking at real production data.

## Half a round counts

Nine holes is a normal way to play, and requiring eighteen left those rounds out of every statistic. Now the front nine or the back nine count as a round, provided the match is closed.

What still does not count is **a card with gaps**. Nine scattered holes are not half a round, they are an abandoned one — and the abandoned ones are the bad ones, which is precisely the bias the whole-cards rule exists to avoid (see #173).

A half round is **scaled to eighteen** before being mixed with the rest, since otherwise playing nine holes would look like an improvement. For the differential that means doubling the adjusted gross and measuring against the eighteen-hole rating. That is mathematically identical to measuring nine against half the rating and doubling the result — `2 × (113/S) × (AGS₉ − CR/2)` is `(113/S) × (2·AGS₉ − CR)` — but avoids building a `TeeRating` with a CR of 35.9 and a par of 36, which its own validation rejects for falling outside the WHS limits.

The approximation is assuming the nine played are worth half the course. Without nine-hole ratings there is no way to do better, and those are data the federation publishes separately.

## Comparable figures in the match feed

The feed mixed notations that cannot be compared with each other — `1UP` from match play, `+18` from medal, `26 pts` from Stableford — so telling which round was better meant translating each one first.

It now also reports **strokes, holes played and Stableford points**, and the points are computed **in every format**, not just in Stableford rounds. They are the one figure that compares rounds to each other: 36 points is playing to your handicap, on any course and in any format. Holes played matters now that half rounds count: "45 strokes" next to "90 strokes" reads like a great round rather than half a round.

Tournament rounds needed their scorecards loaded to report this, which is one extra query per match in the feed — bounded by the feed's own limit.

## Verification

2483 unit tests, 411 integration, lint and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for valid nine-hole rounds in player statistics.
  - Nine-hole rounds are scaled to 18 holes for averages, differentials, and scores relative to par.
  - Recent match history now displays total strokes, holes played, and Stableford points.
  - Tournament matches now include calculated scoring metrics.

- **Bug Fixes**
  - Excluded incomplete or scattered-hole scorecards from round calculations.
  - Standardized statistics across tournament and quick matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->