### PR TITLE
feat(social): Player profiles visible to friends, and the friends feed

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ from src.modules.quick_match.infrastructure.persistence.mappers.quick_match_mapp
     start_quick_match_mappers,
 )
 from src.modules.social.infrastructure.api.v1 import friend_routes  # noqa: E402
+from src.modules.social.infrastructure.api.v1 import profile_routes  # noqa: E402
 from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper import (  # noqa: E402
     start_activity_event_mappers,
 )
@@ -432,6 +433,12 @@ app.include_router(
     friend_routes.router,
     prefix="/api/v1",
     tags=["Friends"],
+)
+
+app.include_router(
+    profile_routes.router,
+    prefix="/api/v1",
+    tags=["Profiles & Feed"],
 )
 
 app.include_router(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -266,9 +266,21 @@ from src.modules.social.application.ports.social_email_service_interface import 
     ISocialEmailService,
 )
 from src.modules.social.application.use_cases.block_user_use_case import BlockUserUseCase
+from src.modules.social.application.use_cases.get_friends_feed_use_case import (
+    GetFriendsFeedUseCase,
+)
+from src.modules.social.application.use_cases.get_player_activity_use_case import (
+    GetPlayerActivityUseCase,
+)
+from src.modules.social.application.use_cases.get_player_profile_use_case import (
+    GetPlayerProfileUseCase,
+)
 from src.modules.social.application.use_cases.list_friends_use_case import ListFriendsUseCase
 from src.modules.social.application.use_cases.list_pending_requests_use_case import (
     ListPendingRequestsUseCase,
+)
+from src.modules.social.application.use_cases.mark_feed_as_seen_use_case import (
+    MarkFeedAsSeenUseCase,
 )
 from src.modules.social.application.use_cases.publish_round_achievements_use_case import (
     PublishRoundAchievementsUseCase,
@@ -1334,6 +1346,38 @@ def get_player_differentials(
 ) -> PlayerDifferentialsInterface:
     """Proveedor del puerto de diferenciales que usa el feed de logros."""
     return StatsPlayerDifferentialsAdapter(stats_use_case)
+
+
+def get_player_profile_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    stats_use_case: GetPlayerStatsUseCase = Depends(get_get_player_stats_use_case),
+) -> GetPlayerProfileUseCase:
+    """Proveedor del caso de uso GetPlayerProfileUseCase."""
+    return GetPlayerProfileUseCase(social_uow, user_uow, stats_use_case)
+
+
+def get_player_activity_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> GetPlayerActivityUseCase:
+    """Proveedor del caso de uso GetPlayerActivityUseCase."""
+    return GetPlayerActivityUseCase(social_uow, user_uow)
+
+
+def get_friends_feed_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> GetFriendsFeedUseCase:
+    """Proveedor del caso de uso GetFriendsFeedUseCase."""
+    return GetFriendsFeedUseCase(social_uow, user_uow)
+
+
+def get_mark_feed_as_seen_use_case(
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> MarkFeedAsSeenUseCase:
+    """Proveedor del caso de uso MarkFeedAsSeenUseCase."""
+    return MarkFeedAsSeenUseCase(user_uow)
 
 
 def get_set_activity_sharing_use_case(

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -76,5 +76,10 @@ class FeedResponseDTO(BaseModel):
         description="Pasalo como `cursor` para la siguiente pagina. None cuando no hay mas",
     )
     unseen_count: int = Field(
-        default=0, description="Cuantas entradas se han publicado desde la ultima visita"
+        default=0,
+        description=(
+            "Cuantas entradas **de amigos** se han publicado desde la ultima visita. "
+            "Los logros propios no cuentan: lo que uno acaba de hacer no es novedad "
+            "para uno"
+        ),
     )

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -54,6 +54,13 @@ class PlayerProfileResponseDTO(BaseModel):
         default=False,
         description="Si tiene foto propia subida; la imagen se pide al endpoint de avatares",
     )
+    friends_count: int = Field(
+        default=0,
+        description=(
+            "Cuantos amigos tiene. Va en la ficha publica, como el contador de "
+            "seguidores de cualquier perfil: es un numero, no dice quienes son"
+        ),
+    )
     friendship: FriendshipStateDTO = Field(
         description="En que punto esta tu relacion con el, para saber que boton ofrecer"
     )

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -7,30 +7,68 @@ from pydantic import BaseModel, Field
 from src.modules.user.application.dto.player_stats_dto import PlayerStatsResponseDTO
 
 
+class FriendshipStateDTO(BaseModel):
+    """
+    En que punto esta la relacion con el jugador del perfil.
+
+    Va en el perfil para que el cliente sepa que boton pintar sin tener que
+    cruzar la lista de amigos con la de solicitudes. `PENDING_SENT` y
+    `PENDING_RECEIVED` se distinguen porque no llevan al mismo sitio: una espera
+    respuesta del otro, la otra pide una respuesta tuya.
+    """
+
+    status: str = Field(
+        description="NONE, PENDING_SENT, PENDING_RECEIVED, ACCEPTED, DECLINED o BLOCKED"
+    )
+    friendship_id: str | None = Field(
+        default=None,
+        description=(
+            "Id de la relacion, necesario para aceptarla o deshacerla. "
+            "None cuando todavia no hay ninguna"
+        ),
+    )
+
+
 class PlayerProfileResponseDTO(BaseModel):
     """
-    El perfil de un jugador tal y como lo ve un amigo.
+    El perfil de un jugador, con dos niveles de detalle segun quien mire.
 
-    Lleva lo justo para pintar la ficha: quien es, su avatar, su handicap y el
-    mismo resumen de rendimiento que el jugador ve en su propio panel. No lleva
-    correo ni nada de la cuenta: es el perfil de golf de alguien, no su ficha
-    de usuario.
+    **Cualquiera ve la ficha minima**: nombre, apellidos y foto. Es lo que hace
+    falta para encontrar a alguien por su nombre y reconocerlo antes de mandarle
+    una solicitud, y no dice nada de el que no diga ya la busqueda.
+
+    **Solo los amigos ven lo de detras**: handicap, estadisticas y actividad.
+    Esos campos llegan en None a quien no es amigo, no recortados ni a cero — un
+    cero se leeria como "juega fatal" en lugar de "no puedes ver esto".
+
+    Nunca lleva correo ni datos de la cuenta, ni siquiera entre amigos: esto es
+    el perfil de golf de alguien, no su ficha de usuario.
     """
 
     id: str
     first_name: str
     last_name: str
-    handicap: float | None = Field(
-        default=None, description="Handicap del perfil, None si aun no lo ha fijado"
-    )
     avatar_source: str
     avatar_preset_id: int | None = None
     has_avatar_upload: bool = Field(
         default=False,
         description="Si tiene foto propia subida; la imagen se pide al endpoint de avatares",
     )
-    stats: PlayerStatsResponseDTO = Field(
-        description="El mismo resumen de rendimiento que su propio panel (BE #128, #167)"
+    friendship: FriendshipStateDTO = Field(
+        description="En que punto esta tu relacion con el, para saber que boton ofrecer"
+    )
+    is_friend: bool = Field(
+        default=False, description="Atajo de `friendship.status == ACCEPTED`"
+    )
+    handicap: float | None = Field(
+        default=None, description="Solo entre amigos. None si no lo sois o si no lo ha fijado"
+    )
+    stats: PlayerStatsResponseDTO | None = Field(
+        default=None,
+        description=(
+            "Solo entre amigos: el mismo resumen que su propio panel (BE #128, #167). "
+            "None cuando no sois amigos"
+        ),
     )
 
 

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -1,0 +1,80 @@
+"""DTOs del perfil de un jugador y del feed de actividad."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from src.modules.user.application.dto.player_stats_dto import PlayerStatsResponseDTO
+
+
+class PlayerProfileResponseDTO(BaseModel):
+    """
+    El perfil de un jugador tal y como lo ve un amigo.
+
+    Lleva lo justo para pintar la ficha: quien es, su avatar, su handicap y el
+    mismo resumen de rendimiento que el jugador ve en su propio panel. No lleva
+    correo ni nada de la cuenta: es el perfil de golf de alguien, no su ficha
+    de usuario.
+    """
+
+    id: str
+    first_name: str
+    last_name: str
+    handicap: float | None = Field(
+        default=None, description="Handicap del perfil, None si aun no lo ha fijado"
+    )
+    avatar_source: str
+    avatar_preset_id: int | None = None
+    has_avatar_upload: bool = Field(
+        default=False,
+        description="Si tiene foto propia subida; la imagen se pide al endpoint de avatares",
+    )
+    stats: PlayerStatsResponseDTO = Field(
+        description="El mismo resumen de rendimiento que su propio panel (BE #128, #167)"
+    )
+
+
+class ActivityEventDTO(BaseModel):
+    """Una entrada del feed."""
+
+    id: str
+    user_id: str
+    type: str
+    occurred_at: datetime
+    payload: dict = Field(
+        default_factory=dict,
+        description="El detalle propio de cada tipo: cuantos birdies, en que hoyos, que campo",
+    )
+    source_match_id: str = Field(description="La partida de la que sale, para enlazar al detalle")
+
+
+class FeedAuthorDTO(BaseModel):
+    """Quien publico una entrada, para no obligar al cliente a pedir cada perfil."""
+
+    id: str
+    first_name: str
+    last_name: str
+    avatar_source: str
+    avatar_preset_id: int | None = None
+
+
+class FeedResponseDTO(BaseModel):
+    """
+    Una pagina del feed, con el cursor para pedir la siguiente.
+
+    El cursor son **dos** valores y no solo la fecha: todos los logros de una
+    misma vuelta comparten `occurred_at`, asi que paginar por fecha sola se
+    dejaria fuera los que aun no se han enseñado de esa vuelta.
+    """
+
+    events: list[ActivityEventDTO] = Field(default_factory=list)
+    authors: dict[str, FeedAuthorDTO] = Field(
+        default_factory=dict, description="Autores de esta pagina, indexados por id"
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description="Pasalo como `cursor` para la siguiente pagina. None cuando no hay mas",
+    )
+    unseen_count: int = Field(
+        default=0, description="Cuantas entradas se han publicado desde la ultima visita"
+    )

--- a/src/modules/social/application/exceptions.py
+++ b/src/modules/social/application/exceptions.py
@@ -27,15 +27,25 @@ class NotAddresseeError(Exception):
 
 class ProfileNotVisibleError(Exception):
     """
-    El perfil pedido no es visible para quien pregunta.
+    El jugador pedido no esta: no existe o esta dado de baja.
 
-    **Se traduce a 404, nunca a 403.** Un 403 diria "existe, pero no puedes
-    verlo", que es justo lo que no debe saberse: convertiria el endpoint en un
-    detector de cuentas, donde probar identificadores distingue las que existen
-    de las que no. Para quien no es amigo, el perfil sencillamente no esta.
+    **Se traduce a 404.** No cubre el caso de "existe pero no sois amigos": la
+    ficha minima de un jugador (nombre, apellidos y foto) la ve cualquier
+    usuario registrado, porque los jugadores se buscan por nombre y hay que
+    poder reconocer a alguien antes de mandarle una solicitud.
+    """
 
-    Por eso tampoco distingue entre "no existe esa cuenta" y "existe pero no
-    sois amigos": las dos situaciones producen esta misma excepcion.
+    pass
+
+
+class ActivityNotVisibleError(Exception):
+    """
+    La actividad de ese jugador es privada para quien pregunta.
+
+    **Se traduce a 403 y no a 404**, al contrario que el perfil. Aqui un 403 no
+    filtra nada: la ficha minima del jugador ya es visible, asi que su
+    existencia no es ningun secreto que proteger. Fingir un 404 solo confundiria
+    al cliente, que acaba de recibir el perfil de esa misma persona.
     """
 
     pass

--- a/src/modules/social/application/exceptions.py
+++ b/src/modules/social/application/exceptions.py
@@ -23,3 +23,19 @@ class NotAddresseeError(Exception):
     """El usuario no es el destinatario de la solicitud de amistad."""
 
     pass
+
+
+class ProfileNotVisibleError(Exception):
+    """
+    El perfil pedido no es visible para quien pregunta.
+
+    **Se traduce a 404, nunca a 403.** Un 403 diria "existe, pero no puedes
+    verlo", que es justo lo que no debe saberse: convertiria el endpoint en un
+    detector de cuentas, donde probar identificadores distingue las que existen
+    de las que no. Para quien no es amigo, el perfil sencillamente no esta.
+
+    Por eso tampoco distingue entre "no existe esa cuenta" y "existe pero no
+    sois amigos": las dos situaciones producen esta misma excepcion.
+    """
+
+    pass

--- a/src/modules/social/application/feed_cursor.py
+++ b/src/modules/social/application/feed_cursor.py
@@ -11,7 +11,7 @@ instante—, asi que un cursor por fecha sola dejaria fuera los que aun no se ha
 enseñado de esa vuelta.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from src.modules.social.domain.entities.activity_event import ActivityEvent
@@ -26,12 +26,21 @@ def parse_cursor(cursor: str | None) -> tuple[datetime | None, UUID | None]:
 
     Un cursor corrupto devuelve la primera pagina en lugar de un error: lo peor
     que le pasa a quien manipule el parametro es empezar por arriba.
+
+    La fecha se deja **sin zona horaria** aunque venga con ella. El cursor llega
+    del cliente, que puede mandar `...+02:00` a mano, y comparar una fecha con
+    zona contra las de la base de datos —que no la llevan— revienta con
+    `TypeError` y tumba la peticion entera. Se convierte a UTC y se le quita la
+    zona, que deja el mismo instante en la escala que usa el resto.
     """
     if not cursor:
         return None, None
     try:
         fecha, id_raw = cursor.split(CURSOR_SEPARATOR, 1)
-        return datetime.fromisoformat(fecha), UUID(id_raw)
+        parsed = datetime.fromisoformat(fecha)
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+        return parsed, UUID(id_raw)
     except (ValueError, AttributeError):
         return None, None
 

--- a/src/modules/social/application/feed_cursor.py
+++ b/src/modules/social/application/feed_cursor.py
@@ -1,0 +1,50 @@
+"""
+El cursor con el que se pagina el feed.
+
+Vive aparte porque lo comparten el feed de amigos y la actividad de un jugador:
+son la misma paginacion sobre los mismos eventos, y dos implementaciones se
+separarian en cuanto una de las dos cambiara de formato.
+
+El cursor son **dos** valores, fecha e id, y no solo la fecha. Todos los logros
+de una misma vuelta se publican con el mismo `occurred_at` —salen del mismo
+instante—, asi que un cursor por fecha sola dejaria fuera los que aun no se han
+enseñado de esa vuelta.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+
+# La fecha en ISO no contiene '|', asi que parte el cursor sin ambiguedad
+CURSOR_SEPARATOR = "|"
+
+
+def parse_cursor(cursor: str | None) -> tuple[datetime | None, UUID | None]:
+    """
+    El cursor de vuelta, o `(None, None)` si no vale.
+
+    Un cursor corrupto devuelve la primera pagina en lugar de un error: lo peor
+    que le pasa a quien manipule el parametro es empezar por arriba.
+    """
+    if not cursor:
+        return None, None
+    try:
+        fecha, id_raw = cursor.split(CURSOR_SEPARATOR, 1)
+        return datetime.fromisoformat(fecha), UUID(id_raw)
+    except (ValueError, AttributeError):
+        return None, None
+
+
+def build_cursor(eventos: list[ActivityEvent], limit: int) -> str | None:
+    """
+    Por donde seguir, o None si esta pagina ya era la ultima.
+
+    Solo se devuelve cursor cuando la pagina vino llena: una pagina a medias
+    significa que no queda nada detras, y dar cursor ahi haria que el cliente
+    pidiera una pagina vacia solo para descubrirlo.
+    """
+    if len(eventos) < limit:
+        return None
+    ultimo = eventos[-1]
+    return f"{ultimo.occurred_at.isoformat()}{CURSOR_SEPARATOR}{ultimo.id}"

--- a/src/modules/social/application/use_cases/get_friends_feed_use_case.py
+++ b/src/modules/social/application/use_cases/get_friends_feed_use_case.py
@@ -1,0 +1,161 @@
+"""Caso de Uso: El feed de actividad de mis amigos."""
+
+from datetime import datetime
+
+from src.modules.social.application.dto.profile_dto import (
+    ActivityEventDTO,
+    FeedAuthorDTO,
+    FeedResponseDTO,
+)
+from src.modules.social.application.feed_cursor import build_cursor, parse_cursor
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# Tope duro por pagina. El cliente puede pedir menos, nunca mas: el feed carga
+# los autores de cada pagina, y una pagina enorme seria una consulta enorme.
+MAX_PAGE_SIZE = 50
+DEFAULT_PAGE_SIZE = 20
+
+
+class GetFriendsFeedUseCase:
+    """
+    Lo que han conseguido mis amigos, de lo mas reciente a lo mas antiguo.
+
+    **El feed se lee, no se escribe** (fan-out on read): al pedirlo se consultan
+    los eventos de mis amigos. No hay una copia por amigo creada al publicar.
+    Con el tamaño de esta aplicacion es la opcion correcta y con diferencia la
+    mas simple; repartir en escritura solo compensa con miles de seguidores por
+    cuenta y trae duplicacion y reconciliacion cada vez que alguien acepta o
+    deshace una amistad.
+
+    **La privacidad se aplica antes de paginar, no despues.** Quien tiene la
+    publicacion apagada se descarta de la lista de autores *antes* de consultar,
+    de modo que el limite de la pagina se aplica ya sobre lo que se puede
+    enseñar. Filtrar despues devolveria paginas de tamaño irregular —una de 20,
+    la siguiente de 14— y obligaria al cliente a adivinar si quedan mas.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._social_uow = social_uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self, viewer_id_raw: str, limit: int = DEFAULT_PAGE_SIZE, cursor: str | None = None
+    ) -> FeedResponseDTO:
+        viewer_id = UserId(viewer_id_raw)
+        limit = max(1, min(limit, MAX_PAGE_SIZE))
+        before, before_id = parse_cursor(cursor)
+
+        # Las unidades de trabajo se abren en serie, nunca una dentro de otra:
+        # comparten sesion por debajo, y el `commit` de la interior cerraria la
+        # transaccion que la exterior todavia esta usando
+        async with self._social_uow:
+            amigos = await self._social_uow.friendships.find_friend_ids(viewer_id)
+
+        publicables, visto_hasta = await self._publicables_y_ultima_visita(viewer_id, amigos)
+        if not publicables:
+            return FeedResponseDTO()
+
+        async with self._social_uow:
+            eventos = await self._social_uow.activity_events.find_for_users(
+                publicables, limit=limit, before=before, before_id=before_id
+            )
+            no_vistos = (
+                0
+                if visto_hasta is None
+                else await self._social_uow.activity_events.count_for_users_since(
+                    publicables, since=visto_hasta
+                )
+            )
+
+        autores = await self._autores(eventos)
+
+        return FeedResponseDTO(
+            events=[self._a_dto(e) for e in eventos],
+            authors=autores,
+            next_cursor=build_cursor(eventos, limit),
+            unseen_count=no_vistos,
+        )
+
+    async def _publicables_y_ultima_visita(
+        self, viewer_id: UserId, amigos: list[UserId]
+    ) -> tuple[list[UserId], datetime | None]:
+        """
+        De mis amigos, los que tienen la publicacion encendida; y cuando mire yo
+        el feed por ultima vez.
+
+        Las dos cosas salen del mismo sitio, asi que se resuelven en una sola
+        apertura en lugar de dos.
+
+        Apagar la publicacion ya retira lo publicado (BE #175), asi que en la
+        practica no deberian quedar eventos suyos. Se filtra igualmente porque
+        la regla es "no aparece en el feed de nadie", y no debe depender de que
+        el borrado de otro caso de uso haya ido bien.
+
+        `feed_last_seen_at` en None significa que nunca lo ha abierto: entonces
+        no hay novedades que contar. Anunciar "247 novedades" a quien entra por
+        primera vez no ayuda a nadie.
+        """
+        if not amigos:
+            return [], None
+
+        publicables = []
+        async with self._user_uow:
+            for amigo in amigos:
+                user = await self._user_uow.users.find_by_id(amigo)
+                if user is not None and user.is_active and user.share_activity:
+                    publicables.append(amigo)
+
+            viewer = await self._user_uow.users.find_by_id(viewer_id)
+            visto_hasta = viewer.feed_last_seen_at if viewer else None
+
+        return publicables, visto_hasta
+
+    async def _autores(self, eventos: list[ActivityEvent]) -> dict[str, FeedAuthorDTO]:
+        """
+        Quien publico cada entrada de esta pagina.
+
+        Van en la respuesta para que pintar el feed no exija una peticion de
+        perfil por entrada. Se consulta cada autor una vez aunque aparezca en
+        varias entradas.
+        """
+        ids = {e.user_id for e in eventos}
+        if not ids:
+            return {}
+
+        autores: dict[str, FeedAuthorDTO] = {}
+        async with self._user_uow:
+            for user_id in ids:
+                user = await self._user_uow.users.find_by_id(user_id)
+                if user is None:
+                    continue
+                autores[str(user_id.value)] = FeedAuthorDTO(
+                    id=str(user_id.value),
+                    first_name=user.first_name,
+                    last_name=user.last_name,
+                    avatar_source=user.avatar_source.value,
+                    avatar_preset_id=user.avatar_preset_id,
+                )
+        return autores
+
+    @staticmethod
+    def _a_dto(evento: ActivityEvent) -> ActivityEventDTO:
+        return ActivityEventDTO(
+            id=str(evento.id),
+            user_id=str(evento.user_id.value),
+            type=evento.type.value,
+            occurred_at=evento.occurred_at,
+            payload=evento.payload,
+            source_match_id=evento.source_match_id,
+        )
+

--- a/src/modules/social/application/use_cases/get_friends_feed_use_case.py
+++ b/src/modules/social/application/use_cases/get_friends_feed_use_case.py
@@ -25,7 +25,14 @@ DEFAULT_PAGE_SIZE = 20
 
 class GetFriendsFeedUseCase:
     """
-    Lo que han conseguido mis amigos, de lo mas reciente a lo mas antiguo.
+    Lo que hemos conseguido mis amigos y yo, de lo mas reciente a lo mas antiguo.
+
+    **Uno se ve a si mismo en su propio feed.** Un feed donde no sale lo que
+    acabas de hacer se lee como si no se hubiera guardado, y ademas deja el feed
+    vacio a quien todavia no tiene amigos. Lo propio se incluye sin mirar el
+    interruptor de publicacion: ese decide lo que ven los demas, no lo que uno
+    ve de si mismo. El aviso de novedades, en cambio, solo cuenta lo de los
+    amigos — los logros de uno no son noticia para uno.
 
     **El feed se lee, no se escribe** (fan-out on read): al pedirlo se consultan
     los eventos de mis amigos. No hay una copia por amigo creada al publicar.
@@ -62,19 +69,26 @@ class GetFriendsFeedUseCase:
         async with self._social_uow:
             amigos = await self._social_uow.friendships.find_friend_ids(viewer_id)
 
-        publicables, visto_hasta = await self._publicables_y_ultima_visita(viewer_id, amigos)
-        if not publicables:
-            return FeedResponseDTO()
+        de_amigos, visto_hasta = await self._publicables_y_ultima_visita(viewer_id, amigos)
+
+        # El jugador se ve a si mismo en su propio feed, junto a sus amigos: un
+        # feed donde no sale lo que uno acaba de hacer se lee como si no se
+        # hubiera guardado. Se añade sin mirar su `share_activity`, porque ese
+        # interruptor gobierna lo que ven los demas, no lo que uno ve de si mismo
+        publicables = [*de_amigos, viewer_id]
 
         async with self._social_uow:
             eventos = await self._social_uow.activity_events.find_for_users(
                 publicables, limit=limit, before=before, before_id=before_id
             )
+            # El aviso cuenta solo lo de los amigos: los logros de uno mismo no
+            # son novedad para uno. Terminar una partida y que el feed anuncie
+            # "3 novedades" que son tuyas seria absurdo
             no_vistos = (
                 0
-                if visto_hasta is None
+                if visto_hasta is None or not de_amigos
                 else await self._social_uow.activity_events.count_for_users_since(
-                    publicables, since=visto_hasta
+                    de_amigos, since=visto_hasta
                 )
             )
 

--- a/src/modules/social/application/use_cases/get_player_activity_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_activity_use_case.py
@@ -1,7 +1,10 @@
 """Caso de Uso: La actividad publicada por un jugador."""
 
 from src.modules.social.application.dto.profile_dto import ActivityEventDTO, FeedResponseDTO
-from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    ProfileNotVisibleError,
+)
 from src.modules.social.application.feed_cursor import build_cursor, parse_cursor
 from src.modules.social.application.use_cases.get_friends_feed_use_case import (
     DEFAULT_PAGE_SIZE,
@@ -20,9 +23,13 @@ class GetPlayerActivityUseCase:
     """
     Los logros de un jugador concreto, visibles solo entre amigos.
 
-    Mismo guard que el perfil: quien no es amigo recibe el mismo error que si la
-    cuenta no existiera. Y la misma regla de publicacion: con el interruptor
-    apagado no hay actividad que enseñar, ni siquiera a un amigo.
+    A diferencia del perfil —cuya ficha minima ve cualquiera—, la actividad es
+    **solo para amigos**: es de lo que trata el componente social. Quien no lo
+    sea recibe un 403 y no un 404, porque la existencia del jugador ya no es
+    ningun secreto: acaba de poder ver su ficha.
+
+    Y la misma regla de publicacion: con el interruptor apagado no hay actividad
+    que enseñar, ni siquiera a un amigo.
 
     Reutiliza el paginado del feed en vez de repetirlo — es el mismo cursor
     sobre los mismos eventos, solo que de un autor en lugar de varios.
@@ -48,16 +55,16 @@ class GetPlayerActivityUseCase:
         limit = max(1, min(limit, MAX_PAGE_SIZE))
         before, before_id = parse_cursor(cursor)
 
-        if viewer_id != target_id:
-            async with self._social_uow:
-                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
-                    raise ProfileNotVisibleError("Profile not found")
-
         async with self._user_uow:
             target = await self._user_uow.users.find_by_id(target_id)
             if target is None or not target.is_active:
                 raise ProfileNotVisibleError("Profile not found")
             publica = target.share_activity
+
+        if viewer_id != target_id:
+            async with self._social_uow:
+                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
+                    raise ActivityNotVisibleError("Only friends can see this player's activity")
 
         # El interruptor apagado no es un error: el perfil existe y es visible,
         # simplemente no tiene actividad publicada

--- a/src/modules/social/application/use_cases/get_player_activity_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_activity_use_case.py
@@ -1,0 +1,85 @@
+"""Caso de Uso: La actividad publicada por un jugador."""
+
+from src.modules.social.application.dto.profile_dto import ActivityEventDTO, FeedResponseDTO
+from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.feed_cursor import build_cursor, parse_cursor
+from src.modules.social.application.use_cases.get_friends_feed_use_case import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+)
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class GetPlayerActivityUseCase:
+    """
+    Los logros de un jugador concreto, visibles solo entre amigos.
+
+    Mismo guard que el perfil: quien no es amigo recibe el mismo error que si la
+    cuenta no existiera. Y la misma regla de publicacion: con el interruptor
+    apagado no hay actividad que enseñar, ni siquiera a un amigo.
+
+    Reutiliza el paginado del feed en vez de repetirlo — es el mismo cursor
+    sobre los mismos eventos, solo que de un autor en lugar de varios.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._social_uow = social_uow
+        self._user_uow = user_uow
+
+    async def execute(
+        self,
+        viewer_id_raw: str,
+        target_id_raw: str,
+        limit: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+    ) -> FeedResponseDTO:
+        viewer_id = UserId(viewer_id_raw)
+        target_id = UserId(target_id_raw)
+        limit = max(1, min(limit, MAX_PAGE_SIZE))
+        before, before_id = parse_cursor(cursor)
+
+        if viewer_id != target_id:
+            async with self._social_uow:
+                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
+                    raise ProfileNotVisibleError("Profile not found")
+
+        async with self._user_uow:
+            target = await self._user_uow.users.find_by_id(target_id)
+            if target is None or not target.is_active:
+                raise ProfileNotVisibleError("Profile not found")
+            publica = target.share_activity
+
+        # El interruptor apagado no es un error: el perfil existe y es visible,
+        # simplemente no tiene actividad publicada
+        if not publica:
+            return FeedResponseDTO()
+
+        async with self._social_uow:
+            eventos = await self._social_uow.activity_events.find_for_users(
+                [target_id], limit=limit, before=before, before_id=before_id
+            )
+
+        return FeedResponseDTO(
+            events=[
+                ActivityEventDTO(
+                    id=str(e.id),
+                    user_id=str(e.user_id.value),
+                    type=e.type.value,
+                    occurred_at=e.occurred_at,
+                    payload=e.payload,
+                    source_match_id=e.source_match_id,
+                )
+                for e in eventos
+            ],
+            next_cursor=build_cursor(eventos, limit),
+        )

--- a/src/modules/social/application/use_cases/get_player_activity_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_activity_use_case.py
@@ -67,8 +67,14 @@ class GetPlayerActivityUseCase:
                     raise ActivityNotVisibleError("Only friends can see this player's activity")
 
         # El interruptor apagado no es un error: el perfil existe y es visible,
-        # simplemente no tiene actividad publicada
-        if not publica:
+        # simplemente no tiene actividad publicada.
+        #
+        # No se aplica a uno mismo. El interruptor gobierna lo que ven los demas,
+        # no lo que uno ve de si mismo — es la misma regla que ya sigue el feed,
+        # donde los logros propios salen tenga el interruptor como lo tenga.
+        # Sin esta excepcion, apagarlo dejaria al jugador sin poder consultar su
+        # propio historial.
+        if not publica and viewer_id != target_id:
             return FeedResponseDTO()
 
         async with self._social_uow:

--- a/src/modules/social/application/use_cases/get_player_profile_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_profile_use_case.py
@@ -1,10 +1,15 @@
-"""Caso de Uso: Ver el perfil de un amigo."""
+"""Caso de Uso: Ver el perfil de un jugador."""
 
-from src.modules.social.application.dto.profile_dto import PlayerProfileResponseDTO
+from src.modules.social.application.dto.profile_dto import (
+    FriendshipStateDTO,
+    PlayerProfileResponseDTO,
+)
 from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.domain.entities.friendship import Friendship
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
 )
+from src.modules.social.domain.value_objects.friendship_status import FriendshipStatus
 from src.modules.user.application.use_cases.get_player_stats_use_case import (
     GetPlayerStatsUseCase,
 )
@@ -13,24 +18,34 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.user_id import UserId
 
+# Estados que ve el cliente. Los dos "pendiente" se separan porque no llevan al
+# mismo boton: uno espera respuesta del otro, el otro pide respuesta tuya.
+NO_RELATIONSHIP = "NONE"
+PENDING_SENT = "PENDING_SENT"
+PENDING_RECEIVED = "PENDING_RECEIVED"
+
 
 class GetPlayerProfileUseCase:
     """
-    El perfil de otro jugador, visible solo entre amigos.
+    El perfil de un jugador, con dos niveles segun quien mire.
 
-    **La amistad es un guard, no un filtro.** Quien no es amigo no recibe una
-    version recortada del perfil: no recibe perfil. La comprobacion decide si se
-    responde, no cuanto se responde.
+    **La ficha minima es publica entre usuarios registrados**: nombre, apellidos
+    y foto. Es lo que permite buscar a alguien por su nombre, reconocerlo y
+    mandarle una solicitud, y no dice nada que la propia busqueda no diga ya.
 
-    Se comprueba en cada peticion y no se guarda nada en cache, que es lo que
-    hace que deshacer una amistad retire el acceso al instante: la siguiente
-    peticion ya no encuentra la relacion.
+    **Lo de detras es solo para amigos**: handicap, estadisticas y actividad.
+    Quien no es amigo los recibe en None, no recortados ni a cero: un cero se
+    leeria como "juega fatal" en vez de "esto no se puede ver".
 
-    El resumen de rendimiento sale de `GetPlayerStatsUseCase` tal cual. Ese caso
-    de uso recibe un `UserId` cualquiera, asi que sirve para otro jugador sin
-    tocar nada, y asi el perfil de un amigo enseña exactamente las mismas
-    cifras que el propio panel en vez de una segunda version que se separaria
-    con el tiempo.
+    Antes esto era un 404 para cualquiera que no fuera amigo, con la idea de no
+    confirmar que la cuenta existia. Esa proteccion dejo de tener sentido cuando
+    se decidio que los jugadores se buscan por nombre: la cuenta ya es
+    descubrible por diseño, y seguir fingiendo que no existe solo impediria
+    mandarle una solicitud. El 404 se reserva ahora para lo que de verdad no
+    esta: cuentas inexistentes o dadas de baja.
+
+    La relacion se consulta en cada peticion y no se guarda en cache, que es lo
+    que hace que deshacer una amistad retire el acceso al instante.
     """
 
     def __init__(
@@ -44,39 +59,68 @@ class GetPlayerProfileUseCase:
         self._stats = stats_use_case
 
     async def execute(self, viewer_id_raw: str, target_id_raw: str) -> PlayerProfileResponseDTO:
-        """
-        El perfil pedido, o `ProfileNotVisibleError` si no procede enseñarlo.
-
-        Un jugador siempre puede verse a si mismo: sin esa salida, mirar el
-        propio perfil exigiria ser amigo de uno mismo.
-        """
         viewer_id = UserId(viewer_id_raw)
         target_id = UserId(target_id_raw)
-
-        if viewer_id != target_id:
-            async with self._social_uow:
-                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
-                    raise ProfileNotVisibleError("Profile not found")
+        propio = viewer_id == target_id
 
         async with self._user_uow:
             user = await self._user_uow.users.find_by_id(target_id)
-            # La misma excepcion que para un desconocido: distinguir "no existe"
-            # de "no sois amigos" convertiria esto en un detector de cuentas
             if user is None or not user.is_active:
                 raise ProfileNotVisibleError("Profile not found")
 
-            perfil = {
+            ficha = {
                 "id": str(user.id.value),
                 "first_name": user.first_name,
                 "last_name": user.last_name,
-                "handicap": float(user.handicap.value) if user.handicap else None,
                 "avatar_source": user.avatar_source.value,
                 "avatar_preset_id": user.avatar_preset_id,
                 "has_avatar_upload": user.active_avatar_upload_id is not None,
             }
+            handicap = float(user.handicap.value) if user.handicap else None
+
+        relacion = await self._relacion(viewer_id, target_id, propio)
+        puede_ver_todo = propio or relacion.status == FriendshipStatus.ACCEPTED.value
 
         # Fuera de la unidad de trabajo: las estadisticas abren las suyas, y
         # anidarlas sobre la misma sesion la cerraria antes de tiempo
-        stats = await self._stats.execute(target_id)
+        stats = await self._stats.execute(target_id) if puede_ver_todo else None
 
-        return PlayerProfileResponseDTO(**perfil, stats=stats)
+        return PlayerProfileResponseDTO(
+            **ficha,
+            friendship=relacion,
+            is_friend=relacion.status == FriendshipStatus.ACCEPTED.value,
+            handicap=handicap if puede_ver_todo else None,
+            stats=stats,
+        )
+
+    async def _relacion(
+        self, viewer_id: UserId, target_id: UserId, propio: bool
+    ) -> FriendshipStateDTO:
+        """En que punto esta la relacion, para que el cliente sepa que ofrecer."""
+        if propio:
+            return FriendshipStateDTO(status=NO_RELATIONSHIP)
+
+        async with self._social_uow:
+            friendship = await self._social_uow.friendships.find_by_pair(viewer_id, target_id)
+
+        if friendship is None:
+            return FriendshipStateDTO(status=NO_RELATIONSHIP)
+
+        return FriendshipStateDTO(
+            status=self._estado(friendship, viewer_id),
+            friendship_id=str(friendship.id.value),
+        )
+
+    @staticmethod
+    def _estado(friendship: Friendship, viewer_id: UserId) -> str:
+        """
+        El estado desde el punto de vista de quien mira.
+
+        Una solicitud pendiente no significa lo mismo para los dos lados, asi
+        que se traduce a dos estados distintos en lugar de devolver `PENDING` y
+        dejar que el cliente deduzca quien la mando.
+        """
+        if friendship.status != FriendshipStatus.PENDING:
+            return friendship.status.value
+
+        return PENDING_SENT if friendship.requester_id == viewer_id else PENDING_RECEIVED

--- a/src/modules/social/application/use_cases/get_player_profile_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_profile_use_case.py
@@ -78,7 +78,7 @@ class GetPlayerProfileUseCase:
             }
             handicap = float(user.handicap.value) if user.handicap else None
 
-        relacion = await self._relacion(viewer_id, target_id, propio)
+        relacion, amigos = await self._relacion_y_amigos(viewer_id, target_id, propio)
         puede_ver_todo = propio or relacion.status == FriendshipStatus.ACCEPTED.value
 
         # Fuera de la unidad de trabajo: las estadisticas abren las suyas, y
@@ -87,28 +87,44 @@ class GetPlayerProfileUseCase:
 
         return PlayerProfileResponseDTO(
             **ficha,
+            friends_count=amigos,
             friendship=relacion,
             is_friend=relacion.status == FriendshipStatus.ACCEPTED.value,
             handicap=handicap if puede_ver_todo else None,
             stats=stats,
         )
 
-    async def _relacion(
+    async def _relacion_y_amigos(
         self, viewer_id: UserId, target_id: UserId, propio: bool
-    ) -> FriendshipStateDTO:
-        """En que punto esta la relacion, para que el cliente sepa que ofrecer."""
-        if propio:
-            return FriendshipStateDTO(status=NO_RELATIONSHIP)
+    ) -> tuple[FriendshipStateDTO, int]:
+        """
+        En que punto esta la relacion y cuantos amigos tiene el otro.
 
+        Las dos cosas salen del mismo repositorio, asi que se resuelven en una
+        sola apertura en lugar de dos.
+
+        **El contador va en la ficha publica**, junto al nombre y la foto. Es un
+        numero: dice si alguien esta empezando o lleva tiempo, que es justo lo
+        que ayuda a decidir si mandarle una solicitud, y no dice quienes son sus
+        amigos ni nada de ellos.
+        """
         async with self._social_uow:
+            amigos = await self._social_uow.friendships.count_friends(target_id)
+
+            if propio:
+                return FriendshipStateDTO(status=NO_RELATIONSHIP), amigos
+
             friendship = await self._social_uow.friendships.find_by_pair(viewer_id, target_id)
 
         if friendship is None:
-            return FriendshipStateDTO(status=NO_RELATIONSHIP)
+            return FriendshipStateDTO(status=NO_RELATIONSHIP), amigos
 
-        return FriendshipStateDTO(
-            status=self._estado(friendship, viewer_id),
-            friendship_id=str(friendship.id.value),
+        return (
+            FriendshipStateDTO(
+                status=self._estado(friendship, viewer_id),
+                friendship_id=str(friendship.id.value),
+            ),
+            amigos,
         )
 
     @staticmethod

--- a/src/modules/social/application/use_cases/get_player_profile_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_profile_use_case.py
@@ -1,0 +1,82 @@
+"""Caso de Uso: Ver el perfil de un amigo."""
+
+from src.modules.social.application.dto.profile_dto import PlayerProfileResponseDTO
+from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.application.use_cases.get_player_stats_use_case import (
+    GetPlayerStatsUseCase,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class GetPlayerProfileUseCase:
+    """
+    El perfil de otro jugador, visible solo entre amigos.
+
+    **La amistad es un guard, no un filtro.** Quien no es amigo no recibe una
+    version recortada del perfil: no recibe perfil. La comprobacion decide si se
+    responde, no cuanto se responde.
+
+    Se comprueba en cada peticion y no se guarda nada en cache, que es lo que
+    hace que deshacer una amistad retire el acceso al instante: la siguiente
+    peticion ya no encuentra la relacion.
+
+    El resumen de rendimiento sale de `GetPlayerStatsUseCase` tal cual. Ese caso
+    de uso recibe un `UserId` cualquiera, asi que sirve para otro jugador sin
+    tocar nada, y asi el perfil de un amigo enseña exactamente las mismas
+    cifras que el propio panel en vez de una segunda version que se separaria
+    con el tiempo.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        stats_use_case: GetPlayerStatsUseCase,
+    ):
+        self._social_uow = social_uow
+        self._user_uow = user_uow
+        self._stats = stats_use_case
+
+    async def execute(self, viewer_id_raw: str, target_id_raw: str) -> PlayerProfileResponseDTO:
+        """
+        El perfil pedido, o `ProfileNotVisibleError` si no procede enseñarlo.
+
+        Un jugador siempre puede verse a si mismo: sin esa salida, mirar el
+        propio perfil exigiria ser amigo de uno mismo.
+        """
+        viewer_id = UserId(viewer_id_raw)
+        target_id = UserId(target_id_raw)
+
+        if viewer_id != target_id:
+            async with self._social_uow:
+                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
+                    raise ProfileNotVisibleError("Profile not found")
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(target_id)
+            # La misma excepcion que para un desconocido: distinguir "no existe"
+            # de "no sois amigos" convertiria esto en un detector de cuentas
+            if user is None or not user.is_active:
+                raise ProfileNotVisibleError("Profile not found")
+
+            perfil = {
+                "id": str(user.id.value),
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "handicap": float(user.handicap.value) if user.handicap else None,
+                "avatar_source": user.avatar_source.value,
+                "avatar_preset_id": user.avatar_preset_id,
+                "has_avatar_upload": user.active_avatar_upload_id is not None,
+            }
+
+        # Fuera de la unidad de trabajo: las estadisticas abren las suyas, y
+        # anidarlas sobre la misma sesion la cerraria antes de tiempo
+        stats = await self._stats.execute(target_id)
+
+        return PlayerProfileResponseDTO(**perfil, stats=stats)

--- a/src/modules/social/application/use_cases/mark_feed_as_seen_use_case.py
+++ b/src/modules/social/application/use_cases/mark_feed_as_seen_use_case.py
@@ -1,0 +1,49 @@
+"""Caso de Uso: Dar el feed por visto."""
+
+from datetime import datetime
+
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class MarkFeedAsSeenUseCase:
+    """
+    Apaga el aviso de novedades del feed.
+
+    Es una llamada aparte y no un efecto de leer el feed porque son dos
+    intenciones distintas: cargar la primera pagina no significa haber visto lo
+    que hay: el cliente pide el feed tambien para refrescarlo en segundo plano,
+    y marcarlo ahi apagaria el aviso sin que nadie lo hubiera mirado.
+
+    Guarda **el momento de la llamada** y no la fecha del ultimo evento
+    devuelto: lo que se publique mientras el jugador lee vuelve a contar como
+    novedad, que es lo que se espera de un aviso.
+
+    Usa `datetime.now()` y no UTC porque esta fecha se compara con el
+    `occurred_at` de los eventos, que sale del `created_at` de la partida, y ese
+    lo escribe el dominio con `datetime.now()`. Con UTC quedaria desplazada las
+    horas que separen al servidor de UTC, y los logros publicados en esa
+    ventana contarian como no vistos para siempre: el aviso no se apagaria nunca
+    del todo.
+    """
+
+    def __init__(self, user_uow: UserUnitOfWorkInterface):
+        self._user_uow = user_uow
+
+    async def execute(self, user_id_raw: str) -> datetime:
+        """Marca el feed como visto y devuelve el momento registrado."""
+        user_id = UserId(user_id_raw)
+        visto_en = datetime.now()
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            if user is None:
+                raise UserNotFoundError(f"User not found: {user_id_raw}")
+
+            user.mark_feed_as_seen(visto_en)
+            await self._user_uow.users.save(user)
+
+        return visto_en

--- a/src/modules/social/domain/repositories/friendship_repository_interface.py
+++ b/src/modules/social/domain/repositories/friendship_repository_interface.py
@@ -87,3 +87,18 @@ class FriendshipRepositoryInterface(ABC):
     async def are_friends(self, user_id_a: UserId, user_id_b: UserId) -> bool:
         """Verifica si dos usuarios tienen una amistad en estado ACCEPTED."""
         pass
+
+    @abstractmethod
+    async def find_friend_ids(self, user_id: UserId) -> list[UserId]:
+        """
+        Los ids de todos los amigos aceptados, sin paginar.
+
+        El feed los necesita todos a la vez para preguntar por sus eventos en
+        una sola consulta, asi que aqui no cabe la paginacion de `list_friends`:
+        con media lista de amigos, el feed se dejaria fuera a la otra media.
+
+        Devuelve solo los ids y no las relaciones porque es lo unico que el feed
+        usa; traer las entidades enteras seria cargar dos ids, dos fechas y un
+        estado por amigo para tirarlos acto seguido.
+        """
+        pass

--- a/src/modules/social/infrastructure/api/v1/profile_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_routes.py
@@ -20,7 +20,10 @@ from src.modules.social.application.dto.profile_dto import (
     FeedResponseDTO,
     PlayerProfileResponseDTO,
 )
-from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    ProfileNotVisibleError,
+)
 from src.modules.social.application.use_cases.get_friends_feed_use_case import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE,
@@ -51,9 +54,10 @@ PROFILE_NOT_FOUND = "Profile not found"
     response_model=PlayerProfileResponseDTO,
     summary="Get a player's profile",
     description=(
-        "The profile of a player you are friends with, including their performance "
-        "summary. Returns 404 when there is no accepted friendship — deliberately "
-        "indistinguishable from a profile that does not exist."
+        "Any registered user sees the minimum card — name, surname and photo — which is "
+        "what makes it possible to recognise someone found by name before sending them a "
+        "request. Handicap and stats come back as null unless you are friends. Returns "
+        "404 only when the player does not exist or has been deactivated."
     ),
 )
 async def get_player_profile(
@@ -74,9 +78,9 @@ async def get_player_profile(
     response_model=FeedResponseDTO,
     summary="Get a player's published achievements",
     description=(
-        "The achievements a friend has published, newest first. Returns 404 under the "
-        "same rule as the profile. An empty list means they publish nothing, which is "
-        "not an error."
+        "The achievements a friend has published, newest first. Friends only: 403 "
+        "otherwise, since the player's existence is already public. 404 means the player "
+        "does not exist. An empty list means they publish nothing, which is not an error."
     ),
 )
 async def get_player_activity(
@@ -94,6 +98,8 @@ async def get_player_activity(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=PROFILE_NOT_FOUND
         ) from e
+    except ActivityNotVisibleError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
 
 
 @router.get(

--- a/src/modules/social/infrastructure/api/v1/profile_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_routes.py
@@ -1,0 +1,130 @@
+"""
+Profile & Feed Routes - API REST Layer (Infrastructure).
+
+Perfiles de jugador y feed de actividad entre amigos (BE #176).
+"""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.config.dependencies import (
+    get_current_user,
+    get_friends_feed_use_case,
+    get_mark_feed_as_seen_use_case,
+    get_player_activity_use_case,
+    get_player_profile_use_case,
+)
+from src.modules.social.application.dto.profile_dto import (
+    FeedResponseDTO,
+    PlayerProfileResponseDTO,
+)
+from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.use_cases.get_friends_feed_use_case import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    GetFriendsFeedUseCase,
+)
+from src.modules.social.application.use_cases.get_player_activity_use_case import (
+    GetPlayerActivityUseCase,
+)
+from src.modules.social.application.use_cases.get_player_profile_use_case import (
+    GetPlayerProfileUseCase,
+)
+from src.modules.social.application.use_cases.mark_feed_as_seen_use_case import (
+    MarkFeedAsSeenUseCase,
+)
+from src.modules.user.application.dto.user_dto import UserResponseDTO
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# Un perfil que no se puede ver responde 404, nunca 403: un 403 diria "existe
+# pero no puedes verlo", y probar identificadores serviria para averiguar que
+# cuentas hay. Es la misma respuesta que para una cuenta inexistente.
+PROFILE_NOT_FOUND = "Profile not found"
+
+
+@router.get(
+    "/users/{user_id}/profile",
+    response_model=PlayerProfileResponseDTO,
+    summary="Get a player's profile",
+    description=(
+        "The profile of a player you are friends with, including their performance "
+        "summary. Returns 404 when there is no accepted friendship — deliberately "
+        "indistinguishable from a profile that does not exist."
+    ),
+)
+async def get_player_profile(
+    user_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetPlayerProfileUseCase = Depends(get_player_profile_use_case),
+):
+    try:
+        return await use_case.execute(str(current_user.id), str(user_id))
+    except ProfileNotVisibleError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=PROFILE_NOT_FOUND
+        ) from e
+
+
+@router.get(
+    "/users/{user_id}/activity",
+    response_model=FeedResponseDTO,
+    summary="Get a player's published achievements",
+    description=(
+        "The achievements a friend has published, newest first. Returns 404 under the "
+        "same rule as the profile. An empty list means they publish nothing, which is "
+        "not an error."
+    ),
+)
+async def get_player_activity(
+    user_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetPlayerActivityUseCase = Depends(get_player_activity_use_case),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    cursor: str | None = Query(None, description="From a previous response's next_cursor"),
+):
+    try:
+        return await use_case.execute(
+            str(current_user.id), str(user_id), limit=limit, cursor=cursor
+        )
+    except ProfileNotVisibleError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=PROFILE_NOT_FOUND
+        ) from e
+
+
+@router.get(
+    "/users/me/feed",
+    response_model=FeedResponseDTO,
+    summary="Get my friends' activity feed",
+    description=(
+        "What your friends have achieved, newest first, paginated by cursor rather than "
+        "page number — the feed grows from the top, so an offset would repeat entries."
+    ),
+)
+async def get_my_feed(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetFriendsFeedUseCase = Depends(get_friends_feed_use_case),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    cursor: str | None = Query(None, description="From a previous response's next_cursor"),
+):
+    return await use_case.execute(str(current_user.id), limit=limit, cursor=cursor)
+
+
+@router.put(
+    "/users/me/feed/seen",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Mark the feed as seen",
+    description=(
+        "Clears the unseen counter. Separate from reading the feed on purpose: clients "
+        "also fetch the feed to refresh in the background, and that should not clear it."
+    ),
+)
+async def mark_feed_as_seen(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: MarkFeedAsSeenUseCase = Depends(get_mark_feed_as_seen_use_case),
+):
+    await use_case.execute(str(current_user.id))

--- a/src/modules/social/infrastructure/api/v1/profile_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_routes.py
@@ -99,10 +99,12 @@ async def get_player_activity(
 @router.get(
     "/users/me/feed",
     response_model=FeedResponseDTO,
-    summary="Get my friends' activity feed",
+    summary="Get my activity feed",
     description=(
-        "What your friends have achieved, newest first, paginated by cursor rather than "
-        "page number — the feed grows from the top, so an offset would repeat entries."
+        "What you and your friends have achieved, newest first, paginated by cursor "
+        "rather than page number — the feed grows from the top, so an offset would "
+        "repeat entries. Your own achievements appear in it, but never count towards "
+        "`unseen_count`."
     ),
 )
 async def get_my_feed(

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_friendship_repository.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_friendship_repository.py
@@ -104,3 +104,11 @@ class InMemoryFriendshipRepository(FriendshipRepositoryInterface):
     async def are_friends(self, user_id_a: UserId, user_id_b: UserId) -> bool:
         friendship = await self.find_by_pair(user_id_a, user_id_b)
         return friendship is not None and friendship.status == FriendshipStatus.ACCEPTED
+
+    async def find_friend_ids(self, user_id: UserId) -> list[UserId]:
+        return [
+            f.addressee_id if f.requester_id == user_id else f.requester_id
+            for f in self._friendships.values()
+            if f.status == FriendshipStatus.ACCEPTED
+            and user_id in (f.requester_id, f.addressee_id)
+        ]

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/friendship_repository.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/friendship_repository.py
@@ -9,6 +9,9 @@ from src.modules.social.domain.repositories.friendship_repository_interface impo
 )
 from src.modules.social.domain.value_objects.friendship_id import FriendshipId
 from src.modules.social.domain.value_objects.friendship_status import FriendshipStatus
+from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (
+    friendships_table,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
@@ -151,3 +154,28 @@ class SQLAlchemyFriendshipRepository(FriendshipRepositoryInterface):
     async def are_friends(self, user_id_a: UserId, user_id_b: UserId) -> bool:
         friendship = await self.find_by_pair(user_id_a, user_id_b)
         return friendship is not None and friendship.status == FriendshipStatus.ACCEPTED
+
+    async def find_friend_ids(self, user_id: UserId) -> list[UserId]:
+        """
+        Los ids de los amigos aceptados, en una sola consulta.
+
+        Se piden las dos columnas y se descarta la propia: la amistad se guarda
+        una vez con quien la pidio y quien la recibio, y el usuario puede estar
+        en cualquiera de los dos lados.
+        """
+        stmt = select(
+            friendships_table.c.requester_id, friendships_table.c.addressee_id
+        ).where(
+            and_(
+                friendships_table.c.status == FriendshipStatus.ACCEPTED,
+                or_(
+                    friendships_table.c.requester_id == user_id,
+                    friendships_table.c.addressee_id == user_id,
+                ),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return [
+            addressee_id if requester_id == user_id else requester_id
+            for requester_id, addressee_id in result.all()
+        ]

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -131,11 +131,27 @@ class FindUserResponseDTO(BaseModel):
 
 
 class SearchUsersItemDTO(BaseModel):
-    """Single user result in search autocomplete."""
+    """
+    Un jugador encontrado por su nombre.
+
+    **No lleva correo.** Cualquiera puede buscar por nombre, asi que lo que
+    devuelva esta busqueda es publico entre usuarios registrados: solo nombre,
+    apellidos y foto. Antes devolvia el correo, lo que permitia recolectar
+    direcciones tecleando nombres sueltos.
+
+    La foto es lo que permite distinguir a dos jugadores que se llamen igual,
+    que es el trabajo que hacia el correo.
+    """
 
     user_id: UUID = Field(..., description="ID del usuario.")
-    email: EmailStr = Field(..., description=EMAIL_DESCRIPTION)
     full_name: str = Field(..., description="Nombre completo del usuario.")
+    first_name: str = Field(default="", description="Nombre, ya separado del apellido.")
+    last_name: str = Field(default="", description="Apellidos, ya separados del nombre.")
+    avatar_source: str = Field(default="", description="De donde sale su foto de perfil.")
+    avatar_preset_id: int | None = Field(default=None, description="Avatar predefinido, si usa uno.")
+    has_avatar_upload: bool = Field(
+        default=False, description="Si tiene foto propia subida."
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/modules/user/application/use_cases/search_users_use_case.py
+++ b/src/modules/user/application/use_cases/search_users_use_case.py
@@ -11,6 +11,12 @@ class SearchUsersUseCase:
     """
     Use case for autocomplete user search by partial name.
     Returns a list of users matching the query.
+
+    Devuelve **solo lo publico**: nombre, apellidos y foto. Cualquier usuario
+    registrado puede buscar por nombre, asi que todo lo que salga de aqui es
+    visible para cualquiera. El correo se retiro por eso: tecleando nombres
+    sueltos se podian recolectar direcciones de gente con la que no tienes
+    ninguna relacion.
     """
 
     MIN_QUERY_LENGTH = 2
@@ -32,8 +38,12 @@ class SearchUsersUseCase:
                 users=[
                     SearchUsersItemDTO(
                         user_id=user.id.value,
-                        email=user.email.value,
                         full_name=user.get_full_name(),
+                        first_name=user.first_name,
+                        last_name=user.last_name,
+                        avatar_source=user.avatar_source.value,
+                        avatar_preset_id=user.avatar_preset_id,
+                        has_avatar_upload=user.active_avatar_upload_id is not None,
                     )
                     for user in users
                 ]

--- a/tests/integration/api/v1/test_profile_feed_endpoints.py
+++ b/tests/integration/api/v1/test_profile_feed_endpoints.py
@@ -1,0 +1,181 @@
+"""
+Tests E2E de perfiles y feed (BE #176).
+
+El guard se comprueba aqui de punta a punta porque lo que importa es el **codigo
+de respuesta**: un 403 delataria que la cuenta existe, asi que tiene que ser 404
+y ser identico al de una cuenta inventada.
+"""
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_authenticated_user, set_auth_cookies
+
+
+async def _hacerse_amigos(client: AsyncClient, a: dict, b: dict) -> None:
+    """a envia solicitud, b la acepta."""
+    set_auth_cookies(client, a["cookies"])
+    respuesta = await client.post(
+        "/api/v1/friends/requests", json={"addressee_id": b["user"]["id"]}
+    )
+    friendship_id = respuesta.json()["id"]
+
+    set_auth_cookies(client, b["cookies"])
+    await client.post(
+        f"/api/v1/friends/requests/{friendship_id}/respond", json={"action": "ACCEPT"}
+    )
+
+
+class TestPerfil:
+    @pytest.mark.asyncio
+    async def test_un_amigo_ve_el_perfil(self, client: AsyncClient):
+        """Given dos amigos / When uno pide el perfil / Then 200 con sus datos."""
+        ana = await create_authenticated_user(
+            client, "perfil_a@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        luis = await create_authenticated_user(
+            client, "perfil_b@test.com", "P@ssw0rd123!", "Luis", "Perez"
+        )
+        await _hacerse_amigos(client, ana, luis)
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
+
+        assert respuesta.status_code == 200
+        datos = respuesta.json()
+        assert datos["id"] == luis["user"]["id"]
+        assert datos["first_name"] == "Luis"
+        assert "stats" in datos
+        # El perfil de golf no lleva datos de la cuenta
+        assert "email" not in datos
+
+    @pytest.mark.asyncio
+    async def test_un_desconocido_recibe_404_y_no_403(self, client: AsyncClient):
+        """
+        Given dos usuarios sin amistad / When uno pide el perfil / Then 404.
+
+        Un 403 confirmaria que la cuenta existe, que es justo lo que no debe
+        poder averiguarse probando identificadores.
+        """
+        ana = await create_authenticated_user(
+            client, "perfil_c@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        luis = await create_authenticated_user(
+            client, "perfil_d@test.com", "P@ssw0rd123!", "Luis", "Perez"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
+
+        assert respuesta.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_una_cuenta_inventada_responde_igual_que_un_desconocido(
+        self, client: AsyncClient
+    ):
+        """
+        Given un id que no existe / When se pide su perfil / Then la respuesta es
+        indistinguible de la de alguien que existe pero no es amigo.
+        """
+        ana = await create_authenticated_user(
+            client, "perfil_e@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        luis = await create_authenticated_user(
+            client, "perfil_f@test.com", "P@ssw0rd123!", "Luis", "Perez"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        inventado = await client.get(f"/api/v1/users/{uuid4()}/profile")
+        desconocido = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
+
+        assert inventado.status_code == desconocido.status_code == 404
+        assert inventado.json() == desconocido.json()
+
+    @pytest.mark.asyncio
+    async def test_requiere_autenticacion(self, client: AsyncClient):
+        """Given nadie autenticado / When pide un perfil / Then 401."""
+        client.cookies.clear()
+
+        respuesta = await client.get(f"/api/v1/users/{uuid4()}/profile")
+
+        assert respuesta.status_code == 401
+
+
+class TestFeed:
+    @pytest.mark.asyncio
+    async def test_el_feed_llega_vacio_sin_amigos(self, client: AsyncClient):
+        """Given un jugador sin amigos / When pide su feed / Then 200 y vacio."""
+        ana = await create_authenticated_user(
+            client, "feed_a@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get("/api/v1/users/me/feed")
+
+        assert respuesta.status_code == 200
+        datos = respuesta.json()
+        assert datos["events"] == []
+        assert datos["next_cursor"] is None
+        assert datos["unseen_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_marcar_el_feed_como_visto(self, client: AsyncClient):
+        """Given un jugador / When marca el feed como visto / Then 204."""
+        ana = await create_authenticated_user(
+            client, "feed_b@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.put("/api/v1/users/me/feed/seen")
+
+        assert respuesta.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_el_limite_de_pagina_tiene_tope(self, client: AsyncClient):
+        """Given un limite desmedido / When se pide el feed / Then se rechaza."""
+        ana = await create_authenticated_user(
+            client, "feed_c@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get("/api/v1/users/me/feed?limit=5000")
+
+        assert respuesta.status_code == 422
+
+
+class TestActividad:
+    @pytest.mark.asyncio
+    async def test_la_actividad_de_un_desconocido_da_404(self, client: AsyncClient):
+        """Given dos sin amistad / When se pide su actividad / Then 404, igual que el perfil."""
+        ana = await create_authenticated_user(
+            client, "act_a@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        luis = await create_authenticated_user(
+            client, "act_b@test.com", "P@ssw0rd123!", "Luis", "Perez"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/activity")
+
+        assert respuesta.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_un_amigo_sin_logros_devuelve_lista_vacia_no_error(
+        self, client: AsyncClient
+    ):
+        """Given un amigo que no ha publicado nada / When se pide / Then 200 y vacio."""
+        ana = await create_authenticated_user(
+            client, "act_c@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        luis = await create_authenticated_user(
+            client, "act_d@test.com", "P@ssw0rd123!", "Luis", "Perez"
+        )
+        await _hacerse_amigos(client, ana, luis)
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/activity")
+
+        assert respuesta.status_code == 200
+        assert respuesta.json()["events"] == []

--- a/tests/integration/api/v1/test_profile_feed_endpoints.py
+++ b/tests/integration/api/v1/test_profile_feed_endpoints.py
@@ -52,12 +52,10 @@ class TestPerfil:
         assert "email" not in datos
 
     @pytest.mark.asyncio
-    async def test_un_desconocido_recibe_404_y_no_403(self, client: AsyncClient):
+    async def test_un_desconocido_ve_la_ficha_pero_no_lo_privado(self, client: AsyncClient):
         """
-        Given dos usuarios sin amistad / When uno pide el perfil / Then 404.
-
-        Un 403 confirmaria que la cuenta existe, que es justo lo que no debe
-        poder averiguarse probando identificadores.
+        Given dos usuarios sin amistad / When uno pide el perfil / Then 200 con
+        nombre, apellidos y foto, pero sin handicap ni estadisticas.
         """
         ana = await create_authenticated_user(
             client, "perfil_c@test.com", "P@ssw0rd123!", "Ana", "Garcia"
@@ -69,29 +67,52 @@ class TestPerfil:
         set_auth_cookies(client, ana["cookies"])
         respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
 
-        assert respuesta.status_code == 404
+        assert respuesta.status_code == 200
+        datos = respuesta.json()
+        assert datos["first_name"] == "Luis"
+        assert datos["is_friend"] is False
+        assert datos["friendship"]["status"] == "NONE"
+        assert datos["stats"] is None
+        assert datos["handicap"] is None
+        assert "email" not in datos
 
     @pytest.mark.asyncio
-    async def test_una_cuenta_inventada_responde_igual_que_un_desconocido(
-        self, client: AsyncClient
-    ):
+    async def test_una_cuenta_inventada_si_da_404(self, client: AsyncClient):
         """
-        Given un id que no existe / When se pide su perfil / Then la respuesta es
-        indistinguible de la de alguien que existe pero no es amigo.
+        Given un id que no existe / When se pide su perfil / Then 404.
+
+        El 404 se reserva para lo que de verdad no esta. Ya no sirve para ocultar
+        que una cuenta existe: los jugadores se buscan por nombre, asi que su
+        existencia es publica por diseño.
         """
         ana = await create_authenticated_user(
             client, "perfil_e@test.com", "P@ssw0rd123!", "Ana", "Garcia"
         )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{uuid4()}/profile")
+
+        assert respuesta.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_el_perfil_dice_en_que_punto_esta_la_solicitud(self, client: AsyncClient):
+        """
+        Given una solicitud enviada / When miro su perfil / Then el estado lo
+        refleja, para no ofrecerme mandar otra.
+        """
+        ana = await create_authenticated_user(
+            client, "perfil_g@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
         luis = await create_authenticated_user(
-            client, "perfil_f@test.com", "P@ssw0rd123!", "Luis", "Perez"
+            client, "perfil_h@test.com", "P@ssw0rd123!", "Luis", "Perez"
         )
 
         set_auth_cookies(client, ana["cookies"])
-        inventado = await client.get(f"/api/v1/users/{uuid4()}/profile")
-        desconocido = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
+        await client.post("/api/v1/friends/requests", json={"addressee_id": luis["user"]["id"]})
+        respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/profile")
 
-        assert inventado.status_code == desconocido.status_code == 404
-        assert inventado.json() == desconocido.json()
+        assert respuesta.json()["friendship"]["status"] == "PENDING_SENT"
+        assert respuesta.json()["friendship"]["friendship_id"] is not None
 
     @pytest.mark.asyncio
     async def test_requiere_autenticacion(self, client: AsyncClient):
@@ -101,6 +122,36 @@ class TestPerfil:
         respuesta = await client.get(f"/api/v1/users/{uuid4()}/profile")
 
         assert respuesta.status_code == 401
+
+
+class TestBusqueda:
+    @pytest.mark.asyncio
+    async def test_la_busqueda_no_devuelve_correos(self, client: AsyncClient):
+        """
+        Given un jugador buscando por nombre / When encuentra a alguien / Then
+        recibe nombre, apellidos y foto, nunca su correo.
+
+        Cualquiera puede buscar por nombre, asi que lo que salga de aqui es
+        publico. Devolver el correo permitia recolectar direcciones tecleando
+        nombres sueltos.
+        """
+        await create_authenticated_user(
+            client, "busca_diana@test.com", "P@ssw0rd123!", "Diana", "Buscada"
+        )
+        ana = await create_authenticated_user(
+            client, "busca_ana@test.com", "P@ssw0rd123!", "Ana", "Buscadora"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get("/api/v1/users/search-autocomplete?query=Diana")
+
+        assert respuesta.status_code == 200
+        encontrados = respuesta.json()["users"]
+        assert len(encontrados) >= 1
+        for usuario in encontrados:
+            assert "email" not in usuario
+            assert "avatar_source" in usuario
+        assert "busca_diana@test.com" not in respuesta.text
 
 
 class TestFeed:
@@ -147,8 +198,14 @@ class TestFeed:
 
 class TestActividad:
     @pytest.mark.asyncio
-    async def test_la_actividad_de_un_desconocido_da_404(self, client: AsyncClient):
-        """Given dos sin amistad / When se pide su actividad / Then 404, igual que el perfil."""
+    async def test_la_actividad_de_un_desconocido_da_403(self, client: AsyncClient):
+        """
+        Given dos sin amistad / When se pide su actividad / Then 403, no 404.
+
+        Aqui el 403 no filtra nada: el perfil de esa persona ya es visible, asi
+        que su existencia no es ningun secreto. Fingir un 404 confundiria al
+        cliente, que acaba de recibir su ficha.
+        """
         ana = await create_authenticated_user(
             client, "act_a@test.com", "P@ssw0rd123!", "Ana", "Garcia"
         )
@@ -158,6 +215,18 @@ class TestActividad:
 
         set_auth_cookies(client, ana["cookies"])
         respuesta = await client.get(f"/api/v1/users/{luis['user']['id']}/activity")
+
+        assert respuesta.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_la_actividad_de_una_cuenta_inventada_da_404(self, client: AsyncClient):
+        """Given un id que no existe / When se pide su actividad / Then 404, no 403."""
+        ana = await create_authenticated_user(
+            client, "act_e@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+
+        set_auth_cookies(client, ana["cookies"])
+        respuesta = await client.get(f"/api/v1/users/{uuid4()}/activity")
 
         assert respuesta.status_code == 404
 

--- a/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_friendship_friend_ids.py
+++ b/tests/integration/modules/social/infrastructure/persistence/sqlalchemy/test_friendship_friend_ids.py
@@ -1,0 +1,105 @@
+"""
+Tests de integracion de `find_friend_ids` (BE #176).
+
+Es la consulta que alimenta el feed, y tiene una trampa propia: la amistad se
+guarda una sola vez, asi que el usuario puede estar en la columna de quien la
+pidio o en la de quien la recibio. Devolver la columna equivocada llenaria el
+feed de los propios logros en vez de los de los amigos.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.value_objects.friendship_id import FriendshipId
+from src.modules.social.infrastructure.persistence.sqlalchemy.friendship_repository import (
+    SQLAlchemyFriendshipRepository,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.sqlalchemy.user_repository import (
+    SQLAlchemyUserRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _make_saved_user(db_session, email: str) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=email,
+        plain_password="ValidPassword123!",
+    )
+    await SQLAlchemyUserRepository(db_session).save(user)
+    await db_session.commit()
+    return user
+
+
+async def _accepted(db_session, requester: User, addressee: User) -> Friendship:
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=requester.id, addressee_id=addressee.id
+    )
+    friendship.accept()
+    await SQLAlchemyFriendshipRepository(db_session).add(friendship)
+    await db_session.commit()
+    return friendship
+
+
+async def test_devuelve_al_otro_lado_de_la_amistad(db_session):
+    """
+    Given amistades donde soy el que pidio y donde soy el que recibio / When
+    pido mis amigos / Then salen los otros, nunca yo mismo.
+    """
+    yo = await _make_saved_user(db_session, "ids-1@example.com")
+    pedi_yo = await _make_saved_user(db_session, "ids-2@example.com")
+    me_pidio = await _make_saved_user(db_session, "ids-3@example.com")
+    await _accepted(db_session, yo, pedi_yo)
+    await _accepted(db_session, me_pidio, yo)
+
+    amigos = await SQLAlchemyFriendshipRepository(db_session).find_friend_ids(yo.id)
+
+    assert set(amigos) == {pedi_yo.id, me_pidio.id}
+    assert yo.id not in amigos
+
+
+async def test_no_devuelve_las_solicitudes_sin_aceptar(db_session):
+    """Given una solicitud pendiente / When pido mis amigos / Then no cuenta."""
+    yo = await _make_saved_user(db_session, "ids-4@example.com")
+    pendiente = await _make_saved_user(db_session, "ids-5@example.com")
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=yo.id, addressee_id=pendiente.id
+    )
+    await SQLAlchemyFriendshipRepository(db_session).add(friendship)
+    await db_session.commit()
+
+    amigos = await SQLAlchemyFriendshipRepository(db_session).find_friend_ids(yo.id)
+
+    assert amigos == []
+
+
+async def test_sin_amigos_devuelve_vacio(db_session):
+    """Given un jugador recien llegado / When pido sus amigos / Then lista vacia."""
+    solo = await _make_saved_user(db_session, "ids-6@example.com")
+
+    amigos = await SQLAlchemyFriendshipRepository(db_session).find_friend_ids(solo.id)
+
+    assert amigos == []
+
+
+async def test_no_pagina_la_lista(db_session):
+    """
+    Given mas amigos que el limite por defecto de `list_friends` / When pido los
+    ids / Then salen todos: el feed no puede dejarse fuera a media lista.
+    """
+    yo = await _make_saved_user(db_session, "ids-7@example.com")
+    esperados = set()
+    for i in range(25):
+        amigo = await _make_saved_user(db_session, f"ids-7-{i}@example.com")
+        await _accepted(db_session, yo, amigo)
+        esperados.add(amigo.id)
+
+    amigos = await SQLAlchemyFriendshipRepository(db_session).find_friend_ids(yo.id)
+
+    assert set(amigos) == esperados
+    assert len(amigos) == 25

--- a/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
@@ -121,14 +121,56 @@ class TestQueSeVe:
 
         assert feed.events == []
 
-    async def test_sin_amigos_el_feed_llega_vacio(self, social_uow, user_uow):
-        """Given un jugador sin amigos / When pide el feed / Then llega vacio."""
+    async def test_sin_amigos_ni_logros_propios_el_feed_llega_vacio(
+        self, social_uow, user_uow
+    ):
+        """Given un jugador recien llegado / When pide el feed / Then llega vacio."""
         yo = await _create_user(user_uow)
 
         feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
 
         assert feed.events == []
         assert feed.next_cursor is None
+
+    async def test_me_veo_a_mi_mismo_en_mi_feed(self, social_uow, user_uow):
+        """
+        Given un logro mio y otro de un amigo / When pido el feed / Then salen
+        los dos: un feed donde no aparece lo que acabo de hacer se lee como si
+        no se hubiera guardado.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, yo, "mio")
+        await _publica(social_uow, amigo, "suyo", CUANDO - timedelta(days=1))
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert [e.source_match_id for e in feed.events] == ["mio", "suyo"]
+
+    async def test_me_veo_aunque_no_tenga_amigos(self, social_uow, user_uow):
+        """
+        Given un jugador sin amigos pero con logros / When pide el feed / Then
+        ve los suyos: el feed no nace vacio para quien aun no ha hecho amigos.
+        """
+        yo = await _create_user(user_uow)
+        await _publica(social_uow, yo, "mio")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert [e.source_match_id for e in feed.events] == ["mio"]
+
+    async def test_me_veo_aunque_tenga_la_publicacion_apagada(self, social_uow, user_uow):
+        """
+        Given que apague mi publicacion / When pido mi feed / Then sigo viendo
+        lo mio: el interruptor decide lo que ven los demas, no lo que veo yo.
+        """
+        yo = await _create_user(user_uow, share_activity=False)
+        await _publica(social_uow, yo, "mio")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert [e.source_match_id for e in feed.events] == ["mio"]
 
     async def test_deshacer_la_amistad_retira_sus_logros_del_feed(self, social_uow, user_uow):
         """Given un amigo con logros / When dejamos de ser amigos / Then desaparecen."""
@@ -281,6 +323,25 @@ class TestAvisoDeNovedades:
 
         feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
 
+        assert feed.unseen_count == 0
+
+    async def test_mis_propios_logros_no_cuentan_como_novedad(self, social_uow, user_uow):
+        """
+        Given que acabo de publicar tres logros mios / When pido el feed / Then
+        el aviso sigue a cero: lo que uno acaba de hacer no es noticia para uno.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        yo.mark_feed_as_seen(CUANDO)
+        async with user_uow:
+            await user_uow.users.save(yo)
+        for i in range(3):
+            await _publica(social_uow, yo, f"mio-{i}", CUANDO + timedelta(hours=i + 1))
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert len(feed.events) == 3
         assert feed.unseen_count == 0
 
     async def test_cuenta_lo_publicado_despues_de_la_ultima_visita(self, social_uow, user_uow):

--- a/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
@@ -1,0 +1,299 @@
+"""
+Tests del feed de amigos (BE #176).
+
+Dos reglas gobiernan estos tests: el feed solo enseña lo de los amigos
+aceptados, y la privacidad se aplica **antes** de paginar — si se filtrara
+despues, las paginas saldrian de tamaños irregulares.
+"""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.use_cases.get_friends_feed_use_case import (
+    GetFriendsFeedUseCase,
+)
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.domain.value_objects.friendship_id import FriendshipId
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+CUANDO = datetime(2026, 8, 10, 12, 0)
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+async def _create_user(user_uow, share_activity: bool = True) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=f"feed_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    if not share_activity:
+        user.set_activity_sharing(False)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _hacer_amigos(social_uow, a: User, b: User) -> Friendship:
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=a.id, addressee_id=b.id
+    )
+    friendship.accept()
+    async with social_uow:
+        await social_uow.friendships.add(friendship)
+    return friendship
+
+
+async def _publica(social_uow, user: User, match_id: str, cuando: datetime = CUANDO):
+    async with social_uow:
+        await social_uow.activity_events.add_many(
+            [
+                ActivityEvent.create(
+                    user_id=user.id,
+                    type=ActivityEventType.BIRDIE,
+                    occurred_at=cuando,
+                    source_match_id=match_id,
+                )
+            ]
+        )
+
+
+def _use_case(social_uow, user_uow):
+    return GetFriendsFeedUseCase(social_uow, user_uow)
+
+
+class TestQueSeVe:
+    async def test_veo_los_logros_de_mis_amigos(self, social_uow, user_uow):
+        """Given un amigo con un birdie / When pido el feed / Then sale."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert len(feed.events) == 1
+        assert feed.events[0].source_match_id == "match-1"
+
+    async def test_el_feed_trae_a_sus_autores(self, social_uow, user_uow):
+        """
+        Given un logro de un amigo / When pido el feed / Then viene quien lo
+        publico, para no pedir un perfil por entrada.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert str(amigo.id.value) in feed.authors
+        assert feed.authors[str(amigo.id.value)].first_name == "Ana"
+
+    async def test_no_veo_los_logros_de_quien_no_es_mi_amigo(self, social_uow, user_uow):
+        """Given un extranio con logros / When pido el feed / Then no sale nada."""
+        yo = await _create_user(user_uow)
+        extranio = await _create_user(user_uow)
+        await _publica(social_uow, extranio, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert feed.events == []
+
+    async def test_sin_amigos_el_feed_llega_vacio(self, social_uow, user_uow):
+        """Given un jugador sin amigos / When pide el feed / Then llega vacio."""
+        yo = await _create_user(user_uow)
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert feed.events == []
+        assert feed.next_cursor is None
+
+    async def test_deshacer_la_amistad_retira_sus_logros_del_feed(self, social_uow, user_uow):
+        """Given un amigo con logros / When dejamos de ser amigos / Then desaparecen."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        friendship = await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+        use_case = _use_case(social_uow, user_uow)
+        assert len((await use_case.execute(str(yo.id.value))).events) == 1
+
+        async with social_uow:
+            await social_uow.friendships.remove(friendship)
+
+        assert (await use_case.execute(str(yo.id.value))).events == []
+
+
+class TestPrivacidad:
+    async def test_un_amigo_con_la_publicacion_apagada_no_aparece(self, social_uow, user_uow):
+        """
+        Given un amigo que apago la publicacion / When pido el feed / Then no
+        sale, aunque sigamos siendo amigos y aunque le queden eventos.
+        """
+        yo = await _create_user(user_uow)
+        callado = await _create_user(user_uow, share_activity=False)
+        await _hacer_amigos(social_uow, yo, callado)
+        await _publica(social_uow, callado, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert feed.events == []
+
+    async def test_la_privacidad_no_recorta_la_pagina(self, social_uow, user_uow):
+        """
+        Given dos amigos, uno callado, con 5 logros cada uno / When pido 4 /
+        Then llegan 4 del que si publica — no 2 tras filtrar los del callado.
+
+        Es la regla de la issue: filtrar despues de paginar daria paginas de
+        tamaño irregular y el cliente no sabria si quedan mas.
+        """
+        yo = await _create_user(user_uow)
+        hablador = await _create_user(user_uow)
+        callado = await _create_user(user_uow, share_activity=False)
+        await _hacer_amigos(social_uow, yo, hablador)
+        await _hacer_amigos(social_uow, yo, callado)
+        for i in range(5):
+            await _publica(social_uow, hablador, f"h-{i}", CUANDO - timedelta(days=i))
+            await _publica(social_uow, callado, f"c-{i}", CUANDO - timedelta(hours=i))
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value), limit=4)
+
+        assert len(feed.events) == 4
+        assert all(e.user_id == str(hablador.id.value) for e in feed.events)
+
+
+class TestPaginacion:
+    async def test_pagina_sin_repetir_ni_perder(self, social_uow, user_uow):
+        """Given 5 logros / When paso paginas de 2 / Then salen los 5, una vez cada uno."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        for i in range(5):
+            await _publica(social_uow, amigo, f"match-{i}", CUANDO - timedelta(days=i))
+        use_case = _use_case(social_uow, user_uow)
+
+        vistos, cursor = [], None
+        while True:
+            pagina = await use_case.execute(str(yo.id.value), limit=2, cursor=cursor)
+            vistos.extend(pagina.events)
+            cursor = pagina.next_cursor
+            if cursor is None:
+                break
+
+        assert len(vistos) == 5
+        assert len({e.id for e in vistos}) == 5
+
+    async def test_los_logros_de_una_misma_vuelta_no_se_pierden_al_paginar(
+        self, social_uow, user_uow
+    ):
+        """
+        Given 4 logros publicados en el mismo instante / When paso paginas de 2 /
+        Then salen los 4: el cursor compara fecha e id, no solo la fecha.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        async with social_uow:
+            await social_uow.activity_events.add_many(
+                [
+                    ActivityEvent.create(
+                        user_id=amigo.id, type=t, occurred_at=CUANDO, source_match_id="match-1"
+                    )
+                    for t in (
+                        ActivityEventType.BIRDIE,
+                        ActivityEventType.EAGLE_OR_BETTER,
+                        ActivityEventType.NEW_COURSE,
+                        ActivityEventType.HOLE_IN_ONE,
+                    )
+                ]
+            )
+        use_case = _use_case(social_uow, user_uow)
+
+        vistos, cursor = [], None
+        while True:
+            pagina = await use_case.execute(str(yo.id.value), limit=2, cursor=cursor)
+            vistos.extend(pagina.events)
+            cursor = pagina.next_cursor
+            if cursor is None:
+                break
+
+        assert len({e.id for e in vistos}) == 4
+
+    async def test_una_pagina_a_medias_no_da_cursor(self, social_uow, user_uow):
+        """Given 1 logro / When pido 10 / Then no hay cursor: no queda nada detras."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value), limit=10)
+
+        assert feed.next_cursor is None
+
+    async def test_un_cursor_corrupto_devuelve_la_primera_pagina(self, social_uow, user_uow):
+        """Given un cursor manipulado / When se pide / Then se empieza por arriba, sin error."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+
+        feed = await _use_case(social_uow, user_uow).execute(
+            str(yo.id.value), cursor="no-soy-un-cursor"
+        )
+
+        assert len(feed.events) == 1
+
+
+class TestAvisoDeNovedades:
+    async def test_quien_nunca_ha_abierto_el_feed_no_ve_un_contador_enorme(
+        self, social_uow, user_uow
+    ):
+        """
+        Given un jugador que nunca abrio el feed / When lo pide / Then el aviso
+        va a cero: anunciarle 200 novedades el primer dia no ayuda.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        for i in range(3):
+            await _publica(social_uow, amigo, f"match-{i}", CUANDO - timedelta(days=i))
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert feed.unseen_count == 0
+
+    async def test_cuenta_lo_publicado_despues_de_la_ultima_visita(self, social_uow, user_uow):
+        """Given una visita anterior / When se publica algo nuevo / Then el aviso lo cuenta."""
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        yo.mark_feed_as_seen(CUANDO)
+        async with user_uow:
+            await user_uow.users.save(yo)
+        await _publica(social_uow, amigo, "viejo", CUANDO - timedelta(days=1))
+        await _publica(social_uow, amigo, "nuevo", CUANDO + timedelta(hours=1))
+
+        feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
+
+        assert feed.unseen_count == 1

--- a/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
@@ -358,3 +358,27 @@ class TestAvisoDeNovedades:
         feed = await _use_case(social_uow, user_uow).execute(str(yo.id.value))
 
         assert feed.unseen_count == 1
+
+
+class TestCursorManipulado:
+    async def test_un_cursor_con_zona_horaria_no_tumba_la_peticion(
+        self, social_uow, user_uow
+    ):
+        """
+        Given un cursor con desfase horario / When se pide el feed / Then
+        responde en vez de reventar.
+
+        El cursor viene del cliente y puede traer `+02:00` a mano. Comparar una
+        fecha con zona contra las de la base de datos —que no la llevan— lanza
+        TypeError y tumbaria la peticion entera.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1", CUANDO - timedelta(days=1))
+
+        feed = await _use_case(social_uow, user_uow).execute(
+            str(yo.id.value), cursor=f"{CUANDO.isoformat()}+02:00|{uuid4()}"
+        )
+
+        assert isinstance(feed.events, list)

--- a/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
@@ -1,0 +1,178 @@
+"""
+Tests de la actividad de un jugador (BE #176).
+
+Mismo guard que el perfil, con una diferencia que importa: el interruptor de
+publicacion apagado **no es un error**. El perfil sigue siendo visible; lo que
+no hay es actividad que enseñar.
+"""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.use_cases.get_player_activity_use_case import (
+    GetPlayerActivityUseCase,
+)
+from src.modules.social.domain.entities.activity_event import ActivityEvent
+from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.value_objects.activity_event_type import ActivityEventType
+from src.modules.social.domain.value_objects.friendship_id import FriendshipId
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+CUANDO = datetime(2026, 8, 10, 12, 0)
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+async def _create_user(user_uow, share_activity: bool = True) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=f"act_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    if not share_activity:
+        user.set_activity_sharing(False)
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _hacer_amigos(social_uow, a: User, b: User) -> None:
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=a.id, addressee_id=b.id
+    )
+    friendship.accept()
+    async with social_uow:
+        await social_uow.friendships.add(friendship)
+
+
+async def _publica(social_uow, user: User, match_id: str, cuando: datetime = CUANDO):
+    async with social_uow:
+        await social_uow.activity_events.add_many(
+            [
+                ActivityEvent.create(
+                    user_id=user.id,
+                    type=ActivityEventType.BIRDIE,
+                    occurred_at=cuando,
+                    source_match_id=match_id,
+                )
+            ]
+        )
+
+
+def _use_case(social_uow, user_uow):
+    return GetPlayerActivityUseCase(social_uow, user_uow)
+
+
+async def test_un_amigo_ve_la_actividad(social_uow, user_uow):
+    """Given un amigo con logros / When pido su actividad / Then los veo."""
+    yo = await _create_user(user_uow)
+    amigo = await _create_user(user_uow)
+    await _hacer_amigos(social_uow, yo, amigo)
+    await _publica(social_uow, amigo, "match-1")
+
+    resultado = await _use_case(social_uow, user_uow).execute(
+        str(yo.id.value), str(amigo.id.value)
+    )
+
+    assert len(resultado.events) == 1
+    assert resultado.events[0].source_match_id == "match-1"
+
+
+async def test_un_desconocido_no_ve_la_actividad(social_uow, user_uow):
+    """Given dos sin amistad / When se pide la actividad / Then no existe para el."""
+    yo = await _create_user(user_uow)
+    extranio = await _create_user(user_uow)
+    await _publica(social_uow, extranio, "match-1")
+
+    with pytest.raises(ProfileNotVisibleError):
+        await _use_case(social_uow, user_uow).execute(
+            str(yo.id.value), str(extranio.id.value)
+        )
+
+
+async def test_el_interruptor_apagado_no_es_un_error(social_uow, user_uow):
+    """
+    Given un amigo con la publicacion apagada / When pido su actividad / Then
+    llega vacia, no un error: su perfil existe y es visible.
+    """
+    yo = await _create_user(user_uow)
+    callado = await _create_user(user_uow, share_activity=False)
+    await _hacer_amigos(social_uow, yo, callado)
+    await _publica(social_uow, callado, "match-1")
+
+    resultado = await _use_case(social_uow, user_uow).execute(
+        str(yo.id.value), str(callado.id.value)
+    )
+
+    assert resultado.events == []
+
+
+async def test_puedo_ver_mi_propia_actividad(social_uow, user_uow):
+    """Given un jugador sin amigos / When pide su propia actividad / Then la ve."""
+    yo = await _create_user(user_uow)
+    await _publica(social_uow, yo, "match-1")
+
+    resultado = await _use_case(social_uow, user_uow).execute(
+        str(yo.id.value), str(yo.id.value)
+    )
+
+    assert len(resultado.events) == 1
+
+
+async def test_solo_sale_la_actividad_del_jugador_pedido(social_uow, user_uow):
+    """Given dos amigos con logros / When pido la de uno / Then no sale la del otro."""
+    yo = await _create_user(user_uow)
+    uno = await _create_user(user_uow)
+    otro = await _create_user(user_uow)
+    await _hacer_amigos(social_uow, yo, uno)
+    await _hacer_amigos(social_uow, yo, otro)
+    await _publica(social_uow, uno, "de-uno")
+    await _publica(social_uow, otro, "de-otro")
+
+    resultado = await _use_case(social_uow, user_uow).execute(
+        str(yo.id.value), str(uno.id.value)
+    )
+
+    assert [e.source_match_id for e in resultado.events] == ["de-uno"]
+
+
+async def test_pagina_con_cursor(social_uow, user_uow):
+    """Given 5 logros / When paso paginas de 2 / Then salen los 5 sin repetir."""
+    yo = await _create_user(user_uow)
+    amigo = await _create_user(user_uow)
+    await _hacer_amigos(social_uow, yo, amigo)
+    for i in range(5):
+        await _publica(social_uow, amigo, f"match-{i}", CUANDO - timedelta(days=i))
+    use_case = _use_case(social_uow, user_uow)
+
+    vistos, cursor = [], None
+    while True:
+        pagina = await use_case.execute(
+            str(yo.id.value), str(amigo.id.value), limit=2, cursor=cursor
+        )
+        vistos.extend(pagina.events)
+        cursor = pagina.next_cursor
+        if cursor is None:
+            break
+
+    assert len({e.id for e in vistos}) == 5

--- a/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
@@ -197,3 +197,22 @@ async def test_pagina_con_cursor(social_uow, user_uow):
             break
 
     assert len({e.id for e in vistos}) == 5
+
+
+async def test_puedo_ver_mi_historial_con_la_publicacion_apagada(social_uow, user_uow):
+    """
+    Given que apague mi publicacion / When consulto mi propia actividad / Then
+    sigo viendola.
+
+    Es la misma regla que ya sigue el feed: el interruptor gobierna lo que ven
+    los demas, no lo que uno ve de si mismo. Sin esto, apagarlo dejaria al
+    jugador sin acceso a su propio historial.
+    """
+    yo = await _create_user(user_uow, share_activity=False)
+    await _publica(social_uow, yo, "match-1")
+
+    resultado = await _use_case(social_uow, user_uow).execute(
+        str(yo.id.value), str(yo.id.value)
+    )
+
+    assert len(resultado.events) == 1

--- a/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_activity_use_case.py
@@ -11,7 +11,10 @@ from uuid import uuid4
 
 import pytest
 
-from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    ProfileNotVisibleError,
+)
 from src.modules.social.application.use_cases.get_player_activity_use_case import (
     GetPlayerActivityUseCase,
 )
@@ -99,15 +102,33 @@ async def test_un_amigo_ve_la_actividad(social_uow, user_uow):
 
 
 async def test_un_desconocido_no_ve_la_actividad(social_uow, user_uow):
-    """Given dos sin amistad / When se pide la actividad / Then no existe para el."""
+    """
+    Given dos sin amistad / When se pide la actividad / Then se rechaza.
+
+    La actividad es solo para amigos, a diferencia de la ficha del perfil. Y el
+    rechazo es explicito, no un "no existe": el jugador si existe y quien
+    pregunta ya ha podido ver su ficha.
+    """
     yo = await _create_user(user_uow)
     extranio = await _create_user(user_uow)
     await _publica(social_uow, extranio, "match-1")
 
-    with pytest.raises(ProfileNotVisibleError):
+    with pytest.raises(ActivityNotVisibleError):
         await _use_case(social_uow, user_uow).execute(
             str(yo.id.value), str(extranio.id.value)
         )
+
+
+async def test_un_jugador_que_no_existe_da_un_error_distinto(social_uow, user_uow):
+    """
+    Given un id inventado / When se pide su actividad / Then el error dice que
+    no existe, no que sea privado: son dos situaciones distintas y el cliente
+    reacciona distinto a cada una.
+    """
+    yo = await _create_user(user_uow)
+
+    with pytest.raises(ProfileNotVisibleError):
+        await _use_case(social_uow, user_uow).execute(str(yo.id.value), str(uuid4()))
 
 
 async def test_el_interruptor_apagado_no_es_un_error(social_uow, user_uow):

--- a/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
@@ -260,3 +260,72 @@ class TestLoQueDeVerdadNoEsta:
         )
 
         assert "email" not in perfil.model_dump()
+
+
+class TestContadorDeAmigos:
+    async def test_cuenta_los_amigos_del_perfil_no_los_mios(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given un jugador con dos amigos / When miro su perfil / Then el contador
+        dice dos, aunque yo no tenga ninguno mas.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        marta = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, luis, ana)
+        await _hacer_amigos(social_uow, luis, marta)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.friends_count == 2
+
+    async def test_el_contador_se_ve_sin_ser_amigo(self, social_uow, user_uow, stats):
+        """
+        Given un desconocido con amigos / When miro su ficha / Then veo cuantos
+        tiene: es parte de la ficha publica, como el contador de seguidores de
+        cualquier perfil.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        marta = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, luis, marta)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.is_friend is False
+        assert perfil.friends_count == 1
+
+    async def test_un_jugador_sin_amigos_marca_cero(self, social_uow, user_uow, stats):
+        """Given un recien llegado / When miro su perfil / Then el contador va a cero."""
+        ana = await _create_user(user_uow)
+        solo = await _create_user(user_uow)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(solo.id.value)
+        )
+
+        assert perfil.friends_count == 0
+
+    async def test_las_solicitudes_pendientes_no_cuentan(self, social_uow, user_uow, stats):
+        """
+        Given una solicitud sin aceptar / When miro el perfil / Then no suma:
+        el contador es de amistades hechas, no de invitaciones enviadas.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        pendiente = Friendship.create(
+            id=FriendshipId(uuid4()), requester_id=luis.id, addressee_id=ana.id
+        )
+        async with social_uow:
+            await social_uow.friendships.add(pendiente)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.friends_count == 0

--- a/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
@@ -94,22 +94,53 @@ class TestGuardDeAmistad:
         assert perfil.handicap == 8.4
         assert perfil.stats.rounds_played == 7
 
-    async def test_un_desconocido_no_ve_el_perfil(self, social_uow, user_uow, stats):
-        """Given dos usuarios sin amistad / When uno pide el perfil / Then no existe para el."""
-        ana = await _create_user(user_uow)
-        luis = await _create_user(user_uow)
-
-        with pytest.raises(ProfileNotVisibleError):
-            await _use_case(social_uow, user_uow, stats).execute(
-                str(ana.id.value), str(luis.id.value)
-            )
-
-    async def test_una_solicitud_pendiente_todavia_no_da_acceso(
+    async def test_un_desconocido_ve_la_ficha_pero_no_lo_de_detras(
         self, social_uow, user_uow, stats
     ):
         """
-        Given una solicitud de amistad sin aceptar / When se pide el perfil /
-        Then no se ve: hace falta que este aceptada, no solo enviada.
+        Given dos usuarios sin amistad / When uno pide el perfil / Then ve
+        nombre, apellidos y foto, pero ni handicap ni estadisticas.
+
+        La ficha minima es lo que permite reconocer a alguien encontrado por su
+        nombre antes de mandarle una solicitud.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow, handicap=8.4)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.first_name == "Ana"
+        assert perfil.avatar_source is not None
+        assert perfil.is_friend is False
+        assert perfil.friendship.status == "NONE"
+        assert perfil.handicap is None
+        assert perfil.stats is None
+
+    async def test_lo_privado_llega_en_none_y_no_a_cero(self, social_uow, user_uow, stats):
+        """
+        Given un perfil de alguien que no es amigo / When se pide / Then el
+        handicap llega en None, no en 0: un cero se leeria como "juega fatal"
+        en lugar de "esto no se puede ver".
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow, handicap=8.4)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.handicap is None
+        assert perfil.stats is None
+
+    async def test_una_solicitud_pendiente_no_da_acceso_pero_si_se_distingue(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given una solicitud enviada sin responder / When se pide el perfil /
+        Then sigue sin verse lo privado, pero el estado dice que ya se mando:
+        el cliente necesita saberlo para no ofrecer "enviar solicitud" otra vez.
         """
         ana = await _create_user(user_uow)
         luis = await _create_user(user_uow)
@@ -119,29 +150,56 @@ class TestGuardDeAmistad:
         async with social_uow:
             await social_uow.friendships.add(pendiente)
 
-        with pytest.raises(ProfileNotVisibleError):
-            await _use_case(social_uow, user_uow, stats).execute(
-                str(ana.id.value), str(luis.id.value)
-            )
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
 
-    async def test_deshacer_la_amistad_retira_el_acceso_al_instante(
+        assert perfil.friendship.status == "PENDING_SENT"
+        assert perfil.friendship.friendship_id == str(pendiente.id.value)
+        assert perfil.stats is None
+
+    async def test_quien_recibio_la_solicitud_la_ve_como_recibida(
         self, social_uow, user_uow, stats
     ):
         """
-        Given dos que eran amigos / When se deshace la amistad / Then el perfil
-        deja de verse en la peticion siguiente, sin cache que lo sostenga.
+        Given una solicitud que me han mandado / When miro su perfil / Then el
+        estado es PENDING_RECEIVED, que no lleva al mismo boton que la enviada.
         """
         ana = await _create_user(user_uow)
         luis = await _create_user(user_uow)
+        pendiente = Friendship.create(
+            id=FriendshipId(uuid4()), requester_id=ana.id, addressee_id=luis.id
+        )
+        async with social_uow:
+            await social_uow.friendships.add(pendiente)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(luis.id.value), str(ana.id.value)
+        )
+
+        assert perfil.friendship.status == "PENDING_RECEIVED"
+
+    async def test_deshacer_la_amistad_retira_lo_privado_al_instante(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given dos que eran amigos / When se deshace la amistad / Then la ficha
+        sigue viendose pero las estadisticas desaparecen en la peticion
+        siguiente, sin cache que las sostenga.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow, handicap=8.4)
         friendship = await _hacer_amigos(social_uow, ana, luis)
         use_case = _use_case(social_uow, user_uow, stats)
-        await use_case.execute(str(ana.id.value), str(luis.id.value))
+        assert (await use_case.execute(str(ana.id.value), str(luis.id.value))).stats is not None
 
         async with social_uow:
             await social_uow.friendships.remove(friendship)
 
-        with pytest.raises(ProfileNotVisibleError):
-            await use_case.execute(str(ana.id.value), str(luis.id.value))
+        despues = await use_case.execute(str(ana.id.value), str(luis.id.value))
+        assert despues.first_name == "Ana"
+        assert despues.stats is None
+        assert despues.handicap is None
 
     async def test_uno_siempre_puede_ver_su_propio_perfil(self, social_uow, user_uow, stats):
         """
@@ -157,14 +215,15 @@ class TestGuardDeAmistad:
         assert perfil.id == str(ana.id.value)
 
 
-class TestNoFiltraQueCuentasExisten:
-    async def test_una_cuenta_que_no_existe_da_el_mismo_error_que_un_extranio(
-        self, social_uow, user_uow, stats
-    ):
+class TestLoQueDeVerdadNoEsta:
+    async def test_una_cuenta_que_no_existe_no_se_ve(self, social_uow, user_uow, stats):
         """
-        Given un id inventado / When se pide su perfil / Then el error es el
-        mismo que para alguien que existe pero no es amigo. Distinguirlos
-        convertiria el endpoint en un detector de cuentas.
+        Given un id inventado / When se pide su perfil / Then no hay perfil.
+
+        El 404 se reserva para lo que de verdad no esta. Ya no cubre "existe
+        pero no sois amigos": desde que los jugadores se buscan por nombre, su
+        existencia es publica por diseño y fingir lo contrario solo impediria
+        mandarles una solicitud.
         """
         ana = await _create_user(user_uow)
 
@@ -173,7 +232,9 @@ class TestNoFiltraQueCuentasExisten:
                 str(ana.id.value), str(uuid4())
             )
 
-    async def test_un_amigo_dado_de_baja_tampoco_se_ve(self, social_uow, user_uow, stats):
+    async def test_una_cuenta_dada_de_baja_no_se_ve_ni_siendo_amigos(
+        self, social_uow, user_uow, stats
+    ):
         """Given un amigo con la cuenta desactivada / When se pide / Then no se ve."""
         ana = await _create_user(user_uow)
         luis = await _create_user(user_uow, active=False)
@@ -183,3 +244,19 @@ class TestNoFiltraQueCuentasExisten:
             await _use_case(social_uow, user_uow, stats).execute(
                 str(ana.id.value), str(luis.id.value)
             )
+
+    async def test_el_perfil_nunca_lleva_el_correo(self, social_uow, user_uow, stats):
+        """
+        Given dos amigos / When uno mira el perfil del otro / Then no hay correo
+        ni siquiera entre amigos: esto es su perfil de golf, no su ficha de
+        usuario.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, ana, luis)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert "email" not in perfil.model_dump()

--- a/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
@@ -1,0 +1,185 @@
+"""
+Tests del perfil de un jugador (BE #176).
+
+Lo que importa aqui es el guard: **la amistad decide si se responde, no cuanto
+se responde**. Quien no es amigo recibe exactamente el mismo error que si la
+cuenta no existiera, para que probar identificadores no sirva de detector de
+cuentas.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.exceptions import ProfileNotVisibleError
+from src.modules.social.application.use_cases.get_player_profile_use_case import (
+    GetPlayerProfileUseCase,
+)
+from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.value_objects.friendship_id import FriendshipId
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.application.dto.player_stats_dto import PlayerStatsResponseDTO
+from src.modules.user.domain.entities.user import User
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+@pytest.fixture
+def stats():
+    """Las estadisticas se prueban en su propio caso de uso; aqui solo se reutilizan."""
+    fake = AsyncMock()
+    fake.execute.return_value = PlayerStatsResponseDTO(handicap=12.3, rounds_played=7)
+    return fake
+
+
+async def _create_user(user_uow, handicap: float | None = None, active: bool = True) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=f"perfil_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    if handicap is not None:
+        user.update_handicap(handicap)
+    if not active:
+        user.deactivate(deactivated_by_user_id=str(user.id.value))
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _hacer_amigos(social_uow, a: User, b: User) -> Friendship:
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=a.id, addressee_id=b.id
+    )
+    friendship.accept()
+    async with social_uow:
+        await social_uow.friendships.add(friendship)
+    return friendship
+
+
+def _use_case(social_uow, user_uow, stats):
+    return GetPlayerProfileUseCase(social_uow, user_uow, stats)
+
+
+class TestGuardDeAmistad:
+    async def test_un_amigo_ve_el_perfil(self, social_uow, user_uow, stats):
+        """Given dos amigos / When uno pide el perfil del otro / Then lo recibe."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow, handicap=8.4)
+        await _hacer_amigos(social_uow, ana, luis)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.id == str(luis.id.value)
+        assert perfil.first_name == "Ana"
+        assert perfil.handicap == 8.4
+        assert perfil.stats.rounds_played == 7
+
+    async def test_un_desconocido_no_ve_el_perfil(self, social_uow, user_uow, stats):
+        """Given dos usuarios sin amistad / When uno pide el perfil / Then no existe para el."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await _use_case(social_uow, user_uow, stats).execute(
+                str(ana.id.value), str(luis.id.value)
+            )
+
+    async def test_una_solicitud_pendiente_todavia_no_da_acceso(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given una solicitud de amistad sin aceptar / When se pide el perfil /
+        Then no se ve: hace falta que este aceptada, no solo enviada.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        pendiente = Friendship.create(
+            id=FriendshipId(uuid4()), requester_id=ana.id, addressee_id=luis.id
+        )
+        async with social_uow:
+            await social_uow.friendships.add(pendiente)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await _use_case(social_uow, user_uow, stats).execute(
+                str(ana.id.value), str(luis.id.value)
+            )
+
+    async def test_deshacer_la_amistad_retira_el_acceso_al_instante(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given dos que eran amigos / When se deshace la amistad / Then el perfil
+        deja de verse en la peticion siguiente, sin cache que lo sostenga.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        friendship = await _hacer_amigos(social_uow, ana, luis)
+        use_case = _use_case(social_uow, user_uow, stats)
+        await use_case.execute(str(ana.id.value), str(luis.id.value))
+
+        async with social_uow:
+            await social_uow.friendships.remove(friendship)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await use_case.execute(str(ana.id.value), str(luis.id.value))
+
+    async def test_uno_siempre_puede_ver_su_propio_perfil(self, social_uow, user_uow, stats):
+        """
+        Given un jugador sin amigos / When pide su propio perfil / Then lo ve:
+        no hace falta ser amigo de uno mismo.
+        """
+        ana = await _create_user(user_uow, handicap=15.0)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(ana.id.value)
+        )
+
+        assert perfil.id == str(ana.id.value)
+
+
+class TestNoFiltraQueCuentasExisten:
+    async def test_una_cuenta_que_no_existe_da_el_mismo_error_que_un_extranio(
+        self, social_uow, user_uow, stats
+    ):
+        """
+        Given un id inventado / When se pide su perfil / Then el error es el
+        mismo que para alguien que existe pero no es amigo. Distinguirlos
+        convertiria el endpoint en un detector de cuentas.
+        """
+        ana = await _create_user(user_uow)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await _use_case(social_uow, user_uow, stats).execute(
+                str(ana.id.value), str(uuid4())
+            )
+
+    async def test_un_amigo_dado_de_baja_tampoco_se_ve(self, social_uow, user_uow, stats):
+        """Given un amigo con la cuenta desactivada / When se pide / Then no se ve."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow, active=False)
+        await _hacer_amigos(social_uow, ana, luis)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await _use_case(social_uow, user_uow, stats).execute(
+                str(ana.id.value), str(luis.id.value)
+            )

--- a/tests/unit/modules/social/application/use_cases/test_mark_feed_as_seen_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_mark_feed_as_seen_use_case.py
@@ -1,0 +1,95 @@
+"""Tests de dar el feed por visto (BE #176)."""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.use_cases.mark_feed_as_seen_use_case import (
+    MarkFeedAsSeenUseCase,
+)
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+async def _create_user(user_uow) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=f"seen_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def test_guarda_cuando_se_miro_el_feed(user_uow):
+    """Given un jugador que nunca lo abrio / When lo marca / Then queda la fecha."""
+    user = await _create_user(user_uow)
+    assert user.feed_last_seen_at is None
+
+    visto_en = await MarkFeedAsSeenUseCase(user_uow).execute(str(user.id.value))
+
+    async with user_uow:
+        guardado = await user_uow.users.find_by_id(user.id)
+    assert guardado.feed_last_seen_at == visto_en
+
+
+async def test_marcarlo_dos_veces_adelanta_la_fecha(user_uow):
+    """Given un feed ya marcado / When se marca otra vez / Then la fecha avanza."""
+    user = await _create_user(user_uow)
+    primera = await MarkFeedAsSeenUseCase(user_uow).execute(str(user.id.value))
+
+    segunda = await MarkFeedAsSeenUseCase(user_uow).execute(str(user.id.value))
+
+    assert segunda >= primera
+
+
+async def test_guarda_el_momento_de_la_llamada_y_no_una_fecha_del_pasado(user_uow):
+    """
+    Given un jugador / When marca el feed / Then la fecha es de ahora.
+
+    Importa que sea el momento de la llamada y no la del ultimo evento leido:
+    lo que se publique mientras lee debe volver a contar como novedad.
+    """
+    user = await _create_user(user_uow)
+    antes = datetime.now() - timedelta(seconds=5)
+
+    visto_en = await MarkFeedAsSeenUseCase(user_uow).execute(str(user.id.value))
+
+    assert visto_en > antes
+
+
+async def test_la_fecha_es_comparable_con_la_de_los_eventos(user_uow):
+    """
+    Given un logro publicado ahora / When se marca el feed como visto / Then la
+    marca queda por delante del logro, asi que deja de contar como novedad.
+
+    Fija la regla horaria: esta fecha se compara con el `occurred_at` de los
+    eventos, que el dominio escribe con `datetime.now()`. Si se guardara en UTC,
+    quedaria desplazada y los logros de las ultimas horas contarian como no
+    vistos para siempre.
+    """
+    user = await _create_user(user_uow)
+    ocurrio_ahora = datetime.now()
+
+    visto_en = await MarkFeedAsSeenUseCase(user_uow).execute(str(user.id.value))
+
+    assert visto_en >= ocurrio_ahora
+
+
+async def test_un_jugador_que_no_existe_falla(user_uow):
+    """Given un id inventado / When se marca / Then falla."""
+    with pytest.raises(UserNotFoundError):
+        await MarkFeedAsSeenUseCase(user_uow).execute(str(uuid4()))


### PR DESCRIPTION
Contributes to #176

Profiles, the friends feed, and the visibility rules around them.

## The visibility model changed mid-implementation

The issue as written said 404 for non-friends, reasoning that a 403 would confirm the account exists. That protection stopped making sense once it was decided that players are **searchable by name**: the account is discoverable by design, and hiding it would only prevent sending someone a friend request. [Decision recorded on the issue.](https://github.com/agustinEDev/RyderCupAM/issues/176#issuecomment-5246438957)

| | Any registered user | Friends |
|---|---|---|
| Find by name | yes | yes |
| Name, surname, photo | yes | yes |
| Handicap, stats, activity | no | yes |
| Send a friend request | yes | — |
| Remove the friendship | — | yes |

## Endpoints

```
GET /users/{id}/profile      # minimum card for anyone; full for friends
GET /users/{id}/activity     # friends only — 403 otherwise
GET /users/me/feed           # mine and my friends', cursor-paginated
PUT /users/me/feed/seen      # clears the unseen badge
```

## Decisions worth reviewing

**Private fields arrive as `null`, never zeroed.** A zero handicap reads as "plays terribly" rather than "you cannot see this".

**404 now means what it says** — the account does not exist or was deactivated. Activity answers **403**: a 403 leaks nothing once the client has just seen that player's card, and a fake 404 would only confuse it.

**The profile carries a friendship block** with `NONE` / `PENDING_SENT` / `PENDING_RECEIVED` / `ACCEPTED` / `BLOCKED` and the `friendship_id` needed to accept or remove it. The two pending states are separate because they do not lead to the same button: one waits on the other person, the other waits on you.

**Privacy is applied before paginating, not after.** Friends who turned sharing off are dropped from the author list *before* the query runs, so the page limit already applies to what can be shown. Filtering afterwards would return pages of irregular size — one of 20, the next of 14 — and leave the client unable to tell whether more remain. A test pins it: two friends with 5 achievements each, one of them silent, asking for 4 → 4 arrive, not 2.

**The feed includes your own achievements** but they never count towards `unseen_count`. A feed that omits what you just did reads as if it had not been saved, and it left the feed empty for anyone without friends yet — but being told "3 new things" about your own birdies is noise, not a notification.

**`find_friend_ids` is new** because the feed needs every friend at once. `list_friends` paginates, and half a friend list would have silently dropped the other half from the feed.

**The profile reuses `GetPlayerStatsUseCase`** rather than recomputing, so a friend's profile shows the same figures as that player's own dashboard instead of a second version that would drift.

## Security fix included

`GET /users/search-autocomplete` returned every matched user's **email address** to any authenticated caller, and the frontend rendered it (`AddFriendModal`, `SendInvitationModal`). Typing names harvested addresses of people you have no relationship with.

The email is gone. The endpoint now returns name, surname and avatar — the photo does the job the email was doing, telling apart two players with the same name — and an integration test fails if an address ever reappears in the response.

## A bug a test caught

`mark_feed_as_seen` was storing UTC. That value is compared against events' `occurred_at`, which the domain writes with `datetime.now()`, so the mark landed hours in the past and achievements published in that window would have counted as unseen **forever** — the badge would never fully clear. Fixed, with a test pinning the rule.

## Frontend note for #352

`SearchUsersItemDTO` no longer carries `email`; two screens render it today and will show blank until they switch to the avatar. `first_name` and `last_name` now arrive separated, so clients can stop splitting `full_name` on the first space — which breaks on compound surnames.

## Verification

- **2579** unit tests, **443** integration and security, 1 skipped
- `mypy` clean across 579 files; `ruff` clean on everything touched
- No migration in this PR — it reads what #175 already stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added player profile endpoints with friendship status, public details, and privacy-aware statistics.
  * Added player activity and friends feed views with cursor-based pagination.
  * Added feed “mark as seen” functionality and unseen activity counts.
  * Added privacy controls for activity and restricted profile information.
  * Improved user search results with names and avatar details while removing email addresses.
* **Tests**
  * Added comprehensive integration and unit coverage for profiles, feeds, activity visibility, privacy, pagination, and friendship behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->