### PR TITLE
feat(social): Activity events generated from finished rounds

### DIFF
--- a/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
+++ b/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
@@ -1,0 +1,77 @@
+"""add activity_events table
+
+Revision ID: d4e8f1a3b7c9
+Revises: c7d1e4f8a2b6
+Create Date: 2026-08-10
+
+Feed de actividad entre amigos (BE #175). Guarda los logros que se publican:
+birdies, eagles, hoyos en uno, campos estrenados, récords personales y el
+primer torneo.
+
+Dos detalles del diseño que la tabla refleja:
+
+- `payload` es JSONB porque cada tipo de evento lleva un detalle distinto
+  (cuántos birdies y en qué hoyos, qué diferencial batió al anterior). Añadir un
+  tipo nuevo no debería exigir una migración.
+- La restricción única sobre `(user_id, source_match_id, type)` es lo que impide
+  que reprocesar una partida llene el feed de entradas repetidas.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d4e8f1a3b7c9"
+down_revision = "c7d1e4f8a2b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activity_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column("type", sa.String(30), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("source_match_id", sa.String(36), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "user_id", "source_match_id", "type", name="uq_activity_events_match_type"
+        ),
+    )
+    # El feed siempre pregunta lo mismo: eventos de estos jugadores, del más
+    # reciente al más antiguo
+    op.create_index(
+        "ix_activity_events_user_occurred",
+        "activity_events",
+        ["user_id", "occurred_at"],
+    )
+
+    # Cuándo miró cada jugador su feed por última vez. De aquí sale el aviso de
+    # novedades: contar lo publicado después de esta fecha. Nulo significa que
+    # todavía no lo ha abierto nunca.
+    op.add_column("users", sa.Column("feed_last_seen_at", sa.DateTime(), nullable=True))
+    # Interruptor para no publicar. Activado por defecto: es una aplicación entre
+    # amigos y el feed nacería vacío de otro modo.
+    op.add_column(
+        "users",
+        sa.Column(
+            "share_activity", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "share_activity")
+    op.drop_column("users", "feed_last_seen_at")
+    op.drop_index("ix_activity_events_user_occurred", table_name="activity_events")
+    op.drop_table("activity_events")

--- a/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
+++ b/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
@@ -58,6 +58,14 @@ def upgrade() -> None:
         "activity_events",
         ["user_id", "occurred_at"],
     )
+    # La comprobación de «esta partida ya se publicó» filtra solo por partida.
+    # El índice de arriba empieza por `user_id`, así que no le sirve, y sin este
+    # la comprobación acabaría recorriendo la tabla entera según crece el feed
+    op.create_index(
+        "ix_activity_events_source_match",
+        "activity_events",
+        ["source_match_id"],
+    )
 
     # Cuándo miró cada jugador su feed por última vez. De aquí sale el aviso de
     # novedades: contar lo publicado después de esta fecha. Nulo significa que
@@ -76,5 +84,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("users", "share_activity")
     op.drop_column("users", "feed_last_seen_at")
+    op.drop_index("ix_activity_events_source_match", table_name="activity_events")
     op.drop_index("ix_activity_events_user_occurred", table_name="activity_events")
     op.drop_table("activity_events")

--- a/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
+++ b/alembic/versions/d4e8f1a3b7c9_add_activity_events_table.py
@@ -14,7 +14,10 @@ Dos detalles del diseño que la tabla refleja:
   (cuántos birdies y en qué hoyos, qué diferencial batió al anterior). Añadir un
   tipo nuevo no debería exigir una migración.
 - La restricción única sobre `(user_id, source_match_id, type)` es lo que impide
-  que reprocesar una partida llene el feed de entradas repetidas.
+  que reprocesar una partida llene el feed de entradas repetidas. `source_match_id`
+  es NOT NULL justamente para que esa restricción sirva: en Postgres un NULL no
+  iguala a otro NULL, así que las filas sin partida se le escaparían todas. Todos
+  los logros nacen de una vuelta terminada, así que no deja fuera ningún caso.
 """
 
 import sqlalchemy as sa
@@ -41,7 +44,7 @@ def upgrade() -> None:
             nullable=False,
             server_default="{}",
         ),
-        sa.Column("source_match_id", sa.String(36), nullable=True),
+        sa.Column("source_match_id", sa.String(36), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.UniqueConstraint(

--- a/main.py
+++ b/main.py
@@ -57,6 +57,9 @@ from src.modules.quick_match.infrastructure.persistence.mappers.quick_match_mapp
     start_quick_match_mappers,
 )
 from src.modules.social.infrastructure.api.v1 import friend_routes  # noqa: E402
+from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper import (  # noqa: E402
+    start_activity_event_mappers,
+)
 from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (  # noqa: E402
     start_social_mappers,
 )
@@ -109,6 +112,7 @@ async def lifespan(app: FastAPI):  # noqa: ARG001 - FastAPI requires this signat
     start_golf_course_mappers()  # Golf Course module mappers (before Competition - dependency)
     start_competition_mappers()  # Competition module mappers (depends on GolfCourse)
     start_social_mappers()  # Social module mappers (depends on User)
+    start_activity_event_mappers()  # Activity feed (depends on User)
     start_quick_match_mappers()  # QuickMatch module mappers (depends on User, GolfCourse)
     yield
     print("INFO:     Apagando aplicación...")

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -11,6 +11,9 @@ from src.config.settings import settings
 from src.modules.competition.application.ports.invitation_email_service_interface import (
     IInvitationEmailService,
 )
+from src.modules.competition.application.ports.tournament_achievements_publisher_interface import (
+    TournamentAchievementsPublisherInterface,
+)
 from src.modules.competition.application.use_cases.activate_competition_use_case import (
     ActivateCompetitionUseCase,
 )
@@ -253,6 +256,9 @@ from src.modules.quick_match.domain.services.scoring_coverage_service import (
 from src.modules.quick_match.infrastructure.persistence.sqlalchemy.quick_match_unit_of_work import (
     SQLAlchemyQuickMatchUnitOfWork,
 )
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
 from src.modules.social.application.ports.player_differentials_interface import (
     PlayerDifferentialsInterface,
 )
@@ -267,6 +273,9 @@ from src.modules.social.application.use_cases.list_pending_requests_use_case imp
 from src.modules.social.application.use_cases.publish_round_achievements_use_case import (
     PublishRoundAchievementsUseCase,
 )
+from src.modules.social.application.use_cases.publish_tournament_achievements_use_case import (
+    PublishTournamentAchievementsUseCase,
+)
 from src.modules.social.application.use_cases.remove_friend_use_case import RemoveFriendUseCase
 from src.modules.social.application.use_cases.respond_friend_request_use_case import (
     RespondFriendRequestUseCase,
@@ -274,14 +283,23 @@ from src.modules.social.application.use_cases.respond_friend_request_use_case im
 from src.modules.social.application.use_cases.send_friend_request_use_case import (
     SendFriendRequestUseCase,
 )
+from src.modules.social.application.use_cases.set_activity_sharing_use_case import (
+    SetActivitySharingUseCase,
+)
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
+)
+from src.modules.social.infrastructure.adapters.player_course_history_adapter import (
+    PlayerCourseHistoryAdapter,
 )
 from src.modules.social.infrastructure.adapters.player_differentials_adapter import (
     StatsPlayerDifferentialsAdapter,
 )
 from src.modules.social.infrastructure.adapters.quick_match_achievements_publisher import (
     QuickMatchAchievementsPublisher,
+)
+from src.modules.social.infrastructure.adapters.tournament_achievements_publisher import (
+    TournamentAchievementsPublisher,
 )
 from src.modules.social.infrastructure.persistence.sqlalchemy.social_unit_of_work import (
     SQLAlchemySocialUnitOfWork,
@@ -1318,12 +1336,29 @@ def get_player_differentials(
     return StatsPlayerDifferentialsAdapter(stats_use_case)
 
 
+def get_set_activity_sharing_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+) -> SetActivitySharingUseCase:
+    """Proveedor del caso de uso SetActivitySharingUseCase."""
+    return SetActivitySharingUseCase(user_uow, social_uow)
+
+
+def get_player_course_history(
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+) -> PlayerCourseHistoryInterface:
+    """Proveedor del puerto que dice si un campo ya se habia jugado."""
+    return PlayerCourseHistoryAdapter(quick_match_uow, competition_uow)
+
+
 def get_publish_round_achievements_use_case(
     social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
     quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
     golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
     differentials: PlayerDifferentialsInterface = Depends(get_player_differentials),
+    history: PlayerCourseHistoryInterface = Depends(get_player_course_history),
 ) -> PublishRoundAchievementsUseCase:
     """Proveedor del caso de uso PublishRoundAchievementsUseCase."""
     return PublishRoundAchievementsUseCase(
@@ -1332,7 +1367,37 @@ def get_publish_round_achievements_use_case(
         golf_course_uow=golf_course_uow,
         user_uow=user_uow,
         differentials=differentials,
+        history=history,
     )
+
+
+def get_publish_tournament_achievements_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    competition_uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    differentials: PlayerDifferentialsInterface = Depends(get_player_differentials),
+    history: PlayerCourseHistoryInterface = Depends(get_player_course_history),
+) -> PublishTournamentAchievementsUseCase:
+    """Proveedor del caso de uso PublishTournamentAchievementsUseCase."""
+    return PublishTournamentAchievementsUseCase(
+        social_uow=social_uow,
+        competition_uow=competition_uow,
+        golf_course_uow=golf_course_uow,
+        user_uow=user_uow,
+        differentials=differentials,
+        history=history,
+    )
+
+
+def get_tournament_achievements_publisher(
+    publish_use_case: PublishTournamentAchievementsUseCase = Depends(
+        get_publish_tournament_achievements_use_case
+    ),
+    differentials: PlayerDifferentialsInterface = Depends(get_player_differentials),
+) -> TournamentAchievementsPublisherInterface:
+    """Proveedor del adaptador que conecta competition con el feed social."""
+    return TournamentAchievementsPublisher(publish_use_case, differentials)
 
 
 def get_round_achievements_publisher(
@@ -1538,6 +1603,9 @@ def get_start_competition_use_case(
 
 def get_complete_competition_use_case(
     uow: CompetitionUnitOfWorkInterface = Depends(get_competition_uow),
+    achievements: TournamentAchievementsPublisherInterface = Depends(
+        get_tournament_achievements_publisher
+    ),
 ) -> CompleteCompetitionUseCase:
     """
     Proveedor del caso de uso CompleteCompetitionUseCase.
@@ -1546,8 +1614,11 @@ def get_complete_competition_use_case(
     1. Depende de `get_competition_uow` para obtener una Unit of Work.
     2. Crea una instancia de `CompleteCompetitionUseCase` con esa dependencia.
     3. Devuelve la instancia lista para ser usada por el endpoint de la API.
+
+    Cerrar el torneo es lo que dispara el feed de logros (BE #175), de ahí el
+    publicador.
     """
-    return CompleteCompetitionUseCase(uow)
+    return CompleteCompetitionUseCase(uow, achievements)
 
 
 def get_cancel_competition_use_case(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -199,6 +199,9 @@ from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interf
 from src.modules.golf_course.infrastructure.persistence.sqlalchemy.golf_course_unit_of_work import (
     SQLAlchemyGolfCourseUnitOfWork,
 )
+from src.modules.quick_match.application.ports.round_achievements_publisher_interface import (
+    RoundAchievementsPublisherInterface,
+)
 from src.modules.quick_match.application.use_cases.add_friend_to_quick_match_use_case import (
     AddFriendToQuickMatchUseCase,
 )
@@ -250,6 +253,9 @@ from src.modules.quick_match.domain.services.scoring_coverage_service import (
 from src.modules.quick_match.infrastructure.persistence.sqlalchemy.quick_match_unit_of_work import (
     SQLAlchemyQuickMatchUnitOfWork,
 )
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
 from src.modules.social.application.ports.social_email_service_interface import (
     ISocialEmailService,
 )
@@ -257,6 +263,9 @@ from src.modules.social.application.use_cases.block_user_use_case import BlockUs
 from src.modules.social.application.use_cases.list_friends_use_case import ListFriendsUseCase
 from src.modules.social.application.use_cases.list_pending_requests_use_case import (
     ListPendingRequestsUseCase,
+)
+from src.modules.social.application.use_cases.publish_round_achievements_use_case import (
+    PublishRoundAchievementsUseCase,
 )
 from src.modules.social.application.use_cases.remove_friend_use_case import RemoveFriendUseCase
 from src.modules.social.application.use_cases.respond_friend_request_use_case import (
@@ -267,6 +276,12 @@ from src.modules.social.application.use_cases.send_friend_request_use_case impor
 )
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
+)
+from src.modules.social.infrastructure.adapters.player_differentials_adapter import (
+    StatsPlayerDifferentialsAdapter,
+)
+from src.modules.social.infrastructure.adapters.quick_match_achievements_publisher import (
+    QuickMatchAchievementsPublisher,
 )
 from src.modules.social.infrastructure.persistence.sqlalchemy.social_unit_of_work import (
     SQLAlchemySocialUnitOfWork,
@@ -1296,12 +1311,49 @@ def get_start_quick_match_use_case(
     return StartQuickMatchUseCase(uow, user_uow)
 
 
+def get_player_differentials(
+    stats_use_case: GetPlayerStatsUseCase = Depends(get_get_player_stats_use_case),
+) -> PlayerDifferentialsInterface:
+    """Proveedor del puerto de diferenciales que usa el feed de logros."""
+    return StatsPlayerDifferentialsAdapter(stats_use_case)
+
+
+def get_publish_round_achievements_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    quick_match_uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    differentials: PlayerDifferentialsInterface = Depends(get_player_differentials),
+) -> PublishRoundAchievementsUseCase:
+    """Proveedor del caso de uso PublishRoundAchievementsUseCase."""
+    return PublishRoundAchievementsUseCase(
+        social_uow=social_uow,
+        quick_match_uow=quick_match_uow,
+        golf_course_uow=golf_course_uow,
+        user_uow=user_uow,
+        differentials=differentials,
+    )
+
+
+def get_round_achievements_publisher(
+    publish_use_case: PublishRoundAchievementsUseCase = Depends(
+        get_publish_round_achievements_use_case
+    ),
+    differentials: PlayerDifferentialsInterface = Depends(get_player_differentials),
+) -> RoundAchievementsPublisherInterface:
+    """Proveedor del adaptador que conecta quick_match con el feed social."""
+    return QuickMatchAchievementsPublisher(publish_use_case, differentials)
+
+
 def get_complete_quick_match_use_case(
     uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    achievements: RoundAchievementsPublisherInterface = Depends(
+        get_round_achievements_publisher
+    ),
 ) -> CompleteQuickMatchUseCase:
     """Proveedor del caso de uso CompleteQuickMatchUseCase."""
-    return CompleteQuickMatchUseCase(uow, user_uow)
+    return CompleteQuickMatchUseCase(uow, user_uow, achievements)
 
 
 def get_cancel_quick_match_use_case(

--- a/src/modules/competition/application/ports/tournament_achievements_publisher_interface.py
+++ b/src/modules/competition/application/ports/tournament_achievements_publisher_interface.py
@@ -1,0 +1,28 @@
+"""Puerto: publicar en el feed los logros de un torneo terminado."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class TournamentAchievementsPublisherInterface(ABC):
+    """
+    Lo que `competition` necesita del feed social, sin depender de el.
+
+    Igual que en las partidas rapidas, son dos operaciones porque el record
+    personal solo se puede medir a caballo del cierre: **antes** se pregunta cual
+    era el mejor diferencial de cada jugador y **despues** se compara. Una vez
+    cerrado el torneo, esas vueltas ya cuentan para sus estadisticas.
+    """
+
+    @abstractmethod
+    async def capture_best_differentials(
+        self, user_ids: list[UserId]
+    ) -> dict[str, float | None]:
+        """El mejor diferencial de cada jugador antes de cerrar el torneo."""
+
+    @abstractmethod
+    async def publish(
+        self, competition_id: str, best_differential_before: dict[str, float | None]
+    ) -> int:
+        """Publica los logros del torneo y devuelve cuantos creo."""

--- a/src/modules/competition/application/use_cases/complete_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/complete_competition_use_case.py
@@ -5,6 +5,8 @@ Permite completar/finalizar una competicion (IN_PROGRESS -> COMPLETED).
 Solo el creador puede realizar esta accion.
 """
 
+import logging
+
 from src.modules.competition.application.dto.competition_dto import (
     CompleteCompetitionRequestDTO,
     CompleteCompetitionResponseDTO,
@@ -13,11 +15,16 @@ from src.modules.competition.application.exceptions import (
     CompetitionNotFoundError,
     NotCompetitionCreatorError,
 )
+from src.modules.competition.application.ports.tournament_achievements_publisher_interface import (
+    TournamentAchievementsPublisherInterface,
+)
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
 from src.modules.user.domain.value_objects.user_id import UserId
+
+logger = logging.getLogger(__name__)
 
 
 class CompleteCompetitionUseCase:
@@ -40,14 +47,21 @@ class CompleteCompetitionUseCase:
     5. Commit de la transaccion
     """
 
-    def __init__(self, uow: CompetitionUnitOfWorkInterface):
+    def __init__(
+        self,
+        uow: CompetitionUnitOfWorkInterface,
+        achievements: TournamentAchievementsPublisherInterface | None = None,
+    ):
         """
         Constructor.
 
         Args:
             uow: Unit of Work para gestionar transacciones
+            achievements: Publicador del feed de logros (BE #175). Opcional:
+                sin el, cerrar el torneo sigue funcionando y no se publica nada.
         """
         self._uow = uow
+        self._achievements = achievements
 
     async def execute(
         self, request: CompleteCompetitionRequestDTO, user_id: UserId, is_admin: bool = False
@@ -81,15 +95,59 @@ class CompleteCompetitionUseCase:
             if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede completar la competicion")
 
-            # 3. Completar la competicion (la entidad valida la transicion)
+            # 3. Antes de cerrar: una vez cerrado, estas vueltas ya cuentan para
+            # las estadisticas y no habria forma de saber la marca previa
+            marca_previa = await self._marca_previa(competition_id)
+
+            # 4. Completar la competicion (la entidad valida la transicion)
             competition.complete()
 
-            # 4. Persistir cambios
+            # 5. Persistir cambios
             await self._uow.competitions.update(competition)
 
-        # 6. Retornar DTO de respuesta
+        # 6. Publicar los logros del torneo en el feed de los amigos
+        await self._publicar_logros(request.competition_id, marca_previa)
+
+        # 7. Retornar DTO de respuesta
         return CompleteCompetitionResponseDTO(
             id=competition.id.value,
             status=competition.status.value,
             completed_at=competition.updated_at,
         )
+
+    async def _marca_previa(self, competition_id: CompetitionId) -> dict[str, float | None]:
+        """El mejor diferencial de cada inscrito, antes de cerrar el torneo."""
+        if self._achievements is None:
+            return {}
+
+        try:
+            enrollments = await self._uow.enrollments.find_by_competition(competition_id)
+            return await self._achievements.capture_best_differentials(
+                [enrollment.user_id for enrollment in enrollments]
+            )
+        except Exception:
+            # Sin marca previa se publica todo menos el record personal, que es
+            # mejor que no publicar nada
+            logger.warning("Could not capture differentials before completing", exc_info=True)
+            return {}
+
+    async def _publicar_logros(
+        self, competition_id_raw: str, marca_previa: dict[str, float | None]
+    ) -> None:
+        """
+        Publica los logros del torneo sin dejar que un fallo tumbe el cierre.
+
+        El torneo ya esta cerrado y guardado cuando esto corre. El feed es
+        accesorio y el resultado del torneo no.
+        """
+        if self._achievements is None:
+            return
+
+        try:
+            await self._achievements.publish(competition_id_raw, marca_previa)
+        except Exception:
+            logger.warning(
+                "Could not publish achievements for competition %s",
+                competition_id_raw,
+                exc_info=True,
+            )

--- a/src/modules/competition/application/use_cases/complete_competition_use_case.py
+++ b/src/modules/competition/application/use_cases/complete_competition_use_case.py
@@ -95,36 +95,51 @@ class CompleteCompetitionUseCase:
             if not is_admin and not competition.is_creator(user_id):
                 raise NotCompetitionCreatorError("Solo el creador puede completar la competicion")
 
-            # 3. Antes de cerrar: una vez cerrado, estas vueltas ya cuentan para
-            # las estadisticas y no habria forma de saber la marca previa
-            marca_previa = await self._marca_previa(competition_id)
+            # 3. Los inscritos, para preguntar por su marca previa fuera de aqui
+            inscritos = [
+                enrollment.user_id
+                for enrollment in await self._uow.enrollments.find_by_competition(
+                    competition_id
+                )
+            ]
 
-            # 4. Completar la competicion (la entidad valida la transicion)
+        # 4. Fuera de la transaccion a proposito: preguntar por el mejor
+        # diferencial entra en las estadisticas del jugador, que abren esta misma
+        # unidad de trabajo. Anidarla arriba la cerraria antes de guardar el
+        # cierre. Y va antes de completar: despues, estas vueltas ya cuentan para
+        # sus estadisticas y su marca previa seria imposible de saber
+        marca_previa = await self._marca_previa(inscritos)
+
+        async with self._uow:
+            competition = await self._uow.competitions.find_by_id(competition_id)
+            if not competition:
+                raise CompetitionNotFoundError(
+                    f"No existe competición con ID {request.competition_id}"
+                )
+
+            # 5. Completar la competicion (la entidad valida la transicion)
             competition.complete()
 
-            # 5. Persistir cambios
+            # 6. Persistir cambios
             await self._uow.competitions.update(competition)
 
-        # 6. Publicar los logros del torneo en el feed de los amigos
+        # 7. Publicar los logros del torneo en el feed de los amigos
         await self._publicar_logros(request.competition_id, marca_previa)
 
-        # 7. Retornar DTO de respuesta
+        # 8. Retornar DTO de respuesta
         return CompleteCompetitionResponseDTO(
             id=competition.id.value,
             status=competition.status.value,
             completed_at=competition.updated_at,
         )
 
-    async def _marca_previa(self, competition_id: CompetitionId) -> dict[str, float | None]:
+    async def _marca_previa(self, inscritos: list[UserId]) -> dict[str, float | None]:
         """El mejor diferencial de cada inscrito, antes de cerrar el torneo."""
         if self._achievements is None:
             return {}
 
         try:
-            enrollments = await self._uow.enrollments.find_by_competition(competition_id)
-            return await self._achievements.capture_best_differentials(
-                [enrollment.user_id for enrollment in enrollments]
-            )
+            return await self._achievements.capture_best_differentials(inscritos)
         except Exception:
             # Sin marca previa se publica todo menos el record personal, que es
             # mejor que no publicar nada

--- a/src/modules/quick_match/application/ports/round_achievements_publisher_interface.py
+++ b/src/modules/quick_match/application/ports/round_achievements_publisher_interface.py
@@ -1,0 +1,29 @@
+"""Puerto: publicar en el feed los logros de una vuelta terminada."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class RoundAchievementsPublisherInterface(ABC):
+    """
+    Lo que `quick_match` necesita del feed social, sin depender de el.
+
+    Son dos operaciones y no una porque el record personal solo se puede medir a
+    caballo del cierre: **antes** de cerrar la partida se pregunta cual era el
+    mejor diferencial del jugador, y **despues** se compara. Una vez cerrada, esa
+    vuelta ya cuenta para sus estadisticas y no hay forma de preguntar como
+    estaba el registro sin ella.
+    """
+
+    @abstractmethod
+    async def capture_best_differentials(
+        self, user_ids: list[UserId]
+    ) -> dict[str, float | None]:
+        """El mejor diferencial de cada jugador antes de cerrar la vuelta."""
+
+    @abstractmethod
+    async def publish(
+        self, quick_match_id: str, best_differential_before: dict[str, float | None]
+    ) -> int:
+        """Publica los logros de la partida y devuelve cuantos creo."""

--- a/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
@@ -56,9 +56,21 @@ class CompleteQuickMatchUseCase:
             if quick_match.creator_id != requester_id:
                 raise NotQuickMatchCreatorError("Only the creator can complete the quick match.")
 
-            # Antes de cerrar: una vez cerrada, esta vuelta ya cuenta para las
-            # estadisticas y no habria forma de saber cual era su marca previa
-            marca_previa = await self._marca_previa(quick_match)
+            jugadores = [p.user_id for p in quick_match.participants if p.user_id is not None]
+
+        # Fuera de la transaccion a proposito: preguntar por el mejor diferencial
+        # entra en las estadisticas del jugador, que abren esta misma unidad de
+        # trabajo. Anidarla aqui la cerraria antes de que se guarde el cierre.
+        # Y tiene que ser antes de completar: despues, esta vuelta ya cuenta para
+        # sus estadisticas y su marca previa seria imposible de saber
+        marca_previa = await self._marca_previa(jugadores)
+
+        async with self._uow:
+            quick_match = await self._uow.quick_matches.find_by_id(
+                QuickMatchId(quick_match_id_raw)
+            )
+            if not quick_match:
+                raise QuickMatchNotFoundError(f"Quick match not found: {quick_match_id_raw}")
 
             quick_match.complete()
             await self._uow.quick_matches.update(quick_match)
@@ -67,14 +79,13 @@ class CompleteQuickMatchUseCase:
 
         return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
 
-    async def _marca_previa(self, quick_match) -> dict[str, float | None]:
+    async def _marca_previa(self, jugadores: list[UserId]) -> dict[str, float | None]:
         """El mejor diferencial de cada jugador con cuenta, antes de cerrar."""
         if self._achievements is None:
             return {}
 
-        user_ids = [p.user_id for p in quick_match.participants if p.user_id is not None]
         try:
-            return await self._achievements.capture_best_differentials(user_ids)
+            return await self._achievements.capture_best_differentials(jugadores)
         except Exception:
             # Sin marca previa se publica todo menos el record personal, que es
             # mejor que no publicar nada

--- a/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
@@ -1,11 +1,16 @@
 """Caso de Uso: Finalizar una Partida Rapida."""
 
+import logging
+
 from src.modules.quick_match.application.dto.quick_match_dto import QuickMatchResponseDTO
 from src.modules.quick_match.application.exceptions import (
     NotQuickMatchCreatorError,
     QuickMatchNotFoundError,
 )
 from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.application.ports.round_achievements_publisher_interface import (
+    RoundAchievementsPublisherInterface,
+)
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
@@ -15,13 +20,26 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
+logger = logging.getLogger(__name__)
+
 
 class CompleteQuickMatchUseCase:
-    """El creador marca la partida como finalizada."""
+    """
+    El creador marca la partida como finalizada.
 
-    def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
+    Cerrar la partida es tambien lo que dispara el feed de logros (BE #175): es
+    el momento en que la vuelta pasa a ser definitiva y comparable.
+    """
+
+    def __init__(
+        self,
+        uow: QuickMatchUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        achievements: RoundAchievementsPublisherInterface | None = None,
+    ):
         self._uow = uow
         self._user_uow = user_uow
+        self._achievements = achievements
 
     async def execute(
         self, quick_match_id_raw: str, requester_id_raw: str
@@ -38,7 +56,49 @@ class CompleteQuickMatchUseCase:
             if quick_match.creator_id != requester_id:
                 raise NotQuickMatchCreatorError("Only the creator can complete the quick match.")
 
+            # Antes de cerrar: una vez cerrada, esta vuelta ya cuenta para las
+            # estadisticas y no habria forma de saber cual era su marca previa
+            marca_previa = await self._marca_previa(quick_match)
+
             quick_match.complete()
             await self._uow.quick_matches.update(quick_match)
 
+        await self._publicar_logros(quick_match_id_raw, marca_previa)
+
         return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+
+    async def _marca_previa(self, quick_match) -> dict[str, float | None]:
+        """El mejor diferencial de cada jugador con cuenta, antes de cerrar."""
+        if self._achievements is None:
+            return {}
+
+        user_ids = [p.user_id for p in quick_match.participants if p.user_id is not None]
+        try:
+            return await self._achievements.capture_best_differentials(user_ids)
+        except Exception:
+            # Sin marca previa se publica todo menos el record personal, que es
+            # mejor que no publicar nada
+            logger.warning("Could not capture differentials before completing", exc_info=True)
+            return {}
+
+    async def _publicar_logros(
+        self, quick_match_id_raw: str, marca_previa: dict[str, float | None]
+    ) -> None:
+        """
+        Publica los logros de la vuelta sin dejar que un fallo tumbe el cierre.
+
+        La partida ya esta cerrada y guardada cuando esto corre. El feed es
+        accesorio y la tarjeta no: si publicar falla, el jugador tiene que ver
+        su partida terminada igualmente.
+        """
+        if self._achievements is None:
+            return
+
+        try:
+            await self._achievements.publish(quick_match_id_raw, marca_previa)
+        except Exception:
+            logger.warning(
+                "Could not publish achievements for quick match %s",
+                quick_match_id_raw,
+                exc_info=True,
+            )

--- a/src/modules/social/application/dto/activity_sharing_dto.py
+++ b/src/modules/social/application/dto/activity_sharing_dto.py
@@ -1,0 +1,27 @@
+"""DTOs del interruptor de publicacion de logros."""
+
+from pydantic import BaseModel, Field
+
+
+class SetActivitySharingRequestDTO(BaseModel):
+    """Peticion para encender o apagar la publicacion de logros."""
+
+    enabled: bool = Field(
+        description=(
+            "Si los logros del jugador se publican en el feed de sus amigos. "
+            "Apagarlo retira ademas lo ya publicado."
+        )
+    )
+
+
+class ActivitySharingResponseDTO(BaseModel):
+    """Como queda el interruptor y que se retiro al apagarlo."""
+
+    share_activity: bool = Field(description="Estado en el que queda el interruptor")
+    removed_events: int = Field(
+        default=0,
+        description=(
+            "Cuantas entradas se retiraron del feed. Siempre 0 al encender: "
+            "encender no recupera lo borrado, el feed se llena con lo que se juegue."
+        ),
+    )

--- a/src/modules/social/application/ports/player_course_history_interface.py
+++ b/src/modules/social/application/ports/player_course_history_interface.py
@@ -1,0 +1,28 @@
+"""Puerto: si un jugador ya habia pisado un campo."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class PlayerCourseHistoryInterface(ABC):
+    """
+    Responde si una vuelta estrena campo, mirando **todo** lo que el jugador ha
+    jugado.
+
+    Es un puerto y no una consulta directa porque la respuesta cruza dos
+    modulos: un campo se puede estrenar en una partida rapida o en un torneo, y
+    preguntarle solo a uno haria que el mismo campo se estrenara dos veces.
+    """
+
+    @abstractmethod
+    async def has_played_course_before(
+        self, user_id: UserId, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        """
+        Si el jugador ya habia terminado otra vuelta en ese campo.
+
+        `excluding_match_id` deja fuera la vuelta que se esta juzgando: cuando
+        esto corre ya esta cerrada, asi que contarla haria que nadie estrenara
+        campo nunca.
+        """

--- a/src/modules/social/application/ports/player_differentials_interface.py
+++ b/src/modules/social/application/ports/player_differentials_interface.py
@@ -1,0 +1,26 @@
+"""Puerto: consultar el mejor diferencial de un jugador."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class PlayerDifferentialsInterface(ABC):
+    """
+    Lo único que el feed necesita saber del WHS: cuál es el mejor diferencial
+    de un jugador ahora mismo.
+
+    Se define como puerto en lugar de llamar directamente al caso de uso de
+    estadísticas para que el módulo social no dependa del de usuario. El feed no
+    sabe calcular un diferencial y no debería: solo necesita compararlos para
+    decidir si una vuelta fue un récord.
+    """
+
+    @abstractmethod
+    async def best_differential(self, user_id: UserId) -> float | None:
+        """
+        El mejor diferencial del jugador, o None si aún no tiene ninguno.
+
+        Devuelve None también cuando ninguna de sus vueltas se jugó desde un tee
+        conocido: sin Slope ni Course Rating no hay diferencial que calcular.
+        """

--- a/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
@@ -1,0 +1,294 @@
+"""Caso de Uso: Publicar en el feed los logros de una vuelta terminada."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.social.domain.services.achievement_detector import (
+    AchievementDetector,
+    DetectedAchievement,
+    PlayedHole,
+    RoundContext,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.services.countable_round import countable_holes
+
+# Cuántas partidas del jugador se miran para saber si estrena campo. Un jugador
+# con más historia que esto ya no estrena nada que importe recordar.
+MAX_HISTORY_LOOKUP = 200
+
+
+@dataclass(frozen=True)
+class _RoundToJudge:
+    """
+    La vuelta de un jugador reducida a lo que hace falta para juzgarla.
+
+    Existe para que la lectura y el juicio no se mezclen: aquí ya no hay
+    entidades de `quick_match` ni de `golf_course`, así que juzgar no puede
+    volver a la base de datos sin querer.
+    """
+
+    user_id: UserId
+    match_id: str
+    golf_course_id: str
+    occurred_at: datetime
+    holes: list[PlayedHole]
+    estrena_campo: bool
+
+
+class PublishRoundAchievementsUseCase:
+    """
+    Publica los logros de una partida rápida recién terminada.
+
+    **Solo se publica hacia delante** (decisión de producto en BE #175): no hay
+    backfill, así que este caso de uso es el único que crea eventos y solo se
+    dispara al cerrar una partida. El feed nace vacío y se llena solo.
+
+    Publica para **todos los participantes con cuenta**, no solo para quien
+    cierra la partida: el birdie es de quien lo hizo. Los invitados no tienen
+    dónde publicar.
+
+    Nunca interrumpe el cierre de la partida. Un fallo aquí no puede impedir que
+    una partida se dé por terminada — el feed es accesorio y la tarjeta no.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        differentials: PlayerDifferentialsInterface,
+        detector: AchievementDetector | None = None,
+    ):
+        self._social_uow = social_uow
+        self._quick_match_uow = quick_match_uow
+        self._golf_course_uow = golf_course_uow
+        self._user_uow = user_uow
+        self._differentials = differentials
+        self._detector = detector or AchievementDetector()
+
+    async def execute(
+        self,
+        quick_match_id_raw: str,
+        best_differential_before: dict[str, float | None] | None = None,
+    ) -> int:
+        """
+        Publica lo que merezca publicarse y devuelve cuántos eventos creó.
+
+        `best_differential_before` lleva, por jugador, su mejor diferencial
+        **antes** de que esta vuelta contara. Lo captura quien cierra la partida,
+        porque una vez cerrada ya no hay forma de preguntarlo: las estadísticas
+        solo miran partidas terminadas y esta ya lo está. Comparando aquel valor
+        con el de ahora se sabe si la vuelta batió el récord, sin recalcular por
+        segunda vez un diferencial que el módulo de estadísticas ya sabe hacer.
+        """
+        best_before = best_differential_before or {}
+
+        # Fase 1: leer. Todo lo que hace falta de la partida, en un solo paso y
+        # con las unidades de trabajo abiertas lo justo
+        vueltas = await self._leer_vueltas(quick_match_id_raw)
+        if not vueltas:
+            return 0
+
+        # Fase 2: juzgar. Fuera de cualquier unidad de trabajo abierta, porque
+        # preguntar por el diferencial vuelve a entrar en estas mismas —el puerto
+        # se apoya en las estadísticas del jugador, que consultan quick_match y
+        # golf_course— y anidar dos `async with` sobre la misma sesión la
+        # cerraría antes de tiempo
+        eventos: list[ActivityEvent] = []
+        for vuelta in vueltas:
+            contexto = RoundContext(
+                is_first_round_on_course=vuelta.estrena_campo,
+                # Esto es una partida rápida: estrenar torneo se publica desde
+                # el cierre de la competición
+                is_first_tournament=False,
+                previous_best_differential=self._como_decimal(
+                    best_before.get(str(vuelta.user_id.value))
+                ),
+                differential=await self._diferencial_si_es_record(
+                    vuelta.user_id, best_before.get(str(vuelta.user_id.value))
+                ),
+            )
+            logros = self._detector.detect(holes=vuelta.holes, context=contexto)
+            eventos.extend(
+                self._a_eventos(
+                    logros,
+                    vuelta.user_id,
+                    vuelta.match_id,
+                    vuelta.golf_course_id,
+                    vuelta.occurred_at,
+                    len(vuelta.holes),
+                )
+            )
+
+        if not eventos:
+            return 0
+
+        # Fase 3: publicar
+        async with self._social_uow:
+            await self._social_uow.activity_events.add_many(eventos)
+
+        return len(eventos)
+
+    async def _leer_vueltas(self, quick_match_id_raw: str) -> list["_RoundToJudge"]:
+        """
+        Las vueltas publicables de la partida, ya reducidas a lo que hay que
+        juzgar.
+
+        Deja resuelto aquí todo lo que necesita base de datos —quién publica, qué
+        hoyos cuentan, quién estrena campo— para que juzgar no tenga que volver.
+        """
+        async with self._quick_match_uow, self._golf_course_uow, self._user_uow:
+            match = await self._quick_match_uow.quick_matches.find_by_id(
+                QuickMatchId(quick_match_id_raw)
+            )
+            if match is None or match.status != QuickMatchStatus.COMPLETED:
+                return []
+
+            course = await self._golf_course_uow.golf_courses.find_by_id(match.golf_course_id)
+            if course is None:
+                return []
+
+            scores = await self._quick_match_uow.quick_match_hole_scores.find_by_match(match.id)
+
+            vueltas: list[_RoundToJudge] = []
+            for participant in match.participants:
+                if participant.is_guest or participant.user_id is None:
+                    continue
+
+                user = await self._user_uow.users.find_by_id(participant.user_id)
+                if user is None or not user.share_activity:
+                    continue
+
+                scores_by_hole = {
+                    score.hole_number: score.score
+                    for score in scores
+                    if score.participant_id == participant.participant_id
+                }
+                jugados = countable_holes(scores_by_hole, course)
+                if jugados is None:
+                    # Tarjeta incompleta: si no vale para la media, no vale para
+                    # presumir (BE #173)
+                    continue
+
+                vueltas.append(
+                    _RoundToJudge(
+                        user_id=participant.user_id,
+                        match_id=str(match.id.value),
+                        golf_course_id=str(match.golf_course_id.value),
+                        occurred_at=match.created_at,
+                        holes=[
+                            PlayedHole(
+                                number=hole.number,
+                                par=hole.par,
+                                strokes=scores_by_hole[hole.number],
+                            )
+                            for hole in jugados
+                        ],
+                        estrena_campo=await self._estrena_campo(participant.user_id, match),
+                    )
+                )
+
+        return vueltas
+
+    async def _estrena_campo(self, user_id: UserId, match) -> bool:
+        """
+        Si esta es su primera vuelta terminada en ese campo.
+
+        Se compara contra las **demás** partidas terminadas: la actual ya está
+        cerrada cuando esto corre, así que incluirla haría que nadie estrenara
+        campo nunca.
+        """
+        anteriores = await self._quick_match_uow.quick_matches.list_for_user(
+            user_id, status=QuickMatchStatus.COMPLETED, limit=MAX_HISTORY_LOOKUP
+        )
+        return not any(
+            otra.id != match.id and otra.golf_course_id == match.golf_course_id
+            for otra in anteriores
+        )
+
+    async def _diferencial_si_es_record(
+        self, user_id: UserId, best_before: float | None
+    ) -> Decimal | None:
+        """
+        El diferencial de esta vuelta, pero solo cuando ha batido el récord.
+
+        No se recalcula: si el mejor diferencial del jugador ha mejorado desde
+        que se cerró la partida, la única vuelta nueva es esta, así que el nuevo
+        mejor **es** el suyo. Cuando no ha mejorado se devuelve None y el
+        detector no publica récord, que es justo lo que debe pasar.
+
+        Devolver None cuando no hay nada con lo que comparar deja fuera la
+        primera vuelta con diferencial: es el punto de partida, no un récord.
+        """
+        if best_before is None:
+            return None
+
+        ahora = await self._differentials.best_differential(user_id)
+        if ahora is None or ahora >= best_before:
+            return None
+        return self._como_decimal(ahora)
+
+    @staticmethod
+    def _como_decimal(value: float | None) -> Decimal | None:
+        return None if value is None else Decimal(str(value))
+
+    def _a_eventos(
+        self,
+        logros: list[DetectedAchievement],
+        user_id: UserId,
+        match_id: str,
+        golf_course_id: str,
+        occurred_at: datetime,
+        holes_played: int,
+    ) -> list[ActivityEvent]:
+        """Convierte los logros detectados en entradas del feed."""
+        return [
+            ActivityEvent.create(
+                user_id=user_id,
+                type=logro.type,
+                # La partida rápida no guarda cuándo se jugó: se crea el mismo
+                # día, igual que asumen las estadísticas
+                occurred_at=occurred_at,
+                source_match_id=match_id,
+                payload=self._payload(logro, golf_course_id, holes_played),
+            )
+            for logro in logros
+        ]
+
+    @staticmethod
+    def _payload(logro: DetectedAchievement, golf_course_id: str, holes_played: int) -> dict:
+        """
+        El detalle propio de cada tipo, para que el feed no tenga que ir a
+        buscarlo a otras tablas al pintar la entrada.
+        """
+        payload: dict = {
+            "golf_course_id": golf_course_id,
+            "holes_played": holes_played,
+        }
+        if logro.count > 1:
+            payload["count"] = logro.count
+        if logro.holes:
+            payload["holes"] = list(logro.holes)
+        if logro.detail:
+            payload.update(logro.detail)
+        return payload

--- a/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
@@ -12,6 +12,9 @@ from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interf
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
 from src.modules.social.application.ports.player_differentials_interface import (
     PlayerDifferentialsInterface,
 )
@@ -51,7 +54,6 @@ class _RoundToJudge:
     golf_course_id: str
     occurred_at: datetime
     holes: list[PlayedHole]
-    estrena_campo: bool
 
 
 class PublishRoundAchievementsUseCase:
@@ -77,6 +79,7 @@ class PublishRoundAchievementsUseCase:
         golf_course_uow: GolfCourseUnitOfWorkInterface,
         user_uow: UserUnitOfWorkInterface,
         differentials: PlayerDifferentialsInterface,
+        history: PlayerCourseHistoryInterface,
         detector: AchievementDetector | None = None,
     ):
         self._social_uow = social_uow
@@ -84,6 +87,7 @@ class PublishRoundAchievementsUseCase:
         self._golf_course_uow = golf_course_uow
         self._user_uow = user_uow
         self._differentials = differentials
+        self._history = history
         self._detector = detector or AchievementDetector()
 
     async def execute(
@@ -117,7 +121,9 @@ class PublishRoundAchievementsUseCase:
         eventos: list[ActivityEvent] = []
         for vuelta in vueltas:
             contexto = RoundContext(
-                is_first_round_on_course=vuelta.estrena_campo,
+                is_first_round_on_course=not await self._history.has_played_course_before(
+                    vuelta.user_id, vuelta.golf_course_id, vuelta.match_id
+                ),
                 # Esto es una partida rápida: estrenar torneo se publica desde
                 # el cierre de la competición
                 is_first_tournament=False,
@@ -204,27 +210,10 @@ class PublishRoundAchievementsUseCase:
                             )
                             for hole in jugados
                         ],
-                        estrena_campo=await self._estrena_campo(participant.user_id, match),
                     )
                 )
 
         return vueltas
-
-    async def _estrena_campo(self, user_id: UserId, match) -> bool:
-        """
-        Si esta es su primera vuelta terminada en ese campo.
-
-        Se compara contra las **demás** partidas terminadas: la actual ya está
-        cerrada cuando esto corre, así que incluirla haría que nadie estrenara
-        campo nunca.
-        """
-        anteriores = await self._quick_match_uow.quick_matches.list_for_user(
-            user_id, status=QuickMatchStatus.COMPLETED, limit=MAX_HISTORY_LOOKUP
-        )
-        return not any(
-            otra.id != match.id and otra.golf_course_id == match.golf_course_id
-            for otra in anteriores
-        )
 
     async def _diferencial_si_es_record(
         self, user_id: UserId, best_before: float | None

--- a/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
@@ -101,7 +101,13 @@ class PublishTournamentAchievementsUseCase:
             return 0
 
         eventos: list[ActivityEvent] = []
-        for user_id_raw, vueltas in vueltas_por_jugador.items():
+        for user_id_raw, sin_ordenar in vueltas_por_jugador.items():
+            # `FIRST_TOURNAMENT` y el record cuelgan de `vueltas[0]`, asi que
+            # cual sea esa vuelta no puede depender del orden en que la base de
+            # datos devolvio los partidos: si cambia entre ejecuciones, el mismo
+            # logro colgaria de otro partido y la clave unica dejaria de
+            # reconocerlo como repetido
+            vueltas = sorted(sin_ordenar, key=lambda v: (v.occurred_at, v.match_id))
             marca_previa = best_before.get(user_id_raw)
             # El record se mide una vez por jugador, no una por vuelta: solo hay
             # una marca previa con la que comparar y la mejor de sus vueltas

--- a/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
@@ -1,0 +1,282 @@
+"""Caso de Uso: Publicar en el feed los logros de un torneo terminado."""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_status import CompetitionStatus
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.social.domain.services.achievement_detector import (
+    AchievementDetector,
+    DetectedAchievement,
+    PlayedHole,
+    RoundContext,
+)
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.services.countable_round import countable_holes
+
+logger = logging.getLogger(__name__)
+
+# Cuantas vueltas del jugador se miran hacia atras para saber si estrena torneo.
+MAX_HISTORY_LOOKUP = 200
+
+
+@dataclass(frozen=True)
+class _TournamentRound:
+    """Una vuelta de torneo reducida a lo que hace falta para juzgarla."""
+
+    user_id: UserId
+    match_id: str
+    golf_course_id: str
+    occurred_at: datetime
+    holes: list[PlayedHole]
+
+
+class PublishTournamentAchievementsUseCase:
+    """
+    Publica los logros de un torneo recien terminado.
+
+    Un torneo son varias vueltas por jugador, no una: cada partido terminado se
+    juzga por separado y lleva su propio `source_match_id`, que es lo que hace
+    que reprocesar el cierre no duplique nada.
+
+    `FIRST_TOURNAMENT` se publica **una sola vez por jugador**, colgado de su
+    primer partido. Colgarlo de todos llenaria el feed de la misma noticia
+    repetida, y no colgarlo de ninguno lo dejaria sin idempotencia.
+
+    Se publican los golpes propios (`own_score`) y no el neto validado: el neto
+    solo existe cuando el rival ha cerrado la validacion cruzada, asi que media
+    tarjeta legitima se quedaria fuera por un tramite que no es del jugador.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        differentials: PlayerDifferentialsInterface,
+        history: PlayerCourseHistoryInterface,
+        detector: AchievementDetector | None = None,
+    ):
+        self._social_uow = social_uow
+        self._competition_uow = competition_uow
+        self._golf_course_uow = golf_course_uow
+        self._user_uow = user_uow
+        self._differentials = differentials
+        self._history = history
+        self._detector = detector or AchievementDetector()
+
+    async def execute(
+        self,
+        competition_id_raw: str,
+        best_differential_before: dict[str, float | None] | None = None,
+    ) -> int:
+        """Publica lo que merezca publicarse y devuelve cuantos eventos creo."""
+        best_before = best_differential_before or {}
+
+        vueltas_por_jugador, estrena_torneo = await self._leer_vueltas(competition_id_raw)
+        if not vueltas_por_jugador:
+            return 0
+
+        eventos: list[ActivityEvent] = []
+        for user_id_raw, vueltas in vueltas_por_jugador.items():
+            marca_previa = best_before.get(user_id_raw)
+            # El record se mide una vez por jugador, no una por vuelta: solo hay
+            # una marca previa con la que comparar y la mejor de sus vueltas
+            # nuevas es la que la batio
+            record = await self._diferencial_si_es_record(vueltas[0].user_id, marca_previa)
+
+            for indice, vuelta in enumerate(vueltas):
+                contexto = RoundContext(
+                    is_first_round_on_course=not await self._history.has_played_course_before(
+                        vuelta.user_id, vuelta.golf_course_id, vuelta.match_id
+                    ),
+                    # Colgado del primer partido para que se publique una vez
+                    is_first_tournament=indice == 0 and estrena_torneo.get(user_id_raw, False),
+                    previous_best_differential=self._como_decimal(marca_previa),
+                    differential=record if indice == 0 else None,
+                )
+                logros = self._detector.detect(holes=vuelta.holes, context=contexto)
+                eventos.extend(self._a_eventos(logros, vuelta))
+
+        if not eventos:
+            return 0
+
+        async with self._social_uow:
+            await self._social_uow.activity_events.add_many(eventos)
+
+        return len(eventos)
+
+    async def _leer_vueltas(
+        self, competition_id_raw: str
+    ) -> tuple[dict[str, list[_TournamentRound]], dict[str, bool]]:
+        """
+        Las vueltas publicables del torneo, agrupadas por jugador, y quien
+        estrena torneo con este.
+        """
+        vueltas: dict[str, list[_TournamentRound]] = {}
+        estrena_torneo: dict[str, bool] = {}
+
+        async with self._competition_uow, self._golf_course_uow, self._user_uow:
+            competition_id = CompetitionId(competition_id_raw)
+            competition = await self._competition_uow.competitions.find_by_id(competition_id)
+            if competition is None or competition.status != CompetitionStatus.COMPLETED:
+                return {}, {}
+
+            enrollments = await self._competition_uow.enrollments.find_by_competition(
+                competition_id
+            )
+            courses: dict = {}
+            rounds: dict = {}
+
+            for enrollment in enrollments:
+                user = await self._user_uow.users.find_by_id(enrollment.user_id)
+                if user is None or not user.share_activity:
+                    continue
+
+                partidos = await self._competition_uow.matches.find_completed_for_player(
+                    enrollment.user_id, limit=MAX_HISTORY_LOOKUP
+                )
+
+                del_torneo = []
+                otros_torneos = set()
+                for partido in partidos:
+                    if partido.round_id not in rounds:
+                        rounds[partido.round_id] = (
+                            await self._competition_uow.rounds.find_by_id(partido.round_id)
+                        )
+                    ronda = rounds[partido.round_id]
+                    if ronda is None:
+                        continue
+                    if ronda.competition_id == competition_id:
+                        del_torneo.append((partido, ronda))
+                    else:
+                        otros_torneos.add(str(ronda.competition_id.value))
+
+                if not del_torneo:
+                    continue
+
+                user_id_raw = str(enrollment.user_id.value)
+                estrena_torneo[user_id_raw] = not otros_torneos
+
+                for partido, ronda in del_torneo:
+                    vuelta = await self._a_vuelta(partido, ronda, enrollment.user_id, courses)
+                    if vuelta is not None:
+                        vueltas.setdefault(user_id_raw, []).append(vuelta)
+
+        return vueltas, estrena_torneo
+
+    async def _a_vuelta(
+        self, partido, ronda, user_id: UserId, courses: dict
+    ) -> _TournamentRound | None:
+        """
+        La vuelta de un jugador en un partido, o None si su tarjeta no cuenta.
+
+        `courses` cachea los campos entre partidos: un torneo entero suele
+        jugarse en uno o dos, y sin esto se consultaria el mismo por cada
+        partido de cada jugador.
+        """
+        if ronda.golf_course_id not in courses:
+            courses[ronda.golf_course_id] = await self._golf_course_uow.golf_courses.find_by_id(
+                ronda.golf_course_id
+            )
+        course = courses[ronda.golf_course_id]
+        if course is None:
+            return None
+
+        hole_scores = await self._competition_uow.hole_scores.find_by_match_and_player(
+            partido.id, user_id
+        )
+        scores_by_hole = {
+            hole_score.hole_number: hole_score.own_score
+            for hole_score in hole_scores
+            if hole_score.own_score is not None
+        }
+        jugados = countable_holes(scores_by_hole, course)
+        if jugados is None:
+            return None
+
+        return _TournamentRound(
+            user_id=user_id,
+            match_id=str(partido.id.value),
+            golf_course_id=str(ronda.golf_course_id.value),
+            occurred_at=datetime.combine(ronda.round_date, datetime.min.time()),
+            holes=[
+                PlayedHole(
+                    number=hole.number,
+                    par=hole.par,
+                    strokes=scores_by_hole[hole.number],
+                )
+                for hole in jugados
+            ],
+        )
+
+    async def _diferencial_si_es_record(
+        self, user_id: UserId, best_before: float | None
+    ) -> Decimal | None:
+        """El diferencial del torneo, solo cuando ha batido el record."""
+        if best_before is None:
+            return None
+
+        ahora = await self._differentials.best_differential(user_id)
+        if ahora is None or ahora >= best_before:
+            return None
+        return self._como_decimal(ahora)
+
+    @staticmethod
+    def _como_decimal(value: float | None) -> Decimal | None:
+        return None if value is None else Decimal(str(value))
+
+    def _a_eventos(
+        self, logros: list[DetectedAchievement], vuelta: _TournamentRound
+    ) -> list[ActivityEvent]:
+        return [
+            ActivityEvent.create(
+                user_id=vuelta.user_id,
+                type=logro.type,
+                occurred_at=vuelta.occurred_at,
+                source_match_id=vuelta.match_id,
+                payload=self._payload(logro, vuelta),
+            )
+            for logro in logros
+        ]
+
+    @staticmethod
+    def _payload(logro: DetectedAchievement, vuelta: _TournamentRound) -> dict:
+        payload: dict = {
+            "golf_course_id": vuelta.golf_course_id,
+            "holes_played": len(vuelta.holes),
+            # Distingue en el feed una vuelta de torneo de una entre amigos
+            "from_tournament": True,
+        }
+        if logro.count > 1:
+            payload["count"] = logro.count
+        if logro.holes:
+            payload["holes"] = list(logro.holes)
+        if logro.detail:
+            payload.update(logro.detail)
+        if logro.type == ActivityEventType.FIRST_TOURNAMENT:
+            payload.pop("holes", None)
+        return payload

--- a/src/modules/social/application/use_cases/set_activity_sharing_use_case.py
+++ b/src/modules/social/application/use_cases/set_activity_sharing_use_case.py
@@ -1,0 +1,59 @@
+"""Caso de Uso: Encender o apagar la publicacion de logros."""
+
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SetActivitySharingUseCase:
+    """
+    El jugador decide si sus logros se publican en el feed de sus amigos.
+
+    **Apagarlo retira lo ya publicado**, no solo deja de generar. Es la parte que
+    importa: quien apaga esto casi siempre quiere que lo suyo deje de verse, no
+    que se congele donde estaba. Dejar el historial visible seria cumplir la
+    letra de la peticion y no lo que se estaba pidiendo.
+
+    Volver a encenderlo **no recupera nada**: los eventos borrados no vuelven, y
+    el feed se llena otra vez con las vueltas que se jueguen a partir de ahi.
+    Guardar lo retirado por si acaso significaria conservar justo lo que el
+    jugador pidio quitar.
+    """
+
+    def __init__(
+        self,
+        user_uow: UserUnitOfWorkInterface,
+        social_uow: SocialUnitOfWorkInterface,
+    ):
+        self._user_uow = user_uow
+        self._social_uow = social_uow
+
+    async def execute(self, user_id_raw: str, enabled: bool) -> int:
+        """
+        Cambia el interruptor y devuelve cuantos eventos se retiraron.
+
+        Devuelve 0 al encender: encender no borra nada.
+        """
+        user_id = UserId(user_id_raw)
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            if user is None:
+                raise UserNotFoundError(f"User not found: {user_id_raw}")
+
+            user.set_activity_sharing(enabled)
+            await self._user_uow.users.save(user)
+
+        if enabled:
+            return 0
+
+        # Se borra despues de guardar el interruptor: si fallara entre medias,
+        # es preferible haber dejado de publicar con el historial aun visible
+        # que seguir publicando con el historial ya borrado
+        async with self._social_uow:
+            return await self._social_uow.activity_events.delete_for_user(user_id)

--- a/src/modules/social/domain/entities/activity_event.py
+++ b/src/modules/social/domain/entities/activity_event.py
@@ -1,0 +1,107 @@
+"""Entidad: ActivityEvent — un logro publicado en el feed de los amigos."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class ActivityEvent:
+    """
+    Algo que un jugador ha conseguido y que sus amigos verán.
+
+    **La partida de la que sale se guarda** (`source_match_id`) por dos razones:
+    para poder enlazar al detalle desde el feed, y para no duplicar. Completar
+    una partida dos veces —o reprocesarla— no debe llenar el feed de entradas
+    repetidas, así que la pareja `(source_match_id, type)` es única por jugador.
+
+    El evento es inmutable: un logro ocurrió o no ocurrió. Si deja de ser
+    publicable (el jugador apaga la publicación, se borra la partida) se borra;
+    no se edita.
+    """
+
+    def __init__(
+        self,
+        id: UUID,
+        user_id: UserId,
+        type: ActivityEventType,
+        occurred_at: datetime,
+        payload: dict | None = None,
+        source_match_id: str | None = None,
+    ):
+        if not isinstance(user_id, UserId):
+            raise TypeError("user_id must be a UserId")
+        if not isinstance(type, ActivityEventType):
+            raise TypeError("type must be an ActivityEventType")
+
+        self._id = id
+        self._user_id = user_id
+        self._type = type
+        self._occurred_at = occurred_at
+        self._payload = dict(payload or {})
+        self._source_match_id = source_match_id
+
+    # === Factory Methods ===
+
+    @classmethod
+    def create(
+        cls,
+        user_id: UserId,
+        type: ActivityEventType,
+        occurred_at: datetime,
+        payload: dict | None = None,
+        source_match_id: str | None = None,
+    ) -> "ActivityEvent":
+        return cls(
+            id=uuid4(),
+            user_id=user_id,
+            type=type,
+            occurred_at=occurred_at,
+            payload=payload,
+            source_match_id=source_match_id,
+        )
+
+    @classmethod
+    def reconstruct(cls, **props) -> "ActivityEvent":
+        return cls(**props)
+
+    # === Getters ===
+
+    @property
+    def id(self) -> UUID:
+        return self._id
+
+    @property
+    def user_id(self) -> UserId:
+        return self._user_id
+
+    @property
+    def type(self) -> ActivityEventType:
+        return self._type
+
+    @property
+    def occurred_at(self) -> datetime:
+        return self._occurred_at
+
+    @property
+    def payload(self) -> dict:
+        return dict(self._payload)
+
+    @property
+    def source_match_id(self) -> str | None:
+        return self._source_match_id
+
+    # === Business Rules ===
+
+    def is_from(self, match_id: str) -> bool:
+        return self._source_match_id == match_id
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ActivityEvent) and self._id == other._id
+
+    def __hash__(self) -> int:
+        return hash(self._id)
+
+    def __repr__(self) -> str:
+        return f"<ActivityEvent {self._type.value} user={self._user_id.value}>"

--- a/src/modules/social/domain/entities/activity_event.py
+++ b/src/modules/social/domain/entities/activity_event.py
@@ -11,10 +11,18 @@ class ActivityEvent:
     """
     Algo que un jugador ha conseguido y que sus amigos verán.
 
-    **La partida de la que sale se guarda** (`source_match_id`) por dos razones:
-    para poder enlazar al detalle desde el feed, y para no duplicar. Completar
-    una partida dos veces —o reprocesarla— no debe llenar el feed de entradas
-    repetidas, así que la pareja `(source_match_id, type)` es única por jugador.
+    **La partida de la que sale es obligatoria** (`source_match_id`) por dos
+    razones: para poder enlazar al detalle desde el feed, y para no duplicar.
+    Completar una partida dos veces —o reprocesarla— no debe llenar el feed de
+    entradas repetidas, así que la pareja `(source_match_id, type)` es única por
+    jugador.
+
+    Que sea obligatoria no es un detalle: en Postgres un NULL no es igual a otro
+    NULL, así que un evento sin partida se escaparía de esa clave única y podría
+    publicarse tantas veces como se reprocesara. Todos los logros nacen de una
+    vuelta terminada —incluidos `NEW_COURSE`, `FIRST_TOURNAMENT` y
+    `PERSONAL_BEST`, que también salen de una partida concreta— así que exigirla
+    no deja fuera ningún caso real y sí cierra ese hueco.
 
     El evento es inmutable: un logro ocurrió o no ocurrió. Si deja de ser
     publicable (el jugador apaga la publicación, se borra la partida) se borra;
@@ -27,13 +35,15 @@ class ActivityEvent:
         user_id: UserId,
         type: ActivityEventType,
         occurred_at: datetime,
+        source_match_id: str,
         payload: dict | None = None,
-        source_match_id: str | None = None,
     ):
         if not isinstance(user_id, UserId):
             raise TypeError("user_id must be a UserId")
         if not isinstance(type, ActivityEventType):
             raise TypeError("type must be an ActivityEventType")
+        if not source_match_id:
+            raise ValueError("source_match_id is required: every event comes from a round")
 
         self._id = id
         self._user_id = user_id
@@ -50,8 +60,8 @@ class ActivityEvent:
         user_id: UserId,
         type: ActivityEventType,
         occurred_at: datetime,
+        source_match_id: str,
         payload: dict | None = None,
-        source_match_id: str | None = None,
     ) -> "ActivityEvent":
         return cls(
             id=uuid4(),
@@ -89,7 +99,7 @@ class ActivityEvent:
         return dict(self._payload)
 
     @property
-    def source_match_id(self) -> str | None:
+    def source_match_id(self) -> str:
         return self._source_match_id
 
     # === Business Rules ===

--- a/src/modules/social/domain/repositories/activity_event_repository_interface.py
+++ b/src/modules/social/domain/repositories/activity_event_repository_interface.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime
+from uuid import UUID
 
 from src.modules.social.domain.entities.activity_event import ActivityEvent
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -25,14 +26,23 @@ class ActivityEventRepositoryInterface(ABC):
 
     @abstractmethod
     async def find_for_users(
-        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+        self,
+        user_ids: list[UserId],
+        limit: int,
+        before: datetime | None = None,
+        before_id: UUID | None = None,
     ) -> list[ActivityEvent]:
         """
         Eventos de un conjunto de jugadores, del más reciente al más antiguo.
 
-        `before` pagina por fecha y no por número de página: el feed crece por
+        Se pagina por cursor y no por número de página: el feed crece por
         arriba, así que un desplazamiento numérico repetiría entradas cada vez
         que alguien publica algo mientras se navega.
+
+        El cursor son **las dos cosas**, `before` y `before_id`, porque la fecha
+        sola no es única: todos los eventos de una misma vuelta comparten
+        `occurred_at`. Paginar solo por fecha se dejaría fuera los que aún no se
+        han enseñado de esa vuelta.
         """
 
     @abstractmethod

--- a/src/modules/social/domain/repositories/activity_event_repository_interface.py
+++ b/src/modules/social/domain/repositories/activity_event_repository_interface.py
@@ -1,0 +1,53 @@
+"""Interfaz del repositorio de eventos de actividad."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class ActivityEventRepositoryInterface(ABC):
+    """
+    Acceso a los eventos publicados.
+
+    El feed se resuelve **leyendo**, no escribiendo: al pedirlo se consultan los
+    eventos de los amigos de quien pregunta. No se crea una copia por amigo al
+    publicar. Con el tamaño de esta aplicación es la opción correcta y con
+    diferencia la más simple — el reparto en escritura solo compensa con miles
+    de seguidores por cuenta, y a cambio trae duplicación y reconciliación cada
+    vez que alguien acepta o deshace una amistad.
+    """
+
+    @abstractmethod
+    async def add_many(self, events: list[ActivityEvent]) -> None:
+        """Publica varios eventos de una vez (los de una misma vuelta)."""
+
+    @abstractmethod
+    async def find_for_users(
+        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+    ) -> list[ActivityEvent]:
+        """
+        Eventos de un conjunto de jugadores, del más reciente al más antiguo.
+
+        `before` pagina por fecha y no por número de página: el feed crece por
+        arriba, así que un desplazamiento numérico repetiría entradas cada vez
+        que alguien publica algo mientras se navega.
+        """
+
+    @abstractmethod
+    async def count_for_users_since(self, user_ids: list[UserId], since: datetime) -> int:
+        """Cuántos eventos hay más nuevos que una fecha. Alimenta el aviso."""
+
+    @abstractmethod
+    async def exists_for_match(self, match_id: str) -> bool:
+        """Si esa partida ya generó eventos, para no publicarlos dos veces."""
+
+    @abstractmethod
+    async def delete_for_user(self, user_id: UserId) -> int:
+        """
+        Borra todo lo publicado por un jugador.
+
+        Hace falta al apagar la publicación de actividad: lo que ya se publicó
+        debe desaparecer, no solo dejar de crecer.
+        """

--- a/src/modules/social/domain/repositories/social_unit_of_work_interface.py
+++ b/src/modules/social/domain/repositories/social_unit_of_work_interface.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 
 from src.shared.domain.repositories.unit_of_work_interface import UnitOfWorkInterface
 
+from .activity_event_repository_interface import ActivityEventRepositoryInterface
 from .friendship_repository_interface import FriendshipRepositoryInterface
 
 
@@ -15,12 +16,18 @@ class SocialUnitOfWorkInterface(UnitOfWorkInterface):
     """
     Interfaz especifica para el Unit of Work del modulo Social.
 
-    Proporciona acceso coordinado al repositorio de amistades, manteniendo
-    consistencia transaccional.
+    Proporciona acceso coordinado a los repositorios de amistades y de eventos
+    de actividad, manteniendo consistencia transaccional.
     """
 
     @property
     @abstractmethod
     def friendships(self) -> FriendshipRepositoryInterface:
         """Acceso al repositorio de amistades."""
+        pass
+
+    @property
+    @abstractmethod
+    def activity_events(self) -> ActivityEventRepositoryInterface:
+        """Acceso al repositorio de eventos de actividad."""
         pass

--- a/src/modules/social/domain/services/achievement_detector.py
+++ b/src/modules/social/domain/services/achievement_detector.py
@@ -1,0 +1,147 @@
+"""
+Domain Service: AchievementDetector.
+
+Decide qué merece publicarse de una vuelta ya terminada. Puro, sin IO.
+
+Aquí vive la única regla que gobierna el feed: **se publican logros, no
+actividad**. Nada de lo que salga de aquí puede delatar una vuelta mala, porque
+un feed que publica los días malos empuja a no anotarlos, y las tarjetas sin
+terminar ya sesgan las estadísticas de por sí (BE #173).
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+
+# Golpes bajo par que definen cada logro por hoyo
+BIRDIE_UNDER_PAR = 1
+EAGLE_UNDER_PAR = 2
+HOLE_IN_ONE_STROKES = 1
+
+
+@dataclass(frozen=True)
+class PlayedHole:
+    """Un hoyo jugado, con lo justo para juzgarlo."""
+
+    number: int
+    par: int
+    strokes: int
+
+
+@dataclass(frozen=True)
+class RoundContext:
+    """
+    Lo que hay que saber del pasado del jugador para juzgar esta vuelta.
+
+    Se pasa ya resuelto en lugar de dejar que el detector consulte nada: así
+    sigue siendo puro y se puede probar sin base de datos.
+    """
+
+    is_first_round_on_course: bool = False
+    is_first_tournament: bool = False
+    previous_best_differential: Decimal | None = None
+    differential: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class DetectedAchievement:
+    """
+    Un logro listo para publicarse.
+
+    `count` agrupa los de un mismo tipo dentro de la vuelta: cuatro birdies son
+    una entrada que dice cuatro, no cuatro entradas seguidas empujándose unas a
+    otras en el feed de los amigos.
+    """
+
+    type: ActivityEventType
+    count: int = 1
+    holes: tuple[int, ...] = ()
+    detail: dict | None = None
+
+
+class AchievementDetector:
+    """Qué merece contarse de una vuelta."""
+
+    def detect(
+        self, holes: list[PlayedHole], context: RoundContext | None = None
+    ) -> list[DetectedAchievement]:
+        """
+        Los logros de una vuelta, agrupados y sin solaparse entre sí.
+
+        Cada hoyo aporta **como mucho un logro, el mayor**: un hoyo en uno en un
+        par 4 es también un albatros y un eagle, pero contarlo tres veces sería
+        absurdo. El orden de preferencia es hoyo en uno, luego eagle o mejor, y
+        por último birdie.
+        """
+        context = context or RoundContext()
+        achievements: list[DetectedAchievement] = []
+
+        por_tipo: dict[ActivityEventType, list[int]] = {}
+        for hole in holes:
+            tipo = self._hole_achievement(hole)
+            if tipo is not None:
+                por_tipo.setdefault(tipo, []).append(hole.number)
+
+        # Del más raro al más común, que es como se leen en el feed
+        for tipo in (
+            ActivityEventType.HOLE_IN_ONE,
+            ActivityEventType.EAGLE_OR_BETTER,
+            ActivityEventType.BIRDIE,
+        ):
+            numeros = por_tipo.get(tipo)
+            if numeros:
+                achievements.append(
+                    DetectedAchievement(type=tipo, count=len(numeros), holes=tuple(numeros))
+                )
+
+        achievements.extend(self._round_achievements(context))
+        return achievements
+
+    @staticmethod
+    def _hole_achievement(hole: PlayedHole) -> ActivityEventType | None:
+        """El mayor logro de un hoyo, o None si no hubo ninguno."""
+        if hole.strokes <= 0 or hole.par <= 0:
+            return None
+
+        if hole.strokes == HOLE_IN_ONE_STROKES:
+            # Un hoyo en uno en un par 3 es además un eagle; se cuenta una vez
+            return ActivityEventType.HOLE_IN_ONE
+
+        under_par = hole.par - hole.strokes
+        if under_par >= EAGLE_UNDER_PAR:
+            return ActivityEventType.EAGLE_OR_BETTER
+        if under_par == BIRDIE_UNDER_PAR:
+            return ActivityEventType.BIRDIE
+        return None
+
+    @staticmethod
+    def _round_achievements(context: RoundContext) -> list[DetectedAchievement]:
+        """Los logros que dependen del pasado del jugador, no de un hoyo."""
+        achievements: list[DetectedAchievement] = []
+
+        if context.is_first_round_on_course:
+            achievements.append(DetectedAchievement(type=ActivityEventType.NEW_COURSE))
+
+        if context.is_first_tournament:
+            achievements.append(DetectedAchievement(type=ActivityEventType.FIRST_TOURNAMENT))
+
+        # Récord personal: hace falta un diferencial que batir y uno anterior con
+        # el que compararlo. La primera vuelta con diferencial no es un récord,
+        # es el punto de partida — anunciarla como récord sería vacío
+        if (
+            context.differential is not None
+            and context.previous_best_differential is not None
+            and context.differential < context.previous_best_differential
+        ):
+            achievements.append(
+                DetectedAchievement(
+                    type=ActivityEventType.PERSONAL_BEST,
+                    detail={
+                        "differential": str(context.differential),
+                        "previous_best": str(context.previous_best_differential),
+                    },
+                )
+            )
+
+        return achievements

--- a/src/modules/social/domain/value_objects/activity_event_type.py
+++ b/src/modules/social/domain/value_objects/activity_event_type.py
@@ -1,0 +1,33 @@
+"""Tipos de evento que se publican en el feed de los amigos."""
+
+from enum import Enum
+
+
+class ActivityEventType(str, Enum):
+    """
+    Lo que se publica en el feed.
+
+    **Son logros, no actividad.** La diferencia no es de matiz: un birdie
+    apetece enseñarlo, y "jugó 108 golpes el martes" no. Publicar lo segundo
+    empujaría a la gente a no anotar sus vueltas malas, que es justo el sesgo
+    que las estadísticas ya sufren (BE #173) y que no conviene alimentar desde
+    otro sitio.
+
+    De ahí que aquí no haya ningún `ROUND_PLAYED` ni nada que delate una vuelta
+    mala. Todo lo que entre en esta lista tiene que ser algo que el propio
+    jugador enseñaría.
+    """
+
+    HOLE_IN_ONE = "HOLE_IN_ONE"
+    EAGLE_OR_BETTER = "EAGLE_OR_BETTER"
+    BIRDIE = "BIRDIE"
+    NEW_COURSE = "NEW_COURSE"
+    PERSONAL_BEST = "PERSONAL_BEST"
+    FIRST_TOURNAMENT = "FIRST_TOURNAMENT"
+
+    @classmethod
+    def from_string(cls, value: str) -> "ActivityEventType":
+        try:
+            return cls(value)
+        except ValueError as error:
+            raise ValueError(f"Unknown activity event type: {value}") from error

--- a/src/modules/social/infrastructure/adapters/player_course_history_adapter.py
+++ b/src/modules/social/infrastructure/adapters/player_course_history_adapter.py
@@ -1,0 +1,75 @@
+"""Adaptador: el historial de campos sale de las partidas rapidas y los torneos."""
+
+from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
+    CompetitionUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
+    QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# Cuantas vueltas del jugador se miran hacia atras. Quien tenga mas historia que
+# esto ya no estrena nada que merezca contarse.
+MAX_HISTORY_LOOKUP = 200
+
+
+class PlayerCourseHistoryAdapter(PlayerCourseHistoryInterface):
+    """
+    Junta las dos fuentes de vueltas para decidir si un campo es nuevo.
+
+    Un campo se estrena una sola vez en la vida del jugador, y da igual si fue
+    jugando con amigos o en un torneo. Preguntar solo a las partidas rapidas
+    haria que un campo estrenado en competicion volviera a anunciarse.
+    """
+
+    def __init__(
+        self,
+        quick_match_uow: QuickMatchUnitOfWorkInterface,
+        competition_uow: CompetitionUnitOfWorkInterface,
+    ):
+        self._quick_match_uow = quick_match_uow
+        self._competition_uow = competition_uow
+
+    async def has_played_course_before(
+        self, user_id: UserId, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        if await self._jugo_en_partida_rapida(user_id, golf_course_id, excluding_match_id):
+            return True
+        return await self._jugo_en_torneo(user_id, golf_course_id, excluding_match_id)
+
+    async def _jugo_en_partida_rapida(
+        self, user_id: UserId, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        async with self._quick_match_uow:
+            partidas = await self._quick_match_uow.quick_matches.list_for_user(
+                user_id, status=QuickMatchStatus.COMPLETED, limit=MAX_HISTORY_LOOKUP
+            )
+        return any(
+            str(partida.id.value) != excluding_match_id
+            and str(partida.golf_course_id.value) == golf_course_id
+            for partida in partidas
+        )
+
+    async def _jugo_en_torneo(
+        self, user_id: UserId, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        async with self._competition_uow:
+            partidos = await self._competition_uow.matches.find_completed_for_player(
+                user_id, limit=MAX_HISTORY_LOOKUP
+            )
+            rondas: dict = {}
+            for partido in partidos:
+                if str(partido.id.value) == excluding_match_id:
+                    continue
+                if partido.round_id not in rondas:
+                    rondas[partido.round_id] = await self._competition_uow.rounds.find_by_id(
+                        partido.round_id
+                    )
+                ronda = rondas[partido.round_id]
+                if ronda is not None and str(ronda.golf_course_id.value) == golf_course_id:
+                    return True
+        return False

--- a/src/modules/social/infrastructure/adapters/player_differentials_adapter.py
+++ b/src/modules/social/infrastructure/adapters/player_differentials_adapter.py
@@ -1,0 +1,28 @@
+"""Adaptador: el mejor diferencial sale del modulo de estadisticas."""
+
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.user.application.use_cases.get_player_stats_use_case import (
+    GetPlayerStatsUseCase,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class StatsPlayerDifferentialsAdapter(PlayerDifferentialsInterface):
+    """
+    Implementa el puerto delegando en las estadisticas del jugador (BE #167).
+
+    El diferencial no se recalcula aqui: el WHS ya esta implementado una vez, en
+    `GetPlayerStatsUseCase`, y tener una segunda implementacion solo para el feed
+    garantizaria que las dos se separaran con el tiempo. El adaptador vive en
+    infraestructura precisamente para que el caso de uso del feed no sepa de que
+    modulo sale el numero.
+    """
+
+    def __init__(self, stats_use_case: GetPlayerStatsUseCase):
+        self._stats = stats_use_case
+
+    async def best_differential(self, user_id: UserId) -> float | None:
+        stats = await self._stats.execute(user_id)
+        return stats.best_differential

--- a/src/modules/social/infrastructure/adapters/quick_match_achievements_publisher.py
+++ b/src/modules/social/infrastructure/adapters/quick_match_achievements_publisher.py
@@ -1,0 +1,45 @@
+"""Adaptador: `quick_match` publica sus logros a traves del modulo social."""
+
+from src.modules.quick_match.application.ports.round_achievements_publisher_interface import (
+    RoundAchievementsPublisherInterface,
+)
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.application.use_cases.publish_round_achievements_use_case import (
+    PublishRoundAchievementsUseCase,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class QuickMatchAchievementsPublisher(RoundAchievementsPublisherInterface):
+    """
+    Une los dos modulos sin que ninguno importe al otro.
+
+    `quick_match` conoce solo su puerto; `social` conoce solo su caso de uso.
+    Este adaptador vive en infraestructura, que es donde el proyecto permite
+    conocer ambos lados.
+    """
+
+    def __init__(
+        self,
+        publish_use_case: PublishRoundAchievementsUseCase,
+        differentials: PlayerDifferentialsInterface,
+    ):
+        self._publish = publish_use_case
+        self._differentials = differentials
+
+    async def capture_best_differentials(
+        self, user_ids: list[UserId]
+    ) -> dict[str, float | None]:
+        return {
+            str(user_id.value): await self._differentials.best_differential(user_id)
+            for user_id in user_ids
+        }
+
+    async def publish(
+        self, quick_match_id: str, best_differential_before: dict[str, float | None]
+    ) -> int:
+        return await self._publish.execute(
+            quick_match_id, best_differential_before=best_differential_before
+        )

--- a/src/modules/social/infrastructure/adapters/tournament_achievements_publisher.py
+++ b/src/modules/social/infrastructure/adapters/tournament_achievements_publisher.py
@@ -1,0 +1,45 @@
+"""Adaptador: `competition` publica sus logros a traves del modulo social."""
+
+from src.modules.competition.application.ports.tournament_achievements_publisher_interface import (
+    TournamentAchievementsPublisherInterface,
+)
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.application.use_cases.publish_tournament_achievements_use_case import (
+    PublishTournamentAchievementsUseCase,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class TournamentAchievementsPublisher(TournamentAchievementsPublisherInterface):
+    """
+    Une `competition` con el feed sin que ninguno importe al otro.
+
+    Mismo reparto que en las partidas rapidas: el modulo que cierra la vuelta
+    conoce solo su puerto, y el adaptador —que vive en infraestructura— es el
+    unico que ve los dos lados.
+    """
+
+    def __init__(
+        self,
+        publish_use_case: PublishTournamentAchievementsUseCase,
+        differentials: PlayerDifferentialsInterface,
+    ):
+        self._publish = publish_use_case
+        self._differentials = differentials
+
+    async def capture_best_differentials(
+        self, user_ids: list[UserId]
+    ) -> dict[str, float | None]:
+        return {
+            str(user_id.value): await self._differentials.best_differential(user_id)
+            for user_id in user_ids
+        }
+
+    async def publish(
+        self, competition_id: str, best_differential_before: dict[str, float | None]
+    ) -> int:
+        return await self._publish.execute(
+            competition_id, best_differential_before=best_differential_before
+        )

--- a/src/modules/social/infrastructure/api/v1/friend_routes.py
+++ b/src/modules/social/infrastructure/api/v1/friend_routes.py
@@ -18,8 +18,13 @@ from src.config.dependencies import (
     get_remove_friend_use_case,
     get_respond_friend_request_use_case,
     get_send_friend_request_use_case,
+    get_set_activity_sharing_use_case,
 )
 from src.config.rate_limit import limiter
+from src.modules.social.application.dto.activity_sharing_dto import (
+    ActivitySharingResponseDTO,
+    SetActivitySharingRequestDTO,
+)
 from src.modules.social.application.dto.friendship_dto import (
     FriendshipResponseDTO,
     PaginatedFriendshipResponseDTO,
@@ -44,6 +49,9 @@ from src.modules.social.application.use_cases.respond_friend_request_use_case im
 from src.modules.social.application.use_cases.send_friend_request_use_case import (
     SendFriendRequestUseCase,
 )
+from src.modules.social.application.use_cases.set_activity_sharing_use_case import (
+    SetActivitySharingUseCase,
+)
 from src.modules.social.domain.exceptions.social_violations import (
     BlockedUserViolation,
     DuplicateFriendRequestViolation,
@@ -51,6 +59,7 @@ from src.modules.social.domain.exceptions.social_violations import (
     SelfFriendRequestViolation,
 )
 from src.modules.user.application.dto.user_dto import UserResponseDTO
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -208,3 +217,29 @@ async def list_my_pending_requests(
     limit: int = Query(20, ge=1, le=100),
 ):
     return await use_case.execute(str(current_user.id), direction=direction, page=page, limit=limit)
+
+
+@router.put(
+    "/social/activity-sharing",
+    response_model=ActivitySharingResponseDTO,
+    summary="Turn achievement sharing on or off",
+    description=(
+        "Controls whether the player's achievements are published to their friends' feed. "
+        "Turning it off also removes what was already published; turning it back on does "
+        "not restore it."
+    ),
+)
+async def set_activity_sharing(
+    payload: SetActivitySharingRequestDTO,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: SetActivitySharingUseCase = Depends(get_set_activity_sharing_use_case),
+):
+    try:
+        removed = await use_case.execute(str(current_user.id), enabled=payload.enabled)
+
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    return ActivitySharingResponseDTO(
+        share_activity=payload.enabled, removed_events=removed
+    )

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_activity_event_repository.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_activity_event_repository.py
@@ -1,6 +1,7 @@
 """In-Memory Activity Event Repository para testing."""
 
 from datetime import datetime
+from uuid import UUID
 
 from src.modules.social.domain.entities.activity_event import ActivityEvent
 from src.modules.social.domain.repositories.activity_event_repository_interface import (
@@ -37,11 +38,25 @@ class InMemoryActivityEventRepository(ActivityEventRepositoryInterface):
         )
 
     async def find_for_users(
-        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+        self,
+        user_ids: list[UserId],
+        limit: int,
+        before: datetime | None = None,
+        before_id: UUID | None = None,
     ) -> list[ActivityEvent]:
         encontrados = [e for e in self._events if e.user_id in user_ids]
         if before is not None:
-            encontrados = [e for e in encontrados if e.occurred_at < before]
+            # El mismo par (fecha, id) que compara el SQL: sin el id, los eventos
+            # de una misma vuelta —que comparten `occurred_at`— se perderian al
+            # pasar de pagina
+            if before_id is not None:
+                encontrados = [
+                    e
+                    for e in encontrados
+                    if (e.occurred_at, str(e.id)) < (before, str(before_id))
+                ]
+            else:
+                encontrados = [e for e in encontrados if e.occurred_at < before]
 
         encontrados.sort(key=lambda e: (e.occurred_at, str(e.id)), reverse=True)
         return encontrados[:limit]

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_activity_event_repository.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_activity_event_repository.py
@@ -1,0 +1,60 @@
+"""In-Memory Activity Event Repository para testing."""
+
+from datetime import datetime
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.repositories.activity_event_repository_interface import (
+    ActivityEventRepositoryInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class InMemoryActivityEventRepository(ActivityEventRepositoryInterface):
+    """Implementacion en memoria del repositorio de eventos de actividad."""
+
+    def __init__(self):
+        self._events: list[ActivityEvent] = []
+
+    async def add_many(self, events: list[ActivityEvent]) -> None:
+        """
+        Publica los eventos nuevos y descarta los repetidos.
+
+        Reproduce la clave unica de la tabla —(user_id, source_match_id, type)—
+        porque es una regla del modelo, no un detalle de Postgres: si aqui se
+        aceptara el duplicado, los tests de los casos de uso pasarian con una
+        idempotencia que en produccion depende de la base de datos.
+        """
+        for event in events:
+            if not self._existe(event):
+                self._events.append(event)
+
+    def _existe(self, event: ActivityEvent) -> bool:
+        return any(
+            e.user_id == event.user_id
+            and e.source_match_id == event.source_match_id
+            and e.type == event.type
+            for e in self._events
+        )
+
+    async def find_for_users(
+        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+    ) -> list[ActivityEvent]:
+        encontrados = [e for e in self._events if e.user_id in user_ids]
+        if before is not None:
+            encontrados = [e for e in encontrados if e.occurred_at < before]
+
+        encontrados.sort(key=lambda e: (e.occurred_at, str(e.id)), reverse=True)
+        return encontrados[:limit]
+
+    async def count_for_users_since(self, user_ids: list[UserId], since: datetime) -> int:
+        return len(
+            [e for e in self._events if e.user_id in user_ids and e.occurred_at > since]
+        )
+
+    async def exists_for_match(self, match_id: str) -> bool:
+        return any(e.source_match_id == match_id for e in self._events)
+
+    async def delete_for_user(self, user_id: UserId) -> int:
+        antes = len(self._events)
+        self._events = [e for e in self._events if e.user_id != user_id]
+        return antes - len(self._events)

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_social_unit_of_work.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_social_unit_of_work.py
@@ -1,10 +1,16 @@
 """In-Memory Social Unit of Work para testing."""
 
+from src.modules.social.domain.repositories.activity_event_repository_interface import (
+    ActivityEventRepositoryInterface,
+)
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
+)
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_activity_event_repository import (
+    InMemoryActivityEventRepository,
 )
 from src.modules.social.infrastructure.persistence.in_memory.in_memory_friendship_repository import (
     InMemoryFriendshipRepository,
@@ -16,11 +22,16 @@ class InMemorySocialUnitOfWork(SocialUnitOfWorkInterface):
 
     def __init__(self):
         self._friendships = InMemoryFriendshipRepository()
+        self._activity_events = InMemoryActivityEventRepository()
         self.committed = False
 
     @property
     def friendships(self) -> FriendshipRepositoryInterface:
         return self._friendships
+
+    @property
+    def activity_events(self) -> ActivityEventRepositoryInterface:
+        return self._activity_events
 
     async def __aenter__(self):
         self.committed = False

--- a/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
+++ b/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
@@ -1,0 +1,88 @@
+"""
+SQLAlchemy Mapper para ActivityEvent (módulo Social).
+
+Tabla:
+- activity_events
+"""
+
+import uuid
+from typing import Any
+
+import sqlalchemy.types
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Table, UniqueConstraint
+from sqlalchemy.dialects import postgresql
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (
+    SocialUserIdType,
+)
+from src.shared.infrastructure.persistence.sqlalchemy.base import mapper_registry, metadata
+
+
+class ActivityEventTypeType(sqlalchemy.types.TypeDecorator[ActivityEventType]):
+    """TypeDecorator para el tipo de evento."""
+
+    impl = String(30)
+    cache_ok = True
+
+    def process_bind_param(self, value: ActivityEventType | None, dialect: Any) -> str | None:
+        if value is None:
+            return None
+        return value.value
+
+    def process_result_value(
+        self, value: str | None, dialect: Any
+    ) -> ActivityEventType | None:
+        if value is None:
+            return None
+        return ActivityEventType(value)
+
+
+activity_events_table = Table(
+    "activity_events",
+    metadata,
+    Column("id", postgresql.UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+    Column(
+        "user_id",
+        SocialUserIdType,
+        # Al borrar la cuenta desaparece lo que publicó: el feed no debe
+        # sobrevivir a su autor
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("type", ActivityEventTypeType, nullable=False),
+    Column("occurred_at", DateTime, nullable=False),
+    # El detalle de cada tipo (cuántos birdies, en qué hoyos, qué diferencial)
+    # vive en JSONB en vez de en columnas: cada tipo lleva lo suyo y añadir uno
+    # nuevo no debería exigir una migración
+    Column("payload", postgresql.JSONB, nullable=False, server_default="{}"),
+    # Sin FK: la partida puede ser rápida o de torneo, tablas distintas
+    Column("source_match_id", String(36), nullable=True),
+    # El feed siempre pregunta lo mismo: los eventos de estos jugadores, del más
+    # reciente al más antiguo
+    Index("ix_activity_events_user_occurred", "user_id", "occurred_at"),
+    # Reprocesar una partida no debe duplicar sus entradas
+    UniqueConstraint(
+        "user_id", "source_match_id", "type", name="uq_activity_events_match_type"
+    ),
+)
+
+
+def start_activity_event_mappers() -> None:
+    """
+    Inicia el mapeo de ActivityEvent. Idempotente.
+    """
+    if ActivityEvent not in mapper_registry.mappers:
+        mapper_registry.map_imperatively(
+            ActivityEvent,
+            activity_events_table,
+            properties={
+                "_id": activity_events_table.c.id,
+                "_user_id": activity_events_table.c.user_id,
+                "_type": activity_events_table.c.type,
+                "_occurred_at": activity_events_table.c.occurred_at,
+                "_payload": activity_events_table.c.payload,
+                "_source_match_id": activity_events_table.c.source_match_id,
+            },
+        )

--- a/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
+++ b/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
@@ -57,8 +57,10 @@ activity_events_table = Table(
     # vive en JSONB en vez de en columnas: cada tipo lleva lo suyo y añadir uno
     # nuevo no debería exigir una migración
     Column("payload", postgresql.JSONB, nullable=False, server_default="{}"),
-    # Sin FK: la partida puede ser rápida o de torneo, tablas distintas
-    Column("source_match_id", String(36), nullable=True),
+    # Sin FK: la partida puede ser rápida o de torneo, tablas distintas.
+    # NOT NULL a propósito: con NULL, la clave única de abajo dejaría de proteger
+    # (en Postgres un NULL nunca iguala a otro) y reprocesar duplicaría entradas
+    Column("source_match_id", String(36), nullable=False),
     # El feed siempre pregunta lo mismo: los eventos de estos jugadores, del más
     # reciente al más antiguo
     Index("ix_activity_events_user_occurred", "user_id", "occurred_at"),

--- a/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
+++ b/src/modules/social/infrastructure/persistence/mappers/activity_event_mapper.py
@@ -9,7 +9,16 @@ import uuid
 from typing import Any
 
 import sqlalchemy.types
-from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Table, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Table,
+    UniqueConstraint,
+    inspect,
+)
 from sqlalchemy.dialects import postgresql
 
 from src.modules.social.domain.entities.activity_event import ActivityEvent
@@ -64,6 +73,9 @@ activity_events_table = Table(
     # El feed siempre pregunta lo mismo: los eventos de estos jugadores, del más
     # reciente al más antiguo
     Index("ix_activity_events_user_occurred", "user_id", "occurred_at"),
+    # "Esta partida ya se publico?" filtra solo por partida, y el indice de
+    # arriba empieza por user_id, asi que no le sirve
+    Index("ix_activity_events_source_match", "source_match_id"),
     # Reprocesar una partida no debe duplicar sus entradas
     UniqueConstraint(
         "user_id", "source_match_id", "type", name="uq_activity_events_match_type"
@@ -73,9 +85,14 @@ activity_events_table = Table(
 
 def start_activity_event_mappers() -> None:
     """
-    Inicia el mapeo de ActivityEvent. Idempotente.
+    Inicia el mapeo de ActivityEvent. Idempotente de verdad.
+
+    Se pregunta con `inspect(..., raiseerr=False)` y no con
+    `ActivityEvent not in mapper_registry.mappers`: ese conjunto contiene
+    objetos `Mapper`, no clases, asi que la pregunta siempre da cierto y la
+    segunda llamada revienta con "already has a primary mapper defined".
     """
-    if ActivityEvent not in mapper_registry.mappers:
+    if inspect(ActivityEvent, raiseerr=False) is None:
         mapper_registry.map_imperatively(
             ActivityEvent,
             activity_events_table,

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/activity_event_repository.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/activity_event_repository.py
@@ -1,0 +1,111 @@
+"""Activity Event Repository - SQLAlchemy Implementation."""
+
+from datetime import datetime
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.repositories.activity_event_repository_interface import (
+    ActivityEventRepositoryInterface,
+)
+from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper import (
+    activity_events_table,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+UQ_ACTIVITY_EVENTS_MATCH_TYPE = "uq_activity_events_match_type"
+
+
+class SQLAlchemyActivityEventRepository(ActivityEventRepositoryInterface):
+    """Implementacion asincrona del repositorio de eventos de actividad."""
+
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def add_many(self, events: list[ActivityEvent]) -> None:
+        """
+        Publica los eventos de una vuelta, ignorando los que ya estuvieran.
+
+        Se inserta con ON CONFLICT DO NOTHING en lugar de comprobar antes y
+        escribir despues. La comprobacion previa deja una ventana entre el "no
+        existe" y el INSERT, y dos peticiones que terminan la misma partida a la
+        vez —el movil reintentando sobre una conexion mala es el caso tipico—
+        caerian dentro de ella. Dejar que decida la clave unica cierra esa
+        ventana sin bloquear nada.
+
+        No pasa por la sesion de la ORM a proposito: `session.add_all()` no
+        admite ON CONFLICT, y aqui el evento ya nace completo y no se vuelve a
+        tocar, asi que no se pierde nada por no tenerlo en el identity map.
+        """
+        if not events:
+            return
+
+        filas = [
+            {
+                "id": event.id,
+                "user_id": event.user_id,
+                "type": event.type,
+                "occurred_at": event.occurred_at,
+                "payload": event.payload,
+                "source_match_id": event.source_match_id,
+            }
+            for event in events
+        ]
+
+        stmt = pg_insert(activity_events_table).values(filas)
+        await self._session.execute(
+            stmt.on_conflict_do_nothing(constraint=UQ_ACTIVITY_EVENTS_MATCH_TYPE)
+        )
+
+    async def find_for_users(
+        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+    ) -> list[ActivityEvent]:
+        if not user_ids:
+            return []
+
+        stmt = select(ActivityEvent).where(ActivityEvent._user_id.in_(user_ids))
+        if before is not None:
+            stmt = stmt.where(ActivityEvent._occurred_at < before)
+
+        # El desempate por id evita que dos eventos de la misma vuelta —que
+        # comparten `occurred_at` al milisegundo— salgan en orden distinto en
+        # cada pagina y uno de ellos se repita o se pierda al paginar
+        stmt = stmt.order_by(
+            ActivityEvent._occurred_at.desc(), ActivityEvent._id.desc()
+        ).limit(limit)
+
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def count_for_users_since(self, user_ids: list[UserId], since: datetime) -> int:
+        if not user_ids:
+            return 0
+
+        stmt = (
+            select(func.count())
+            .select_from(activity_events_table)
+            .where(
+                activity_events_table.c.user_id.in_(user_ids),
+                activity_events_table.c.occurred_at > since,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def exists_for_match(self, match_id: str) -> bool:
+        stmt = (
+            select(activity_events_table.c.id)
+            .where(activity_events_table.c.source_match_id == match_id)
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.first() is not None
+
+    async def delete_for_user(self, user_id: UserId) -> int:
+        stmt = delete(activity_events_table).where(
+            activity_events_table.c.user_id == user_id
+        )
+        result = await self._session.execute(stmt)
+        return result.rowcount or 0

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/activity_event_repository.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/activity_event_repository.py
@@ -1,8 +1,9 @@
 """Activity Event Repository - SQLAlchemy Implementation."""
 
 from datetime import datetime
+from uuid import UUID
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -60,18 +61,31 @@ class SQLAlchemyActivityEventRepository(ActivityEventRepositoryInterface):
         )
 
     async def find_for_users(
-        self, user_ids: list[UserId], limit: int, before: datetime | None = None
+        self,
+        user_ids: list[UserId],
+        limit: int,
+        before: datetime | None = None,
+        before_id: UUID | None = None,
     ) -> list[ActivityEvent]:
         if not user_ids:
             return []
 
         stmt = select(ActivityEvent).where(ActivityEvent._user_id.in_(user_ids))
         if before is not None:
-            stmt = stmt.where(ActivityEvent._occurred_at < before)
+            # El cursor compara el par entero, no solo la fecha. Todos los
+            # eventos de una misma vuelta comparten `occurred_at` al
+            # microsegundo —salen del mismo `created_at`— asi que filtrar por
+            # fecha estricta tiraria tambien los que aun no se han enseñado, y
+            # filtrar por `<=` repetiria los ya vistos. El par (fecha, id) si es
+            # unico, y `id` desempata de forma estable entre paginas
+            if before_id is not None:
+                stmt = stmt.where(
+                    tuple_(ActivityEvent._occurred_at, ActivityEvent._id)
+                    < tuple_(before, before_id)
+                )
+            else:
+                stmt = stmt.where(ActivityEvent._occurred_at < before)
 
-        # El desempate por id evita que dos eventos de la misma vuelta —que
-        # comparten `occurred_at` al milisegundo— salgan en orden distinto en
-        # cada pagina y uno de ellos se repita o se pierda al paginar
         stmt = stmt.order_by(
             ActivityEvent._occurred_at.desc(), ActivityEvent._id.desc()
         ).limit(limit)

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
@@ -6,11 +6,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.social.domain.exceptions.social_violations import (
     DuplicateFriendshipViolation,
 )
+from src.modules.social.domain.repositories.activity_event_repository_interface import (
+    ActivityEventRepositoryInterface,
+)
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
+)
+from src.modules.social.infrastructure.persistence.sqlalchemy.activity_event_repository import (
+    SQLAlchemyActivityEventRepository,
 )
 from src.modules.social.infrastructure.persistence.sqlalchemy.friendship_repository import (
     SQLAlchemyFriendshipRepository,
@@ -25,10 +31,15 @@ class SQLAlchemySocialUnitOfWork(SocialUnitOfWorkInterface):
     def __init__(self, session: AsyncSession):
         self._session = session
         self._friendships = SQLAlchemyFriendshipRepository(session)
+        self._activity_events = SQLAlchemyActivityEventRepository(session)
 
     @property
     def friendships(self) -> FriendshipRepositoryInterface:
         return self._friendships
+
+    @property
+    def activity_events(self) -> ActivityEventRepositoryInterface:
+        return self._activity_events
 
     async def __aenter__(self):
         return self

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -29,6 +29,7 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.services.countable_round import HALF_ROUND_HOLES, countable_holes
 
 # Tope de partidas que se agregan para la media, por cada fuente. Sin él, una
 # cuenta con años de historial cargaría todos sus scores para calcular un único
@@ -39,11 +40,6 @@ MAX_ROUNDS_AGGREGATED = 100
 # Handicap sin recortar por formato: el allowance reparte ventaja dentro de una
 # partida, y el WHS mide la vuelta contra el campo, no contra los rivales.
 COURSE_HANDICAP_ALLOWANCE = 100
-
-# Media vuelta: los nueve de ida o los nueve de vuelta. Cuenta como vuelta
-# terminada, siempre que la partida esté cerrada, pero sus cifras se llevan a la
-# escala de 18 antes de mezclarlas con las demás.
-HALF_ROUND_HOLES = 9
 
 
 @dataclass(frozen=True)
@@ -426,29 +422,11 @@ class GetPlayerStatsUseCase:
         """
         Los hoyos que forman una vuelta computable, o None si no forman ninguna.
 
-        Vale la vuelta entera y vale media: los nueve de ida o los nueve de
-        vuelta, que es como se juega media vuelta de verdad. Lo que no vale es
-        una tarjeta a la que le falten hoyos sueltos, porque eso no es media
-        vuelta sino una vuelta abandonada — y son justo las malas las que se
-        abandonan.
-
-        De ahí que a la media vuelta se le exija tener **exactamente** sus
-        nueve: con diez anotados no hay ni vuelta entera ni mitad limpia.
+        La regla vive en `shared` porque el feed de logros (BE #175) tiene que
+        aplicar exactamente la misma: una tarjeta que no vale para la media
+        tampoco vale para presumir.
         """
-        holes = sorted(course.holes, key=lambda hole: hole.number)
-
-        def all_scored(subset: list) -> bool:
-            return all(hole.number in scores_by_hole for hole in subset)
-
-        if all_scored(holes):
-            return holes
-
-        if len(scores_by_hole) == HALF_ROUND_HOLES:
-            for half in (holes[:HALF_ROUND_HOLES], holes[HALF_ROUND_HOLES:]):
-                if len(half) == HALF_ROUND_HOLES and all_scored(half):
-                    return half
-
-        return None
+        return countable_holes(scores_by_hole, course)
 
     @staticmethod
     def _to_eighteen(value: int, holes_played: int) -> int:

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -104,6 +104,8 @@ class User:
         locked_until: datetime | None = None,
         is_admin: bool = False,
         is_active: bool = True,
+        feed_last_seen_at=None,
+        share_activity: bool = True,
         gender: Gender | None = None,
         avatar_source: AvatarSource = AvatarSource.NONE,
         avatar_preset_id: int | None = None,
@@ -129,6 +131,8 @@ class User:
         self._locked_until = locked_until
         self._is_admin = is_admin
         self._is_active = is_active
+        self._feed_last_seen_at = feed_last_seen_at
+        self._share_activity = share_activity
         self._gender = gender
         self._avatar_source = avatar_source
         self._avatar_preset_id = avatar_preset_id
@@ -210,6 +214,29 @@ class User:
     @property
     def is_active(self) -> bool:
         return self._is_active
+
+    @property
+    def feed_last_seen_at(self):
+        """Cuándo miró su feed por última vez. None si nunca lo ha abierto."""
+        return self._feed_last_seen_at
+
+    @property
+    def share_activity(self) -> bool:
+        """Si sus logros se publican en el feed de sus amigos."""
+        return self._share_activity
+
+    def mark_feed_as_seen(self, at) -> None:
+        """Deja de avisar de lo publicado hasta esta fecha."""
+        self._feed_last_seen_at = at
+
+    def set_activity_sharing(self, enabled: bool) -> None:
+        """
+        Enciende o apaga la publicación de logros.
+
+        Apagarlo no basta con dejar de generar eventos nuevos: lo ya publicado
+        también debe retirarse, y de eso se encarga el caso de uso.
+        """
+        self._share_activity = enabled
 
     @property
     def gender(self) -> Gender | None:

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -177,6 +177,10 @@ users_table = Table(
         "avatar_source", AvatarSourceDecorator(), nullable=False, default="NONE", server_default="NONE"
     ),
     Column("avatar_preset_id", Integer, nullable=True),
+    # Feed de actividad (BE #175): cuándo miró el feed por última vez, de donde
+    # sale el aviso de novedades, y si publica o no sus logros
+    Column("feed_last_seen_at", DateTime, nullable=True),
+    Column("share_activity", Boolean, nullable=False, default=True, server_default="true"),
     Column(
         "active_avatar_upload_id",
         ActiveAvatarUploadIdDecorator,
@@ -228,6 +232,8 @@ def start_mappers():
                 "_gender": users_table.c.gender,
                 "_avatar_source": users_table.c.avatar_source,
                 "_avatar_preset_id": users_table.c.avatar_preset_id,
+                "_feed_last_seen_at": users_table.c.feed_last_seen_at,
+                "_share_activity": users_table.c.share_activity,
                 "_active_avatar_upload_id": users_table.c.active_avatar_upload_id,
                 # Value Objects de una columna (Email, Password) → mapeamos la columna
                 # cruda a un atributo "_value" y componemos el VO real sobre el

--- a/src/shared/domain/services/countable_round.py
+++ b/src/shared/domain/services/countable_round.py
@@ -1,0 +1,40 @@
+"""
+Qué tarjeta cuenta como vuelta jugada.
+
+Vive en `shared` porque la regla la necesitan dos módulos que no deben depender
+uno del otro: las estadísticas (`user`, BE #174) y el feed de logros (`social`,
+BE #175). Y tiene que ser **la misma** en ambos: si una tarjeta no es fiable para
+la media del jugador, tampoco lo es para presumir de ella delante de sus amigos.
+"""
+
+# Media vuelta: los nueve de ida o los nueve de vuelta. Cuenta como vuelta
+# terminada, siempre que la partida esté cerrada.
+HALF_ROUND_HOLES = 9
+
+
+def countable_holes(scores_by_hole: dict, course) -> list | None:
+    """
+    Los hoyos que forman una vuelta computable, o None si no forman ninguna.
+
+    Vale la vuelta entera y vale media: los nueve de ida o los nueve de vuelta,
+    que es como se juega media vuelta de verdad. Lo que no vale es una tarjeta a
+    la que le falten hoyos sueltos, porque eso no es media vuelta sino una vuelta
+    abandonada — y son justo las malas las que se abandonan.
+
+    De ahí que a la media vuelta se le exija tener **exactamente** sus nueve: con
+    diez anotados no hay ni vuelta entera ni mitad limpia.
+    """
+    holes = sorted(course.holes, key=lambda hole: hole.number)
+
+    def all_scored(subset: list) -> bool:
+        return all(hole.number in scores_by_hole for hole in subset)
+
+    if all_scored(holes):
+        return holes
+
+    if len(scores_by_hole) == HALF_ROUND_HOLES:
+        for half in (holes[:HALF_ROUND_HOLES], holes[HALF_ROUND_HOLES:]):
+            if len(half) == HALF_ROUND_HOLES and all_scored(half):
+                return half
+
+    return None

--- a/src/shared/domain/services/countable_round.py
+++ b/src/shared/domain/services/countable_round.py
@@ -25,6 +25,12 @@ def countable_holes(scores_by_hole: dict, course) -> list | None:
     diez anotados no hay ni vuelta entera ni mitad limpia.
     """
     holes = sorted(course.holes, key=lambda hole: hole.number)
+    # Sin hoyos no hay vuelta que contar. Hay que decirlo explícitamente porque
+    # `all()` sobre una lista vacía es cierto, así que un campo sin hoyos
+    # devolvería `[]` — que no es `None` y pasaría por vuelta válida de cero
+    # hoyos ante quien pregunte `if holes is None`
+    if not holes:
+        return None
 
     def all_scored(subset: list) -> bool:
         return all(hole.number in scores_by_hole for hole in subset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,9 @@ from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapp
 from src.modules.quick_match.infrastructure.persistence.mappers.quick_match_mapper import (
     start_quick_match_mappers,
 )
+from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper import (
+    start_activity_event_mappers,
+)
 from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (
     start_social_mappers,
 )
@@ -139,6 +142,7 @@ def pytest_configure(config):
         start_competition_mappers()  # Competition module
         start_golf_course_mappers()  # Golf Course module
         start_social_mappers()  # Social module
+        start_activity_event_mappers()  # Activity feed (depends on User)
         start_quick_match_mappers()  # QuickMatch module
         # Marcamos que los mappers ya fueron iniciados para evitar reinicialización
         config.mappers_initialized = True
@@ -156,6 +160,7 @@ def pytest_configure(config):
             start_competition_mappers()
             start_golf_course_mappers()
             start_social_mappers()
+            start_activity_event_mappers()
             start_quick_match_mappers()
         except Exception:
             # Es probable que falle si otro proceso ya lo hizo, lo ignoramos.

--- a/tests/integration/api/v1/test_activity_sharing_endpoint.py
+++ b/tests/integration/api/v1/test_activity_sharing_endpoint.py
@@ -1,0 +1,68 @@
+"""
+Tests E2E del interruptor de publicacion de logros (BE #175).
+
+PUT /api/v1/social/activity-sharing
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_authenticated_user, set_auth_cookies
+
+
+class TestSetActivitySharing:
+    @pytest.mark.asyncio
+    async def test_turning_it_off_returns_the_new_state(self, client: AsyncClient):
+        """Given un jugador / When lo apaga / Then la respuesta lo confirma."""
+        user = await create_authenticated_user(
+            client, "sharing_off@test.com", "P@ssw0rd123!", "Share", "Off"
+        )
+        set_auth_cookies(client, user["cookies"])
+
+        response = await client.put(
+            "/api/v1/social/activity-sharing", json={"enabled": False}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["share_activity"] is False
+        # Sin nada publicado todavia, no hay nada que retirar
+        assert data["removed_events"] == 0
+
+    @pytest.mark.asyncio
+    async def test_turning_it_back_on_removes_nothing(self, client: AsyncClient):
+        """Given un jugador que lo enciende / When lo enciende / Then no borra nada."""
+        user = await create_authenticated_user(
+            client, "sharing_on@test.com", "P@ssw0rd123!", "Share", "On"
+        )
+        set_auth_cookies(client, user["cookies"])
+
+        response = await client.put(
+            "/api/v1/social/activity-sharing", json={"enabled": True}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"share_activity": True, "removed_events": 0}
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self, client: AsyncClient):
+        """Given nadie autenticado / When se llama / Then no se permite."""
+        client.cookies.clear()
+
+        response = await client.put(
+            "/api/v1/social/activity-sharing", json={"enabled": False}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_body_without_the_switch(self, client: AsyncClient):
+        """Given un cuerpo sin `enabled` / When se llama / Then se rechaza."""
+        user = await create_authenticated_user(
+            client, "sharing_bad@test.com", "P@ssw0rd123!", "Share", "Bad"
+        )
+        set_auth_cookies(client, user["cookies"])
+
+        response = await client.put("/api/v1/social/activity-sharing", json={})
+
+        assert response.status_code == 422

--- a/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_activity_event_repository.py
+++ b/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_activity_event_repository.py
@@ -1,0 +1,241 @@
+"""Tests de integracion del repositorio de eventos de actividad."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.infrastructure.persistence.sqlalchemy.activity_event_repository import (
+    SQLAlchemyActivityEventRepository,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.sqlalchemy.user_repository import (
+    SQLAlchemyUserRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+CUANDO = datetime(2026, 8, 10, 12, 0)
+
+
+async def _make_saved_user(db_session, email: str) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=email,
+        plain_password="ValidPassword123!",
+    )
+    await SQLAlchemyUserRepository(db_session).save(user)
+    await db_session.commit()
+    return user
+
+
+def _event(user, type_, match_id, occurred_at=CUANDO, payload=None) -> ActivityEvent:
+    return ActivityEvent.create(
+        user_id=user.id,
+        type=type_,
+        occurred_at=occurred_at,
+        source_match_id=match_id,
+        payload=payload,
+    )
+
+
+async def test_publica_los_eventos_de_una_vuelta(db_session):
+    """Given una vuelta con dos logros / When se publican / Then quedan guardados."""
+    user = await _make_saved_user(db_session, "feed-repo-1@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, "match-1", payload={"count": 2}),
+            _event(user, ActivityEventType.NEW_COURSE, "match-1"),
+        ]
+    )
+    await db_session.commit()
+
+    encontrados = await repository.find_for_users([user.id], limit=10)
+
+    assert len(encontrados) == 2
+    assert {e.type for e in encontrados} == {
+        ActivityEventType.BIRDIE,
+        ActivityEventType.NEW_COURSE,
+    }
+    birdie = next(e for e in encontrados if e.type == ActivityEventType.BIRDIE)
+    assert birdie.payload == {"count": 2}
+    assert birdie.source_match_id == "match-1"
+
+
+async def test_reprocesar_la_misma_vuelta_no_duplica(db_session):
+    """
+    Given una vuelta ya publicada / When se vuelve a procesar / Then no se
+    repite ninguna entrada en el feed.
+
+    Es el caso del movil reintentando sobre una conexion mala: la peticion llega
+    dos veces y el feed no debe enterarse.
+    """
+    user = await _make_saved_user(db_session, "feed-repo-2@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    logros = [
+        _event(user, ActivityEventType.BIRDIE, "match-1", payload={"count": 2}),
+        _event(user, ActivityEventType.EAGLE_OR_BETTER, "match-1"),
+    ]
+
+    await repository.add_many(logros)
+    await db_session.commit()
+    # Eventos nuevos (otro id) para el mismo logro: es lo que produciria un
+    # segundo procesado de la misma tarjeta
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, "match-1", payload={"count": 2}),
+            _event(user, ActivityEventType.EAGLE_OR_BETTER, "match-1"),
+        ]
+    )
+    await db_session.commit()
+
+    encontrados = await repository.find_for_users([user.id], limit=10)
+
+    assert len(encontrados) == 2
+
+
+async def test_el_mismo_logro_en_otra_partida_si_se_publica(db_session):
+    """Given dos vueltas con birdies / When se publican / Then hay dos entradas."""
+    user = await _make_saved_user(db_session, "feed-repo-3@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    await repository.add_many([_event(user, ActivityEventType.BIRDIE, "match-1")])
+    await repository.add_many([_event(user, ActivityEventType.BIRDIE, "match-2")])
+    await db_session.commit()
+
+    encontrados = await repository.find_for_users([user.id], limit=10)
+
+    assert len(encontrados) == 2
+
+
+async def test_el_feed_llega_del_mas_reciente_al_mas_antiguo(db_session):
+    """Given eventos de varios dias / When se pide el feed / Then van en orden."""
+    user = await _make_saved_user(db_session, "feed-repo-4@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, "match-viejo", CUANDO - timedelta(days=2)),
+            _event(user, ActivityEventType.BIRDIE, "match-nuevo", CUANDO),
+            _event(user, ActivityEventType.BIRDIE, "match-medio", CUANDO - timedelta(days=1)),
+        ]
+    )
+    await db_session.commit()
+
+    encontrados = await repository.find_for_users([user.id], limit=10)
+
+    assert [e.source_match_id for e in encontrados] == [
+        "match-nuevo",
+        "match-medio",
+        "match-viejo",
+    ]
+
+
+async def test_pagina_por_fecha_y_no_por_numero_de_pagina(db_session):
+    """Given un feed largo / When se pide lo anterior a una fecha / Then no repite."""
+    user = await _make_saved_user(db_session, "feed-repo-5@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, f"match-{i}", CUANDO - timedelta(days=i))
+            for i in range(5)
+        ]
+    )
+    await db_session.commit()
+
+    primera = await repository.find_for_users([user.id], limit=2)
+    segunda = await repository.find_for_users(
+        [user.id], limit=2, before=primera[-1].occurred_at
+    )
+
+    assert [e.source_match_id for e in primera] == ["match-0", "match-1"]
+    assert [e.source_match_id for e in segunda] == ["match-2", "match-3"]
+
+
+async def test_solo_devuelve_lo_de_los_jugadores_pedidos(db_session):
+    """Given dos jugadores / When se pide el feed de uno / Then no sale el otro."""
+    ana = await _make_saved_user(db_session, "feed-repo-6a@example.com")
+    luis = await _make_saved_user(db_session, "feed-repo-6b@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    await repository.add_many([_event(ana, ActivityEventType.BIRDIE, "match-ana")])
+    await repository.add_many([_event(luis, ActivityEventType.BIRDIE, "match-luis")])
+    await db_session.commit()
+
+    encontrados = await repository.find_for_users([ana.id], limit=10)
+
+    assert [e.source_match_id for e in encontrados] == ["match-ana"]
+
+
+async def test_sin_jugadores_no_consulta_nada(db_session):
+    """Given un jugador sin amigos / When pide el feed / Then llega vacio."""
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    assert await repository.find_for_users([], limit=10) == []
+    assert await repository.count_for_users_since([], since=CUANDO) == 0
+
+
+async def test_cuenta_lo_publicado_despues_de_una_fecha(db_session):
+    """Given eventos antes y despues / When se cuenta / Then solo los de despues."""
+    user = await _make_saved_user(db_session, "feed-repo-7@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, "match-antes", CUANDO - timedelta(days=1)),
+            _event(user, ActivityEventType.BIRDIE, "match-despues", CUANDO + timedelta(days=1)),
+        ]
+    )
+    await db_session.commit()
+
+    assert await repository.count_for_users_since([user.id], since=CUANDO) == 1
+
+
+async def test_sabe_si_una_partida_ya_se_publico(db_session):
+    """Given una partida publicada / When se pregunta / Then lo sabe."""
+    user = await _make_saved_user(db_session, "feed-repo-8@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    await repository.add_many([_event(user, ActivityEventType.BIRDIE, "match-1")])
+    await db_session.commit()
+
+    assert await repository.exists_for_match("match-1") is True
+    assert await repository.exists_for_match("match-2") is False
+
+
+async def test_borra_todo_lo_publicado_por_un_jugador(db_session):
+    """
+    Given dos jugadores con eventos / When uno apaga la publicacion / Then
+    desaparece lo suyo y lo del otro sigue.
+    """
+    ana = await _make_saved_user(db_session, "feed-repo-9a@example.com")
+    luis = await _make_saved_user(db_session, "feed-repo-9b@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    await repository.add_many(
+        [
+            _event(ana, ActivityEventType.BIRDIE, "match-1"),
+            _event(ana, ActivityEventType.NEW_COURSE, "match-1"),
+        ]
+    )
+    await repository.add_many([_event(luis, ActivityEventType.BIRDIE, "match-2")])
+    await db_session.commit()
+
+    borrados = await repository.delete_for_user(ana.id)
+    await db_session.commit()
+
+    assert borrados == 2
+    assert await repository.find_for_users([ana.id], limit=10) == []
+    assert len(await repository.find_for_users([luis.id], limit=10)) == 1
+
+
+async def test_publicar_una_lista_vacia_no_hace_nada(db_session):
+    """Given una vuelta sin logros / When se publica / Then no falla ni escribe."""
+    user = await _make_saved_user(db_session, "feed-repo-10@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+
+    await repository.add_many([])
+    await db_session.commit()
+
+    assert await repository.find_for_users([user.id], limit=10) == []

--- a/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_activity_event_repository.py
+++ b/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_activity_event_repository.py
@@ -149,11 +149,53 @@ async def test_pagina_por_fecha_y_no_por_numero_de_pagina(db_session):
 
     primera = await repository.find_for_users([user.id], limit=2)
     segunda = await repository.find_for_users(
-        [user.id], limit=2, before=primera[-1].occurred_at
+        [user.id],
+        limit=2,
+        before=primera[-1].occurred_at,
+        before_id=primera[-1].id,
     )
 
     assert [e.source_match_id for e in primera] == ["match-0", "match-1"]
     assert [e.source_match_id for e in segunda] == ["match-2", "match-3"]
+
+
+async def test_no_pierde_eventos_que_comparten_la_misma_fecha(db_session):
+    """
+    Given cuatro logros de la misma vuelta —misma `occurred_at` al microsegundo—
+    / When se pagina de dos en dos / Then salen los cuatro, cada uno una vez.
+
+    Es el caso normal, no un borde: todos los eventos de una vuelta se publican
+    con el mismo `occurred_at`. Paginando solo por fecha, la segunda pagina se
+    saltaria los que compartieran la del ultimo de la primera.
+    """
+    user = await _make_saved_user(db_session, "feed-repo-11@example.com")
+    repository = SQLAlchemyActivityEventRepository(db_session)
+    await repository.add_many(
+        [
+            _event(user, ActivityEventType.BIRDIE, "match-1"),
+            _event(user, ActivityEventType.EAGLE_OR_BETTER, "match-1"),
+            _event(user, ActivityEventType.NEW_COURSE, "match-1"),
+            _event(user, ActivityEventType.HOLE_IN_ONE, "match-1"),
+        ]
+    )
+    await db_session.commit()
+
+    vistos = []
+    cursor = None
+    while True:
+        pagina = await repository.find_for_users(
+            [user.id],
+            limit=2,
+            before=cursor.occurred_at if cursor else None,
+            before_id=cursor.id if cursor else None,
+        )
+        if not pagina:
+            break
+        vistos.extend(pagina)
+        cursor = pagina[-1]
+
+    assert len(vistos) == 4
+    assert len({e.id for e in vistos}) == 4
 
 
 async def test_solo_devuelve_lo_de_los_jugadores_pedidos(db_session):

--- a/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
@@ -1,0 +1,488 @@
+"""
+Tests de la publicacion de logros en el feed (BE #175).
+
+Lo que mas importa aqui: **se publican logros, no actividad**, y solo de vueltas
+que cuentan. Una tarjeta incompleta no llega al feed, igual que no llega a las
+estadisticas (BE #173/#174), y un jugador que apago la publicacion no aparece.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.in_memory.in_memory_golf_course_unit_of_work import (
+    InMemoryGolfCourseUnitOfWork,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
+from src.modules.quick_match.domain.value_objects.quick_match_hole_score_id import (
+    QuickMatchHoleScoreId,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
+from src.modules.quick_match.infrastructure.persistence.in_memory.in_memory_quick_match_unit_of_work import (
+    InMemoryQuickMatchUnitOfWork,
+)
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.application.use_cases.publish_round_achievements_use_case import (
+    PublishRoundAchievementsUseCase,
+)
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+pytestmark = pytest.mark.asyncio
+
+PAR = 4
+
+
+class _DifferentialsStub(PlayerDifferentialsInterface):
+    """El mejor diferencial de cada jugador, fijado por el test."""
+
+    def __init__(self, por_jugador: dict | None = None):
+        self._por_jugador = por_jugador or {}
+
+    async def best_differential(self, user_id):
+        return self._por_jugador.get(str(user_id.value))
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+@pytest.fixture
+def qm_uow():
+    return InMemoryQuickMatchUnitOfWork()
+
+
+@pytest.fixture
+def golf_course_uow():
+    return InMemoryGolfCourseUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+async def _create_user(user_uow, share_activity: bool = True) -> User:
+    user = User.create(
+        first_name="Test",
+        last_name="User",
+        email_str=f"feed_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    if not share_activity:
+        user.set_activity_sharing(False)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _create_course(golf_course_uow, creator_id, name: str = "Test Golf Club"):
+    """Campo de par 72: 18 hoyos de par 4."""
+    course = GolfCourse.create(
+        name=name,
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=[
+            Tee(
+                category=TeeCategory.AMATEUR,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+            ),
+            Tee(
+                category=TeeCategory.CHAMPIONSHIP,
+                gender=Gender.MALE,
+                identifier="White",
+                course_rating=72.0,
+                slope_rating=130,
+            ),
+        ],
+        holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+    )
+    course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(course)
+    return course
+
+
+async def _played_match(
+    qm_uow,
+    course,
+    user,
+    *,
+    scores_by_hole: dict | None = None,
+    others=(),
+    complete: bool = True,
+):
+    """Una partida rapida terminada con la vuelta anotada."""
+    match = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=user.id,
+        golf_course_id=course.id,
+        scoring_format=ScoringFormat.MEDAL,
+        creator_tee_category=TeeCategory.AMATEUR,
+        creator_tee_gender=Gender.MALE,
+    )
+    for participant in others:
+        match.add_participant(participant)
+
+    creator_participant_id = match.participants[0].participant_id
+    match.start(scorer_ids=[creator_participant_id])
+    if complete:
+        match.complete()
+
+    tarjeta = scores_by_hole or dict.fromkeys(range(1, 19), PAR)
+
+    async with qm_uow:
+        await qm_uow.quick_matches.add(match)
+        for participant in match.participants:
+            for hole_number, strokes in tarjeta.items():
+                await qm_uow.quick_match_hole_scores.add(
+                    QuickMatchHoleScore(
+                        id=QuickMatchHoleScoreId.generate(),
+                        quick_match_id=match.id,
+                        hole_number=hole_number,
+                        participant_id=participant.participant_id,
+                        score=strokes,
+                        recorded_by_participant_id=creator_participant_id,
+                    )
+                )
+        await qm_uow.commit()
+
+    return match
+
+
+def _use_case(social_uow, qm_uow, golf_course_uow, user_uow, differentials=None):
+    return PublishRoundAchievementsUseCase(
+        social_uow=social_uow,
+        quick_match_uow=qm_uow,
+        golf_course_uow=golf_course_uow,
+        user_uow=user_uow,
+        differentials=differentials or _DifferentialsStub(),
+    )
+
+
+async def _feed_de(social_uow, user):
+    async with social_uow:
+        return await social_uow.activity_events.find_for_users([user.id], limit=50)
+
+
+class TestQueSePublica:
+    async def test_agrupa_los_birdies_de_la_vuelta_en_una_sola_entrada(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una vuelta con tres birdies / When se publica / Then hay una
+        entrada que dice tres, no tres entradas empujandose en el feed.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 19), PAR)
+        for hoyo in (1, 5, 9):
+            tarjeta[hoyo] = PAR - 1
+        match = await _played_match(qm_uow, course, user, scores_by_hole=tarjeta)
+
+        await _use_case(social_uow, qm_uow, golf_course_uow, user_uow).execute(
+            str(match.id.value)
+        )
+
+        eventos = await _feed_de(social_uow, user)
+        birdies = [e for e in eventos if e.type == ActivityEventType.BIRDIE]
+        assert len(birdies) == 1
+        assert birdies[0].payload["count"] == 3
+        assert birdies[0].payload["holes"] == [1, 5, 9]
+
+    async def test_un_hoyo_en_uno_no_se_cuenta_ademas_como_eagle(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given un hoyo en uno en un par 4 / When se publica / Then va una vez."""
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 19), PAR)
+        tarjeta[7] = 1
+        match = await _played_match(qm_uow, course, user, scores_by_hole=tarjeta)
+
+        await _use_case(social_uow, qm_uow, golf_course_uow, user_uow).execute(
+            str(match.id.value)
+        )
+
+        tipos = [e.type for e in await _feed_de(social_uow, user)]
+        assert ActivityEventType.HOLE_IN_ONE in tipos
+        assert ActivityEventType.EAGLE_OR_BETTER not in tipos
+
+    async def test_una_vuelta_sin_nada_que_contar_no_publica(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una vuelta de pares en un campo ya conocido / When se publica /
+        Then el feed no se entera: jugar bien sin destacar no es noticia.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        await _played_match(qm_uow, course, user)
+        match = await _played_match(qm_uow, course, user)
+
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(match.id.value))
+
+        assert publicados == 0
+
+    async def test_estrenar_campo_se_publica_solo_la_primera_vez(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given dos vueltas en el mismo campo / When se publican / Then solo la primera estrena."""
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        use_case = _use_case(social_uow, qm_uow, golf_course_uow, user_uow)
+
+        primera = await _played_match(qm_uow, course, user)
+        await use_case.execute(str(primera.id.value))
+        segunda = await _played_match(qm_uow, course, user)
+        await use_case.execute(str(segunda.id.value))
+
+        estrenos = [
+            e for e in await _feed_de(social_uow, user) if e.type == ActivityEventType.NEW_COURSE
+        ]
+        assert len(estrenos) == 1
+        assert estrenos[0].source_match_id == str(primera.id.value)
+
+    async def test_publica_record_personal_cuando_baja_su_mejor_diferencial(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given un jugador cuyo mejor diferencial ha bajado tras esta vuelta /
+        When se publica / Then sale el record con el anterior y el nuevo.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        match = await _played_match(qm_uow, course, user)
+        differentials = _DifferentialsStub({str(user.id.value): 12.4})
+
+        await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow, differentials
+        ).execute(str(match.id.value), best_differential_before={str(user.id.value): 15.1})
+
+        records = [
+            e
+            for e in await _feed_de(social_uow, user)
+            if e.type == ActivityEventType.PERSONAL_BEST
+        ]
+        assert len(records) == 1
+        assert records[0].payload["differential"] == "12.4"
+        assert records[0].payload["previous_best"] == "15.1"
+
+    async def test_no_publica_record_si_no_mejoro(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given una vuelta que no baja su mejor marca / When se publica / Then no hay record."""
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        match = await _played_match(qm_uow, course, user)
+        differentials = _DifferentialsStub({str(user.id.value): 15.1})
+
+        await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow, differentials
+        ).execute(str(match.id.value), best_differential_before={str(user.id.value): 15.1})
+
+        tipos = [e.type for e in await _feed_de(social_uow, user)]
+        assert ActivityEventType.PERSONAL_BEST not in tipos
+
+    async def test_la_primera_vuelta_con_diferencial_no_es_un_record(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given un jugador sin diferencial previo / When cierra su primera vuelta /
+        Then no se anuncia como record: es el punto de partida.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        match = await _played_match(qm_uow, course, user)
+        differentials = _DifferentialsStub({str(user.id.value): 15.1})
+
+        await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow, differentials
+        ).execute(str(match.id.value), best_differential_before={str(user.id.value): None})
+
+        tipos = [e.type for e in await _feed_de(social_uow, user)]
+        assert ActivityEventType.PERSONAL_BEST not in tipos
+
+
+class TestQuienPublica:
+    async def test_publica_para_todos_los_participantes_con_cuenta(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given dos jugadores registrados en la partida / When se publica / Then
+        cada uno tiene su entrada: el birdie es de quien lo hizo.
+        """
+        creador = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, creador.id)
+        tarjeta = dict.fromkeys(range(1, 19), PAR)
+        tarjeta[3] = PAR - 1
+        match = await _played_match(
+            qm_uow,
+            course,
+            creador,
+            scores_by_hole=tarjeta,
+            others=[QuickMatchParticipant.for_user(amigo.id)],
+        )
+
+        await _use_case(social_uow, qm_uow, golf_course_uow, user_uow).execute(
+            str(match.id.value)
+        )
+
+        assert [e.type for e in await _feed_de(social_uow, creador)].count(
+            ActivityEventType.BIRDIE
+        ) == 1
+        assert [e.type for e in await _feed_de(social_uow, amigo)].count(
+            ActivityEventType.BIRDIE
+        ) == 1
+
+    async def test_no_publica_de_quien_lo_tiene_apagado(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given un jugador con la publicacion apagada / When se publica / Then no aparece."""
+        callado = await _create_user(user_uow, share_activity=False)
+        course = await _create_course(golf_course_uow, callado.id)
+        match = await _played_match(qm_uow, course, callado)
+
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(match.id.value))
+
+        assert publicados == 0
+        assert await _feed_de(social_uow, callado) == []
+
+    async def test_los_invitados_no_generan_eventos(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una partida con un invitado sin cuenta / When se publica / Then
+        solo se publica lo del registrado: el invitado no tiene feed.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        invitado = QuickMatchParticipant.for_guest(
+            first_name="Invitado", last_name="Sin Cuenta", handicap=20.0
+        )
+        match = await _played_match(qm_uow, course, user, others=[invitado])
+
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(match.id.value))
+
+        assert publicados == 1  # solo el NEW_COURSE del registrado
+
+
+class TestQueNoSePublica:
+    async def test_una_tarjeta_incompleta_no_llega_al_feed(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una vuelta abandonada a los 12 hoyos / When se publica / Then no
+        se publica nada: si no vale para la media, no vale para presumir.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 13), PAR)
+        tarjeta[3] = PAR - 1
+        match = await _played_match(qm_uow, course, user, scores_by_hole=tarjeta)
+
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(match.id.value))
+
+        assert publicados == 0
+
+    async def test_media_vuelta_limpia_si_cuenta(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given los nueve de ida enteros / When se publica / Then el birdie cuenta."""
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 10), PAR)
+        tarjeta[2] = PAR - 1
+        match = await _played_match(qm_uow, course, user, scores_by_hole=tarjeta)
+
+        await _use_case(social_uow, qm_uow, golf_course_uow, user_uow).execute(
+            str(match.id.value)
+        )
+
+        eventos = await _feed_de(social_uow, user)
+        birdies = [e for e in eventos if e.type == ActivityEventType.BIRDIE]
+        assert len(birdies) == 1
+        assert birdies[0].payload["holes_played"] == 9
+
+    async def test_una_partida_sin_terminar_no_publica(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una partida en juego / When se intenta publicar / Then no se
+        publica: los logros salen de vueltas terminadas.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        match = await _played_match(qm_uow, course, user, complete=False)
+
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(match.id.value))
+
+        assert publicados == 0
+
+    async def test_una_partida_que_no_existe_no_rompe(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """Given un id que no existe / When se publica / Then devuelve cero sin fallar."""
+        publicados = await _use_case(
+            social_uow, qm_uow, golf_course_uow, user_uow
+        ).execute(str(uuid4()))
+
+        assert publicados == 0
+
+
+class TestIdempotencia:
+    async def test_publicar_dos_veces_la_misma_vuelta_no_duplica(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Given una vuelta ya publicada / When se vuelve a procesar / Then el feed
+        no crece: es el caso del movil reintentando sobre una conexion mala.
+        """
+        user = await _create_user(user_uow)
+        course = await _create_course(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 19), PAR)
+        tarjeta[1] = PAR - 1
+        match = await _played_match(qm_uow, course, user, scores_by_hole=tarjeta)
+        use_case = _use_case(social_uow, qm_uow, golf_course_uow, user_uow)
+
+        await use_case.execute(str(match.id.value))
+        await use_case.execute(str(match.id.value))
+
+        eventos = await _feed_de(social_uow, user)
+        assert len(eventos) == 2  # BIRDIE + NEW_COURSE, una sola vez cada uno

--- a/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
@@ -31,6 +31,9 @@ from src.modules.quick_match.domain.value_objects.scoring_format import ScoringF
 from src.modules.quick_match.infrastructure.persistence.in_memory.in_memory_quick_match_unit_of_work import (
     InMemoryQuickMatchUnitOfWork,
 )
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
 from src.modules.social.application.ports.player_differentials_interface import (
     PlayerDifferentialsInterface,
 )
@@ -61,6 +64,32 @@ class _DifferentialsStub(PlayerDifferentialsInterface):
 
     async def best_differential(self, user_id):
         return self._por_jugador.get(str(user_id.value))
+
+
+class _CourseHistoryFake(PlayerCourseHistoryInterface):
+    """
+    Historial de campos en memoria.
+
+    Recuerda cada vuelta que se le pregunta, que es lo que hace el adaptador de
+    verdad al consultar partidas rapidas y torneos: la segunda vez que un
+    jugador pisa un campo, ya no lo estrena.
+    """
+
+    def __init__(self):
+        self._vueltas: set = set()
+
+    def registra(self, user_id, golf_course_id: str, match_id: str) -> None:
+        self._vueltas.add((str(user_id.value), golf_course_id, match_id))
+
+    async def has_played_course_before(
+        self, user_id, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        return any(
+            usuario == str(user_id.value)
+            and campo == golf_course_id
+            and partida != excluding_match_id
+            for usuario, campo, partida in self._vueltas
+        )
 
 
 @pytest.fixture
@@ -175,13 +204,14 @@ async def _played_match(
     return match
 
 
-def _use_case(social_uow, qm_uow, golf_course_uow, user_uow, differentials=None):
+def _use_case(social_uow, qm_uow, golf_course_uow, user_uow, differentials=None, history=None):
     return PublishRoundAchievementsUseCase(
         social_uow=social_uow,
         quick_match_uow=qm_uow,
         golf_course_uow=golf_course_uow,
         user_uow=user_uow,
         differentials=differentials or _DifferentialsStub(),
+        history=history or _CourseHistoryFake(),
     )
 
 
@@ -242,11 +272,13 @@ class TestQueSePublica:
         """
         user = await _create_user(user_uow)
         course = await _create_course(golf_course_uow, user.id)
-        await _played_match(qm_uow, course, user)
+        anterior = await _played_match(qm_uow, course, user)
         match = await _played_match(qm_uow, course, user)
+        history = _CourseHistoryFake()
+        history.registra(user.id, str(course.id.value), str(anterior.id.value))
 
         publicados = await _use_case(
-            social_uow, qm_uow, golf_course_uow, user_uow
+            social_uow, qm_uow, golf_course_uow, user_uow, history=history
         ).execute(str(match.id.value))
 
         assert publicados == 0
@@ -257,10 +289,12 @@ class TestQueSePublica:
         """Given dos vueltas en el mismo campo / When se publican / Then solo la primera estrena."""
         user = await _create_user(user_uow)
         course = await _create_course(golf_course_uow, user.id)
-        use_case = _use_case(social_uow, qm_uow, golf_course_uow, user_uow)
+        history = _CourseHistoryFake()
+        use_case = _use_case(social_uow, qm_uow, golf_course_uow, user_uow, history=history)
 
         primera = await _played_match(qm_uow, course, user)
         await use_case.execute(str(primera.id.value))
+        history.registra(user.id, str(course.id.value), str(primera.id.value))
         segunda = await _played_match(qm_uow, course, user)
         await use_case.execute(str(segunda.id.value))
 

--- a/tests/unit/modules/social/application/use_cases/test_publish_tournament_achievements_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_publish_tournament_achievements_use_case.py
@@ -1,0 +1,417 @@
+"""
+Tests de la publicacion de logros de un torneo (BE #175).
+
+Un torneo son varias vueltas por jugador, y eso trae dos reglas propias: cada
+partido lleva su propio `source_match_id`, y `FIRST_TOURNAMENT` se publica una
+sola vez aunque el jugador haya jugado cuatro partidos.
+"""
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.entities.competition import Competition
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.entities.hole_score import HoleScore
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.entities.round import Round
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.competition_name import CompetitionName
+from src.modules.competition.domain.value_objects.date_range import DateRange
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.competition.domain.value_objects.location import Location
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.match_player import MatchPlayer
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.competition.domain.value_objects.session_type import SessionType
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryCompetitionUnitOfWork,
+)
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.in_memory.in_memory_golf_course_unit_of_work import (
+    InMemoryGolfCourseUnitOfWork,
+)
+from src.modules.social.application.ports.player_course_history_interface import (
+    PlayerCourseHistoryInterface,
+)
+from src.modules.social.application.ports.player_differentials_interface import (
+    PlayerDifferentialsInterface,
+)
+from src.modules.social.application.use_cases.publish_tournament_achievements_use_case import (
+    PublishTournamentAchievementsUseCase,
+)
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+pytestmark = pytest.mark.asyncio
+
+PAR = 4
+ROUND_DATE = date(2026, 6, 1)
+
+
+class _DifferentialsStub(PlayerDifferentialsInterface):
+    def __init__(self, por_jugador: dict | None = None):
+        self._por_jugador = por_jugador or {}
+
+    async def best_differential(self, user_id):
+        return self._por_jugador.get(str(user_id.value))
+
+
+class _CourseHistoryFake(PlayerCourseHistoryInterface):
+    """Sin historial previo: todo campo se estrena, salvo lo que se registre."""
+
+    def __init__(self):
+        self._vueltas: set = set()
+
+    def registra(self, user_id, golf_course_id: str, match_id: str) -> None:
+        self._vueltas.add((str(user_id.value), golf_course_id, match_id))
+
+    async def has_played_course_before(
+        self, user_id, golf_course_id: str, excluding_match_id: str
+    ) -> bool:
+        return any(
+            usuario == str(user_id.value)
+            and campo == golf_course_id
+            and partida != excluding_match_id
+            for usuario, campo, partida in self._vueltas
+        )
+
+
+@pytest.fixture
+def competition_uow():
+    return InMemoryCompetitionUnitOfWork()
+
+
+@pytest.fixture
+def golf_course_uow():
+    return InMemoryGolfCourseUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+async def _create_user(user_uow, share_activity: bool = True) -> User:
+    user = User.create(
+        first_name="Test",
+        last_name="User",
+        email_str=f"tfeed_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    if not share_activity:
+        user.set_activity_sharing(False)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _create_course(golf_course_uow, creator_id):
+    course = GolfCourse.create(
+        name="Tournament Golf Club",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=[
+            Tee(
+                category=TeeCategory.AMATEUR,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+            ),
+            Tee(
+                category=TeeCategory.CHAMPIONSHIP,
+                gender=Gender.MALE,
+                identifier="White",
+                course_rating=72.0,
+                slope_rating=130,
+            ),
+        ],
+        holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+    )
+    course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(course)
+    return course
+
+
+async def _completed_tournament(
+    competition_uow,
+    course,
+    player,
+    rival,
+    *,
+    scores_by_hole: dict | None = None,
+    matches: int = 1,
+    round_date: date = ROUND_DATE,
+    complete: bool = True,
+):
+    """Un torneo terminado con la tarjeta del jugador anotada en cada partido."""
+    competition = Competition.create(
+        id=CompetitionId(uuid4()),
+        creator_id=player.id,
+        name=CompetitionName("Ryder Cup Test"),
+        dates=DateRange(start_date=round_date, end_date=round_date + timedelta(days=2)),
+        location=Location(main_country=CountryCode("ES")),
+        play_mode=PlayMode.SCRATCH,
+        team_1_name="Team A",
+        team_2_name="Team B",
+    )
+    if complete:
+        competition.activate()
+        competition.close_enrollments(total_enrollments=2)
+        competition.start()
+        competition.complete()
+
+    round_ = Round.create(
+        competition_id=competition.id,
+        golf_course_id=course.id,
+        round_date=round_date,
+        session_type=SessionType.MORNING,
+        match_format=MatchFormat.SINGLES,
+    )
+
+    def match_player(user_id):
+        return MatchPlayer(
+            user_id=user_id,
+            playing_handicap=0,
+            tee_category=TeeCategory.AMATEUR,
+            tee_gender=Gender.MALE,
+            # Scratch: no recibe golpe en ningun hoyo
+            strokes_received=(),
+        )
+
+    tarjeta = scores_by_hole or dict.fromkeys(range(1, 19), PAR)
+    creados = []
+
+    async with competition_uow:
+        await competition_uow.competitions.add(competition)
+        await competition_uow.rounds.add(round_)
+        for numero in range(1, matches + 1):
+            match = Match.create(
+                round_id=round_.id,
+                match_number=numero,
+                team_a_players=[match_player(player.id)],
+                team_b_players=[match_player(rival.id)],
+            )
+            match.start()
+            match.complete({"winner": "A", "score": "2UP"})
+            await competition_uow.matches.add(match)
+            for hole_number, strokes in tarjeta.items():
+                hole_score = HoleScore.create(
+                    match_id=match.id,
+                    hole_number=hole_number,
+                    player_user_id=player.id,
+                    team="A",
+                    strokes_received=0,
+                )
+                hole_score.set_own_score(strokes)
+                await competition_uow.hole_scores.add(hole_score)
+            creados.append(match)
+
+        for jugador in (player, rival):
+            await competition_uow.enrollments.add(
+                Enrollment.direct_enroll(
+                    id=EnrollmentId(uuid4()),
+                    competition_id=competition.id,
+                    user_id=jugador.id,
+                )
+            )
+        await competition_uow.commit()
+
+    return competition, creados
+
+
+def _use_case(
+    social_uow, competition_uow, golf_course_uow, user_uow, differentials=None, history=None
+):
+    return PublishTournamentAchievementsUseCase(
+        social_uow=social_uow,
+        competition_uow=competition_uow,
+        golf_course_uow=golf_course_uow,
+        user_uow=user_uow,
+        differentials=differentials or _DifferentialsStub(),
+        history=history or _CourseHistoryFake(),
+    )
+
+
+async def _feed_de(social_uow, user):
+    async with social_uow:
+        return await social_uow.activity_events.find_for_users([user.id], limit=50)
+
+
+async def test_publica_los_logros_de_la_vuelta_de_torneo(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given un torneo con un birdie / When se cierra / Then sale en el feed."""
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    tarjeta = dict.fromkeys(range(1, 19), PAR)
+    tarjeta[4] = PAR - 1
+    competition, _ = await _completed_tournament(
+        competition_uow, course, player, rival, scores_by_hole=tarjeta
+    )
+
+    await _use_case(social_uow, competition_uow, golf_course_uow, user_uow).execute(
+        str(competition.id.value)
+    )
+
+    eventos = await _feed_de(social_uow, player)
+    birdies = [e for e in eventos if e.type == ActivityEventType.BIRDIE]
+    assert len(birdies) == 1
+    assert birdies[0].payload["from_tournament"] is True
+
+
+async def test_el_primer_torneo_se_publica_una_sola_vez(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """
+    Given un jugador que estrena torneo jugando tres partidos / When se cierra /
+    Then la noticia sale una vez, no tres.
+    """
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    competition, _ = await _completed_tournament(
+        competition_uow, course, player, rival, matches=3
+    )
+
+    await _use_case(social_uow, competition_uow, golf_course_uow, user_uow).execute(
+        str(competition.id.value)
+    )
+
+    estrenos = [
+        e
+        for e in await _feed_de(social_uow, player)
+        if e.type == ActivityEventType.FIRST_TOURNAMENT
+    ]
+    assert len(estrenos) == 1
+
+
+async def test_cada_partido_lleva_su_propia_entrada(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """
+    Given dos partidos con birdie / When se cierra el torneo / Then hay una
+    entrada de birdie por partido, cada una colgada del suyo.
+    """
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    tarjeta = dict.fromkeys(range(1, 19), PAR)
+    tarjeta[4] = PAR - 1
+    competition, partidos = await _completed_tournament(
+        competition_uow, course, player, rival, scores_by_hole=tarjeta, matches=2
+    )
+
+    await _use_case(social_uow, competition_uow, golf_course_uow, user_uow).execute(
+        str(competition.id.value)
+    )
+
+    birdies = [
+        e for e in await _feed_de(social_uow, player) if e.type == ActivityEventType.BIRDIE
+    ]
+    assert len(birdies) == 2
+    assert {e.source_match_id for e in birdies} == {str(p.id.value) for p in partidos}
+
+
+async def test_reprocesar_el_cierre_no_duplica(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given un torneo ya publicado / When se reprocesa / Then el feed no crece."""
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    competition, _ = await _completed_tournament(competition_uow, course, player, rival)
+    use_case = _use_case(social_uow, competition_uow, golf_course_uow, user_uow)
+
+    await use_case.execute(str(competition.id.value))
+    antes = len(await _feed_de(social_uow, player))
+    await use_case.execute(str(competition.id.value))
+
+    assert len(await _feed_de(social_uow, player)) == antes
+
+
+async def test_no_publica_de_quien_lo_tiene_apagado(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given un inscrito con la publicacion apagada / When se cierra / Then no aparece."""
+    player = await _create_user(user_uow, share_activity=False)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    competition, _ = await _completed_tournament(competition_uow, course, player, rival)
+
+    await _use_case(social_uow, competition_uow, golf_course_uow, user_uow).execute(
+        str(competition.id.value)
+    )
+
+    assert await _feed_de(social_uow, player) == []
+
+
+async def test_un_torneo_sin_cerrar_no_publica(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given un torneo en juego / When se intenta publicar / Then no publica nada."""
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    competition, _ = await _completed_tournament(
+        competition_uow, course, player, rival, complete=False
+    )
+
+    publicados = await _use_case(
+        social_uow, competition_uow, golf_course_uow, user_uow
+    ).execute(str(competition.id.value))
+
+    assert publicados == 0
+
+
+async def test_una_tarjeta_incompleta_no_llega_al_feed(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given una tarjeta con huecos / When se cierra / Then esa vuelta no cuenta."""
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = await _create_course(golf_course_uow, player.id)
+    tarjeta = dict.fromkeys(range(1, 13), PAR)
+    tarjeta[4] = PAR - 1
+    competition, _ = await _completed_tournament(
+        competition_uow, course, player, rival, scores_by_hole=tarjeta
+    )
+
+    publicados = await _use_case(
+        social_uow, competition_uow, golf_course_uow, user_uow
+    ).execute(str(competition.id.value))
+
+    assert publicados == 0
+
+
+async def test_un_torneo_que_no_existe_no_rompe(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """Given un id que no existe / When se publica / Then devuelve cero sin fallar."""
+    publicados = await _use_case(
+        social_uow, competition_uow, golf_course_uow, user_uow
+    ).execute(str(uuid4()))
+
+    assert publicados == 0

--- a/tests/unit/modules/social/application/use_cases/test_set_activity_sharing_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_set_activity_sharing_use_case.py
@@ -132,6 +132,26 @@ async def test_encenderlo_no_borra_ni_recupera_nada(user_uow, social_uow):
     assert guardado.share_activity is True
 
 
+async def test_lo_retirado_no_vuelve_al_encenderlo_de_nuevo(user_uow, social_uow):
+    """
+    Given un jugador que apago la publicacion y borro su historial / When lo
+    vuelve a encender / Then lo retirado sigue sin estar: el feed se llena otra
+    vez con las vueltas que juegue a partir de ahi.
+    """
+    user = await _create_user(user_uow)
+    await _publica(social_uow, user, "match-1")
+    use_case = SetActivitySharingUseCase(user_uow, social_uow)
+
+    retirados = await use_case.execute(str(user.id.value), enabled=False)
+    await use_case.execute(str(user.id.value), enabled=True)
+
+    assert retirados == 1
+    assert await _feed_de(social_uow, user) == []
+    async with user_uow:
+        guardado = await user_uow.users.find_by_id(user.id)
+    assert guardado.share_activity is True
+
+
 async def test_un_jugador_que_no_existe_falla(user_uow, social_uow):
     """Given un id que no existe / When se cambia el interruptor / Then falla."""
     with pytest.raises(UserNotFoundError):

--- a/tests/unit/modules/social/application/use_cases/test_set_activity_sharing_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_set_activity_sharing_use_case.py
@@ -1,0 +1,140 @@
+"""
+Tests del interruptor de publicacion de logros (BE #175).
+
+Lo que se comprueba aqui, sobre todo: **apagarlo retira lo ya publicado**. Quien
+lo apaga quiere que lo suyo deje de verse, no que se congele donde estaba.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.use_cases.set_activity_sharing_use_case import (
+    SetActivitySharingUseCase,
+)
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+async def _create_user(user_uow) -> User:
+    user = User.create(
+        first_name="Test",
+        last_name="User",
+        email_str=f"switch_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _publica(social_uow, user, match_id: str) -> None:
+    async with social_uow:
+        await social_uow.activity_events.add_many(
+            [
+                ActivityEvent.create(
+                    user_id=user.id,
+                    type=ActivityEventType.BIRDIE,
+                    occurred_at=datetime(2026, 8, 10),
+                    source_match_id=match_id,
+                )
+            ]
+        )
+
+
+async def _feed_de(social_uow, user):
+    async with social_uow:
+        return await social_uow.activity_events.find_for_users([user.id], limit=50)
+
+
+async def test_apagarlo_retira_lo_ya_publicado(user_uow, social_uow):
+    """
+    Given un jugador con logros publicados / When apaga la publicacion / Then
+    su historial desaparece del feed, no solo deja de crecer.
+    """
+    user = await _create_user(user_uow)
+    await _publica(social_uow, user, "match-1")
+    await _publica(social_uow, user, "match-2")
+
+    retirados = await SetActivitySharingUseCase(user_uow, social_uow).execute(
+        str(user.id.value), enabled=False
+    )
+
+    assert retirados == 2
+    assert await _feed_de(social_uow, user) == []
+
+
+async def test_apagarlo_no_toca_lo_de_los_demas(user_uow, social_uow):
+    """Given dos jugadores publicando / When uno lo apaga / Then el otro sigue."""
+    ana = await _create_user(user_uow)
+    luis = await _create_user(user_uow)
+    await _publica(social_uow, ana, "match-1")
+    await _publica(social_uow, luis, "match-2")
+
+    await SetActivitySharingUseCase(user_uow, social_uow).execute(
+        str(ana.id.value), enabled=False
+    )
+
+    assert await _feed_de(social_uow, ana) == []
+    assert len(await _feed_de(social_uow, luis)) == 1
+
+
+async def test_apagarlo_deja_el_interruptor_guardado(user_uow, social_uow):
+    """Given un jugador / When lo apaga / Then su perfil lo recuerda."""
+    user = await _create_user(user_uow)
+
+    await SetActivitySharingUseCase(user_uow, social_uow).execute(
+        str(user.id.value), enabled=False
+    )
+
+    async with user_uow:
+        guardado = await user_uow.users.find_by_id(user.id)
+    assert guardado.share_activity is False
+
+
+async def test_encenderlo_no_borra_ni_recupera_nada(user_uow, social_uow):
+    """
+    Given un jugador que lo vuelve a encender / When lo enciende / Then no se
+    borra nada, y lo retirado antes no vuelve: se llena con lo que juegue.
+    """
+    user = await _create_user(user_uow)
+    await _publica(social_uow, user, "match-1")
+
+    retirados = await SetActivitySharingUseCase(user_uow, social_uow).execute(
+        str(user.id.value), enabled=True
+    )
+
+    assert retirados == 0
+    assert len(await _feed_de(social_uow, user)) == 1
+    async with user_uow:
+        guardado = await user_uow.users.find_by_id(user.id)
+    assert guardado.share_activity is True
+
+
+async def test_un_jugador_que_no_existe_falla(user_uow, social_uow):
+    """Given un id que no existe / When se cambia el interruptor / Then falla."""
+    with pytest.raises(UserNotFoundError):
+        await SetActivitySharingUseCase(user_uow, social_uow).execute(
+            str(uuid4()), enabled=False
+        )

--- a/tests/unit/modules/social/domain/entities/test_activity_event.py
+++ b/tests/unit/modules/social/domain/entities/test_activity_event.py
@@ -1,0 +1,130 @@
+"""Tests de ActivityEvent (BE #175)."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+@pytest.fixture
+def user_id():
+    return UserId(str(uuid4()))
+
+
+class TestCreacion:
+    def test_crea_un_evento_con_su_identidad(self, user_id):
+        evento = ActivityEvent.create(
+            user_id=user_id,
+            type=ActivityEventType.BIRDIE,
+            occurred_at=datetime(2026, 8, 10, 12, 0),
+            payload={"count": 3, "holes": [1, 5, 9]},
+            source_match_id="match-1",
+        )
+
+        assert isinstance(evento.id, UUID)
+        assert evento.user_id == user_id
+        assert evento.type == ActivityEventType.BIRDIE
+        assert evento.payload == {"count": 3, "holes": [1, 5, 9]}
+        assert evento.source_match_id == "match-1"
+
+    def test_el_payload_no_se_puede_mutar_desde_fuera(self, user_id):
+        payload = {"count": 3}
+        evento = ActivityEvent.create(
+            user_id=user_id,
+            type=ActivityEventType.BIRDIE,
+            occurred_at=datetime(2026, 8, 10),
+            payload=payload,
+        )
+
+        payload["count"] = 99
+        evento.payload["count"] = 77
+
+        assert evento.payload == {"count": 3}
+
+    def test_un_evento_sin_payload_es_valido(self, user_id):
+        """Estrenar campo no necesita detalle: el hecho es el evento."""
+        evento = ActivityEvent.create(
+            user_id=user_id,
+            type=ActivityEventType.NEW_COURSE,
+            occurred_at=datetime(2026, 8, 10),
+        )
+
+        assert evento.payload == {}
+
+    def test_exige_un_user_id_de_verdad(self):
+        with pytest.raises(TypeError, match="user_id"):
+            ActivityEvent.create(
+                user_id="no-soy-un-user-id",
+                type=ActivityEventType.BIRDIE,
+                occurred_at=datetime(2026, 8, 10),
+            )
+
+    def test_exige_un_tipo_de_evento_conocido(self, user_id):
+        with pytest.raises(TypeError, match="type"):
+            ActivityEvent.create(
+                user_id=user_id, type="BIRDIE", occurred_at=datetime(2026, 8, 10)
+            )
+
+
+class TestIdentidad:
+    def test_dos_eventos_distintos_no_son_iguales(self, user_id):
+        comun = {
+            "user_id": user_id,
+            "type": ActivityEventType.BIRDIE,
+            "occurred_at": datetime(2026, 8, 10),
+            "source_match_id": "match-1",
+        }
+
+        assert ActivityEvent.create(**comun) != ActivityEvent.create(**comun)
+
+    def test_reconstruir_conserva_la_identidad(self, user_id):
+        id_ = uuid4()
+        evento = ActivityEvent.reconstruct(
+            id=id_,
+            user_id=user_id,
+            type=ActivityEventType.EAGLE_OR_BETTER,
+            occurred_at=datetime(2026, 8, 10),
+            payload={},
+            source_match_id=None,
+        )
+
+        assert evento.id == id_
+
+    def test_sabe_de_que_partida_viene(self, user_id):
+        evento = ActivityEvent.create(
+            user_id=user_id,
+            type=ActivityEventType.BIRDIE,
+            occurred_at=datetime(2026, 8, 10),
+            source_match_id="match-1",
+        )
+
+        assert evento.is_from("match-1")
+        assert not evento.is_from("match-2")
+
+
+class TestTipos:
+    def test_reconoce_los_tipos_publicables(self):
+        assert ActivityEventType.from_string("HOLE_IN_ONE") == ActivityEventType.HOLE_IN_ONE
+
+    def test_rechaza_un_tipo_inventado(self):
+        with pytest.raises(ValueError, match="Unknown activity event type"):
+            ActivityEventType.from_string("JUGO_MUY_MAL")
+
+    def test_no_existe_ningun_tipo_que_delate_una_vuelta_mala(self):
+        """
+        La lista es corta a proposito. Si alguien anade aqui un ROUND_PLAYED o
+        similar, el feed empezara a publicar los dias malos y la gente dejara de
+        anotar sus tarjetas (ver BE #173).
+        """
+        assert {t.value for t in ActivityEventType} == {
+            "HOLE_IN_ONE",
+            "EAGLE_OR_BETTER",
+            "BIRDIE",
+            "NEW_COURSE",
+            "PERSONAL_BEST",
+            "FIRST_TOURNAMENT",
+        }

--- a/tests/unit/modules/social/domain/entities/test_activity_event.py
+++ b/tests/unit/modules/social/domain/entities/test_activity_event.py
@@ -38,6 +38,7 @@ class TestCreacion:
             type=ActivityEventType.BIRDIE,
             occurred_at=datetime(2026, 8, 10),
             payload=payload,
+            source_match_id="match-1",
         )
 
         payload["count"] = 99
@@ -51,6 +52,7 @@ class TestCreacion:
             user_id=user_id,
             type=ActivityEventType.NEW_COURSE,
             occurred_at=datetime(2026, 8, 10),
+            source_match_id="match-1",
         )
 
         assert evento.payload == {}
@@ -61,12 +63,16 @@ class TestCreacion:
                 user_id="no-soy-un-user-id",
                 type=ActivityEventType.BIRDIE,
                 occurred_at=datetime(2026, 8, 10),
+                source_match_id="match-1",
             )
 
     def test_exige_un_tipo_de_evento_conocido(self, user_id):
         with pytest.raises(TypeError, match="type"):
             ActivityEvent.create(
-                user_id=user_id, type="BIRDIE", occurred_at=datetime(2026, 8, 10)
+                user_id=user_id,
+                type="BIRDIE",
+                occurred_at=datetime(2026, 8, 10),
+                source_match_id="match-1",
             )
 
 
@@ -89,10 +95,23 @@ class TestIdentidad:
             type=ActivityEventType.EAGLE_OR_BETTER,
             occurred_at=datetime(2026, 8, 10),
             payload={},
-            source_match_id=None,
+            source_match_id="match-1",
         )
 
         assert evento.id == id_
+
+    def test_exige_la_partida_de_la_que_sale(self, user_id):
+        """
+        Sin partida, la clave unica de la tabla no protege: en Postgres un NULL
+        no iguala a otro, asi que reprocesar publicaria el logro otra vez.
+        """
+        with pytest.raises(ValueError, match="source_match_id is required"):
+            ActivityEvent.create(
+                user_id=user_id,
+                type=ActivityEventType.BIRDIE,
+                occurred_at=datetime(2026, 8, 10),
+                source_match_id="",
+            )
 
     def test_sabe_de_que_partida_viene(self, user_id):
         evento = ActivityEvent.create(

--- a/tests/unit/modules/social/domain/services/test_achievement_detector.py
+++ b/tests/unit/modules/social/domain/services/test_achievement_detector.py
@@ -1,0 +1,157 @@
+"""
+Tests del AchievementDetector (BE #175).
+
+La regla que protegen estos tests no es de cálculo, es de producto: **solo se
+publican logros**. Si alguna vez sale de aquí algo que delate una vuelta mala,
+el feed empezará a desincentivar que la gente anote sus tarjetas — que es el
+sesgo que ya arrastran las estadísticas (BE #173).
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.modules.social.domain.services.achievement_detector import (
+    AchievementDetector,
+    PlayedHole,
+    RoundContext,
+)
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+
+
+@pytest.fixture
+def detector():
+    return AchievementDetector()
+
+
+def hoyos(*specs):
+    """(par, golpes) por hoyo, numerados desde el 1."""
+    return [PlayedHole(number=i + 1, par=p, strokes=s) for i, (p, s) in enumerate(specs)]
+
+
+class TestLogrosPorHoyo:
+    def test_un_birdie_se_publica(self, detector):
+        [logro] = detector.detect(hoyos((4, 3)))
+
+        assert logro.type == ActivityEventType.BIRDIE
+        assert logro.count == 1
+        assert logro.holes == (1,)
+
+    def test_los_birdies_de_una_vuelta_van_juntos(self, detector):
+        """
+        Cuatro birdies son una entrada que dice cuatro, no cuatro entradas
+        empujandose unas a otras en el feed de los amigos.
+        """
+        [logro] = detector.detect(hoyos((4, 3), (4, 4), (3, 2), (5, 4), (4, 3)))
+
+        assert logro.type == ActivityEventType.BIRDIE
+        assert logro.count == 4
+        assert logro.holes == (1, 3, 4, 5)
+
+    def test_un_eagle_no_cuenta_ademas_como_birdie(self, detector):
+        [logro] = detector.detect(hoyos((5, 3)))
+
+        assert logro.type == ActivityEventType.EAGLE_OR_BETTER
+        assert logro.count == 1
+
+    def test_un_hoyo_en_uno_no_cuenta_ademas_como_eagle(self, detector):
+        """En un par 3, un hoyo en uno es tambien un eagle. Se cuenta una vez."""
+        logros = detector.detect(hoyos((3, 1)))
+
+        assert [logro.type for logro in logros] == [ActivityEventType.HOLE_IN_ONE]
+
+    def test_un_hoyo_en_uno_en_par_4_tampoco_se_duplica(self, detector):
+        logros = detector.detect(hoyos((4, 1)))
+
+        assert [logro.type for logro in logros] == [ActivityEventType.HOLE_IN_ONE]
+
+    def test_se_ordenan_del_mas_raro_al_mas_comun(self, detector):
+        logros = detector.detect(hoyos((4, 3), (5, 3), (3, 1)))
+
+        assert [logro.type for logro in logros] == [
+            ActivityEventType.HOLE_IN_ONE,
+            ActivityEventType.EAGLE_OR_BETTER,
+            ActivityEventType.BIRDIE,
+        ]
+
+    def test_una_vuelta_normal_no_publica_nada(self, detector):
+        """Jugar al par no es noticia."""
+        assert detector.detect(hoyos((4, 4), (3, 3), (5, 5))) == []
+
+    def test_una_vuelta_mala_no_publica_nada(self, detector):
+        """
+        Lo mas importante del feed: jugar mal no genera ninguna entrada. Nadie
+        deberia pensarselo dos veces antes de anotar una tarjeta.
+        """
+        assert detector.detect(hoyos((4, 8), (3, 7), (5, 10))) == []
+
+    def test_ignora_hoyos_sin_datos(self, detector):
+        assert detector.detect(hoyos((4, 0), (0, 3))) == []
+
+
+class TestLogrosDeVuelta:
+    def test_estrenar_campo_se_publica(self, detector):
+        logros = detector.detect(hoyos((4, 4)), RoundContext(is_first_round_on_course=True))
+
+        assert [logro.type for logro in logros] == [ActivityEventType.NEW_COURSE]
+
+    def test_el_primer_torneo_se_publica(self, detector):
+        logros = detector.detect(hoyos((4, 4)), RoundContext(is_first_tournament=True))
+
+        assert [logro.type for logro in logros] == [ActivityEventType.FIRST_TOURNAMENT]
+
+    def test_batir_la_mejor_vuelta_se_publica(self, detector):
+        logros = detector.detect(
+            hoyos((4, 4)),
+            RoundContext(differential=Decimal("12.1"), previous_best_differential=Decimal("14.3")),
+        )
+
+        [logro] = logros
+        assert logro.type == ActivityEventType.PERSONAL_BEST
+        assert logro.detail["differential"] == "12.1"
+        assert logro.detail["previous_best"] == "14.3"
+
+    def test_no_batir_el_record_no_publica_nada(self, detector):
+        logros = detector.detect(
+            hoyos((4, 4)),
+            RoundContext(differential=Decimal("15.0"), previous_best_differential=Decimal("14.3")),
+        )
+
+        assert logros == []
+
+    def test_igualar_el_record_no_es_batirlo(self, detector):
+        logros = detector.detect(
+            hoyos((4, 4)),
+            RoundContext(differential=Decimal("14.3"), previous_best_differential=Decimal("14.3")),
+        )
+
+        assert logros == []
+
+    def test_la_primera_vuelta_con_diferencial_no_es_un_record(self, detector):
+        """
+        Sin nada anterior con lo que compararla no hay record que anunciar: es
+        el punto de partida, y publicarlo seria un anuncio vacio.
+        """
+        logros = detector.detect(
+            hoyos((4, 4)),
+            RoundContext(differential=Decimal("12.1"), previous_best_differential=None),
+        )
+
+        assert logros == []
+
+    def test_una_vuelta_puede_traer_varios_logros(self, detector):
+        logros = detector.detect(
+            hoyos((4, 3), (5, 3)),
+            RoundContext(
+                is_first_round_on_course=True,
+                differential=Decimal("10.0"),
+                previous_best_differential=Decimal("12.0"),
+            ),
+        )
+
+        assert {logro.type for logro in logros} == {
+            ActivityEventType.EAGLE_OR_BETTER,
+            ActivityEventType.BIRDIE,
+            ActivityEventType.NEW_COURSE,
+            ActivityEventType.PERSONAL_BEST,
+        }


### PR DESCRIPTION
Closes #175

The engine behind the friends feed: what gets published, where it comes from, and how a player opts out. The feed itself and the profiles are #176.

## The rule that governs the design

**Achievements get published, not activity.** A birdie is worth showing; "shot 108 on Tuesday" is not. And a system that publishes the second one pushes people to stop entering their bad rounds — exactly the bias already open in #173. A test pins the exact list of event types so that adding one is a deliberate decision.

## No backfill

Decided on the issue: the feed starts from today. Publishing months of history at once reads as noise, and the first thing every player would see is their own past instead of what their friends just did. Consequence: publishing only ever hooks into "round finished", and no migration walks past matches.

## What is included

| | |
|---|---|
| Domain | `ActivityEvent`, `ActivityEventType` (6 types), `AchievementDetector` (pure, no IO) |
| Persistence | `activity_events` table, migration `d4e8f1a3b7c9`, SQLAlchemy + in-memory repositories |
| Publishing | On closing a quick match and on closing a tournament |
| Opt-out | `PUT /api/v1/social/activity-sharing` |

`users` gains `feed_last_seen_at` (where the "something new" badge will come from, in #176) and `share_activity`.

## Decisions worth reviewing

**`source_match_id` is NOT NULL.** The unique key on `(user_id, source_match_id, type)` is the only thing stopping a reprocessed round from filling the feed with repeats, and in Postgres a NULL never equals another NULL — so every event without a match would have slipped past it. Verified against a real database: two rows with NULL both went in. Every achievement is born from a finished round, so requiring it excludes no real case.

**Inserts use `ON CONFLICT DO NOTHING`** rather than checking first and writing after. Checking leaves a window between "it does not exist" and the INSERT, and two requests completing the same match at once — a phone retrying over a bad connection — fall straight into it.

**`PERSONAL_BEST` is measured across the close, not recomputed.** The best differential is captured before the round is completed and compared after; if it improved, the only new round is that one. The WHS is implemented once, in the statistics module (#167), and a second implementation just for the feed would have diverged from it.

**Reading and judging are separate phases.** Asking for a differential re-enters `quick_match` and `golf_course` through the statistics module, so nesting that call inside an open unit of work would commit and close the session the outer block was still using.

**Which rounds count is now one rule in one place.** `countable_holes` moves to `shared` because statistics (#174) and the feed need the same answer: a card too incomplete for a player's average is also too incomplete to brag about.

**Turning sharing off removes what was already published.** Whoever flips that switch wants their activity to stop being visible, not to stop growing. Turning it back on restores nothing — keeping the removed events around for that would mean storing exactly what the player asked to take down.

## Module boundaries

`quick_match` and `competition` each declare a port; `social` implements it in an adapter. Neither module imports the other. A failure to publish is logged and swallowed: the feed is incidental, the scorecard is not, and nothing here may stop a round from being marked as finished.

## Verification

- **2539** unit tests, **426** integration and security tests, 1 skipped
- `mypy` clean across 572 files; `ruff` clean on everything touched
- Migration applied and rolled back against a real PostgreSQL, on a throwaway database in the dev cluster so the shared one kept its Alembic revision. Single Alembic head after the merge.

## Note for whoever tests this

Because there is no backfill, nothing appears in `activity_events` until a **new** round is closed. Rounds already finished before this ships generate no events, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a social activity feed for achievements from quick matches and tournaments.
  * Added achievements for birdies, eagles, hole-in-ones, new courses, personal bests, and first tournaments.
  * Added controls to enable or disable activity sharing; disabling removes previously shared activity.
  * Added feed tracking and reliable duplicate prevention.
* **Bug Fixes**
  * Improved round scoring to consistently support complete and valid nine-hole rounds.
* **Tests**
  * Added comprehensive coverage for achievement publishing, feed privacy, duplicate prevention, and activity storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->