### PR TITLE
feat(social): Profile photo gallery

### DIFF
--- a/alembic/versions/f7c2a9d4e6b8_add_profile_photos_table.py
+++ b/alembic/versions/f7c2a9d4e6b8_add_profile_photos_table.py
@@ -1,0 +1,53 @@
+"""add profile_photos table
+
+Revision ID: f7c2a9d4e6b8
+Revises: d4e8f1a3b7c9
+Create Date: 2026-08-11
+
+Galeria de fotos del perfil (BE #177).
+
+Las imagenes se guardan en la base de datos, como los avatares. A 1080 px y
+calidad 85 cada foto pesa unos 375 KB, con tope de 10 por perfil: unos 3,7 MB
+por jugador. Postgres guarda los `BYTEA` grandes comprimidos en una tabla
+auxiliar (TOAST), asi que su peso no penaliza a ninguna consulta que no pida la
+columna `image_data` — y el listado de la galeria no la pide.
+
+Senal acordada para mover las imagenes fuera de la base de datos: cuando esta
+tabla pase de 2 GB o el backup tarde mas de un par de minutos. Migrar entonces
+es mover bytes y cambiar de donde se leen, no rehacer la funcionalidad.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7c2a9d4e6b8"
+down_revision = "d4e8f1a3b7c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "profile_photos",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column("image_data", sa.LargeBinary(), nullable=False),
+        sa.Column("content_type", sa.String(50), nullable=False),
+        sa.Column("caption", sa.String(280), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    # La galeria siempre se pide igual: las fotos de este jugador, de la mas
+    # reciente a la mas antigua
+    op.create_index(
+        "ix_profile_photos_user_created",
+        "profile_photos",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_profile_photos_user_created", table_name="profile_photos")
+    op.drop_table("profile_photos")

--- a/main.py
+++ b/main.py
@@ -57,9 +57,13 @@ from src.modules.quick_match.infrastructure.persistence.mappers.quick_match_mapp
     start_quick_match_mappers,
 )
 from src.modules.social.infrastructure.api.v1 import friend_routes  # noqa: E402
+from src.modules.social.infrastructure.api.v1 import profile_photo_routes  # noqa: E402
 from src.modules.social.infrastructure.api.v1 import profile_routes  # noqa: E402
 from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper import (  # noqa: E402
     start_activity_event_mappers,
+)
+from src.modules.social.infrastructure.persistence.mappers.profile_photo_mapper import (  # noqa: E402
+    start_profile_photo_mappers,
 )
 from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (  # noqa: E402
     start_social_mappers,
@@ -113,6 +117,7 @@ async def lifespan(app: FastAPI):  # noqa: ARG001 - FastAPI requires this signat
     start_golf_course_mappers()  # Golf Course module mappers (before Competition - dependency)
     start_competition_mappers()  # Competition module mappers (depends on GolfCourse)
     start_social_mappers()  # Social module mappers (depends on User)
+    start_profile_photo_mappers()  # Profile photo gallery (depends on User)
     start_activity_event_mappers()  # Activity feed (depends on User)
     start_quick_match_mappers()  # QuickMatch module mappers (depends on User, GolfCourse)
     yield
@@ -439,6 +444,12 @@ app.include_router(
     profile_routes.router,
     prefix="/api/v1",
     tags=["Profiles & Feed"],
+)
+
+app.include_router(
+    profile_photo_routes.router,
+    prefix="/api/v1",
+    tags=["Profile Photos"],
 )
 
 app.include_router(

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -266,6 +266,9 @@ from src.modules.social.application.ports.social_email_service_interface import 
     ISocialEmailService,
 )
 from src.modules.social.application.use_cases.block_user_use_case import BlockUserUseCase
+from src.modules.social.application.use_cases.delete_profile_photo_use_case import (
+    DeleteProfilePhotoUseCase,
+)
 from src.modules.social.application.use_cases.get_friends_feed_use_case import (
     GetFriendsFeedUseCase,
 )
@@ -274,6 +277,12 @@ from src.modules.social.application.use_cases.get_player_activity_use_case impor
 )
 from src.modules.social.application.use_cases.get_player_profile_use_case import (
     GetPlayerProfileUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_gallery_use_case import (
+    GetProfileGalleryUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_photo_image_use_case import (
+    GetProfilePhotoImageUseCase,
 )
 from src.modules.social.application.use_cases.list_friends_use_case import ListFriendsUseCase
 from src.modules.social.application.use_cases.list_pending_requests_use_case import (
@@ -297,6 +306,9 @@ from src.modules.social.application.use_cases.send_friend_request_use_case impor
 )
 from src.modules.social.application.use_cases.set_activity_sharing_use_case import (
     SetActivitySharingUseCase,
+)
+from src.modules.social.application.use_cases.upload_profile_photo_use_case import (
+    UploadProfilePhotoUseCase,
 )
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
@@ -1346,6 +1358,37 @@ def get_player_differentials(
 ) -> PlayerDifferentialsInterface:
     """Proveedor del puerto de diferenciales que usa el feed de logros."""
     return StatsPlayerDifferentialsAdapter(stats_use_case)
+
+
+def get_upload_profile_photo_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    image_processor: IImageProcessor = Depends(get_image_processor),
+) -> UploadProfilePhotoUseCase:
+    """Proveedor del caso de uso UploadProfilePhotoUseCase."""
+    return UploadProfilePhotoUseCase(social_uow, user_uow, image_processor)
+
+
+def get_profile_gallery_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> GetProfileGalleryUseCase:
+    """Proveedor del caso de uso GetProfileGalleryUseCase."""
+    return GetProfileGalleryUseCase(social_uow, user_uow)
+
+
+def get_profile_photo_image_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+) -> GetProfilePhotoImageUseCase:
+    """Proveedor del caso de uso GetProfilePhotoImageUseCase."""
+    return GetProfilePhotoImageUseCase(social_uow)
+
+
+def get_delete_profile_photo_use_case(
+    social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
+) -> DeleteProfilePhotoUseCase:
+    """Proveedor del caso de uso DeleteProfilePhotoUseCase."""
+    return DeleteProfilePhotoUseCase(social_uow)
 
 
 def get_player_profile_use_case(

--- a/src/modules/social/application/dto/profile_photo_dto.py
+++ b/src/modules/social/application/dto/profile_photo_dto.py
@@ -11,7 +11,7 @@ class ProfilePhotoDTO(BaseModel):
 
     Los bytes no van aqui: se piden aparte, uno por foto, y el navegador los
     cachea para siempre porque una foto no cambia nunca. Meterlos en el listado
-    haria que abrir un perfil moviera casi cuatro megas en base64 cada vez.
+    haria que abrir un perfil moviera siete megas en base64 cada vez.
     """
 
     id: str

--- a/src/modules/social/application/dto/profile_photo_dto.py
+++ b/src/modules/social/application/dto/profile_photo_dto.py
@@ -1,0 +1,31 @@
+"""DTOs de la galeria de fotos del perfil."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProfilePhotoDTO(BaseModel):
+    """
+    Una foto de la galeria, **sin la imagen**.
+
+    Los bytes no van aqui: se piden aparte, uno por foto, y el navegador los
+    cachea para siempre porque una foto no cambia nunca. Meterlos en el listado
+    haria que abrir un perfil moviera casi cuatro megas en base64 cada vez.
+    """
+
+    id: str
+    user_id: str
+    caption: str | None = None
+    created_at: datetime
+    url: str = Field(description="De donde bajar la imagen de esta foto")
+
+
+class ProfileGalleryResponseDTO(BaseModel):
+    """La galeria de un jugador."""
+
+    photos: list[ProfilePhotoDTO] = Field(default_factory=list)
+    total: int = Field(default=0, description="Cuantas fotos tiene")
+    remaining_slots: int = Field(
+        default=0, description="Cuantas mas puede subir antes de llegar al tope"
+    )

--- a/src/modules/social/application/exceptions.py
+++ b/src/modules/social/application/exceptions.py
@@ -38,6 +38,24 @@ class ProfileNotVisibleError(Exception):
     pass
 
 
+class ProfileGalleryFullError(Exception):
+    """
+    La galeria ya tiene el maximo de fotos.
+
+    Se rechaza la subida en lugar de borrar la mas antigua para hacer sitio. Los
+    avatares si podan, porque son historial de una misma cosa; aqui cada foto es
+    una decision del jugador y quitarle una sin avisar seria perderle contenido.
+    """
+
+    pass
+
+
+class PhotoNotFoundError(Exception):
+    """La foto pedida no existe, o no es de quien intenta manejarla."""
+
+    pass
+
+
 class ActivityNotVisibleError(Exception):
     """
     La actividad de ese jugador es privada para quien pregunta.

--- a/src/modules/social/application/use_cases/delete_profile_photo_use_case.py
+++ b/src/modules/social/application/use_cases/delete_profile_photo_use_case.py
@@ -1,0 +1,37 @@
+"""Caso de Uso: Borrar una foto de la galeria propia."""
+
+from src.modules.social.application.exceptions import PhotoNotFoundError
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class DeleteProfilePhotoUseCase:
+    """
+    Borra una foto propia.
+
+    **Solo el dueño borra sus fotos**, ni siquiera un amigo. Y una foto de otro
+    da el mismo error que una que no existe: decir "existe pero no es tuya"
+    convertiria el endpoint en una forma de comprobar que ids de foto son
+    reales.
+
+    El borrado es definitivo, sin papelera: la foto ocupa espacio en la base de
+    datos y guardarla "por si acaso" es justo lo que llena el disco que esta
+    galeria intenta no llenar.
+    """
+
+    def __init__(self, social_uow: SocialUnitOfWorkInterface):
+        self._social_uow = social_uow
+
+    async def execute(self, user_id_raw: str, photo_id_raw: str) -> None:
+        user_id = UserId(user_id_raw)
+        photo_id = ProfilePhotoId(photo_id_raw)
+
+        async with self._social_uow:
+            photo = await self._social_uow.profile_photos.find_by_id(photo_id)
+            if photo is None or not photo.belongs_to(user_id):
+                raise PhotoNotFoundError("Photo not found")
+
+            await self._social_uow.profile_photos.delete(photo_id)

--- a/src/modules/social/application/use_cases/get_profile_gallery_use_case.py
+++ b/src/modules/social/application/use_cases/get_profile_gallery_use_case.py
@@ -28,7 +28,7 @@ class GetProfileGalleryUseCase:
     existencia no es ningun secreto.
 
     El listado **no lleva las imagenes**, solo por donde bajarlas. Diez fotos son
-    casi cuatro megas: mandarlas dentro del listado obligaria a esperar a que
+    mas de siete megas: mandarlas dentro del listado obligaria a esperar a que
     llegaran todas para pintar nada, cuando el navegador puede pedirlas por
     separado, en paralelo, y guardarlas en cache para la proxima visita.
     """

--- a/src/modules/social/application/use_cases/get_profile_gallery_use_case.py
+++ b/src/modules/social/application/use_cases/get_profile_gallery_use_case.py
@@ -1,0 +1,76 @@
+"""Caso de Uso: Ver la galeria de fotos de un jugador."""
+
+from src.modules.social.application.dto.profile_photo_dto import (
+    ProfileGalleryResponseDTO,
+    ProfilePhotoDTO,
+)
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    ProfileNotVisibleError,
+)
+from src.modules.social.domain.entities.profile_photo import MAX_PHOTOS_PER_PROFILE
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class GetProfileGalleryUseCase:
+    """
+    Las fotos de un jugador, **solo para sus amigos**.
+
+    Mismo reparto que la actividad: la ficha de alguien la ve cualquiera, pero
+    lo que hay detras es entre amigos. Y el mismo trato a los errores — 403 si
+    no sois amigos, 404 si el jugador no esta — porque a estas alturas su
+    existencia no es ningun secreto.
+
+    El listado **no lleva las imagenes**, solo por donde bajarlas. Diez fotos son
+    casi cuatro megas: mandarlas dentro del listado obligaria a esperar a que
+    llegaran todas para pintar nada, cuando el navegador puede pedirlas por
+    separado, en paralelo, y guardarlas en cache para la proxima visita.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+    ):
+        self._social_uow = social_uow
+        self._user_uow = user_uow
+
+    async def execute(self, viewer_id_raw: str, target_id_raw: str) -> ProfileGalleryResponseDTO:
+        viewer_id = UserId(viewer_id_raw)
+        target_id = UserId(target_id_raw)
+
+        async with self._user_uow:
+            target = await self._user_uow.users.find_by_id(target_id)
+            if target is None or not target.is_active:
+                raise ProfileNotVisibleError("Profile not found")
+
+        if viewer_id != target_id:
+            async with self._social_uow:
+                if not await self._social_uow.friendships.are_friends(viewer_id, target_id):
+                    raise ActivityNotVisibleError("Only friends can see this player's photos")
+
+        async with self._social_uow:
+            fotos = await self._social_uow.profile_photos.find_metadata_by_user(target_id)
+
+        return ProfileGalleryResponseDTO(
+            photos=[
+                ProfilePhotoDTO(
+                    id=str(foto.id.value),
+                    user_id=str(target_id.value),
+                    caption=foto.caption,
+                    created_at=foto.created_at,
+                    url=f"/api/v1/users/{target_id.value}/photos/{foto.id.value}/image",
+                )
+                for foto in fotos
+            ],
+            total=len(fotos),
+            # Solo tiene sentido para uno mismo, pero se calcula igual: al cliente
+            # le sale gratis y evita una segunda llamada para saber si puede subir
+            remaining_slots=max(0, MAX_PHOTOS_PER_PROFILE - len(fotos)),
+        )

--- a/src/modules/social/application/use_cases/get_profile_photo_image_use_case.py
+++ b/src/modules/social/application/use_cases/get_profile_photo_image_use_case.py
@@ -32,7 +32,7 @@ class GetProfilePhotoImageUseCase:
     quedarselos indefinidamente.
 
     Esto es lo que decide si la galeria es viable: cada foto la sirve el backend
-    ocupando un worker, y un perfil con diez fotos son diez peticiones. Sin
+    ocupando un worker, y un perfil lleno son veinte peticiones. Sin
     cache, cada visita al perfil las pide las diez otra vez.
     """
 

--- a/src/modules/social/application/use_cases/get_profile_photo_image_use_case.py
+++ b/src/modules/social/application/use_cases/get_profile_photo_image_use_case.py
@@ -1,0 +1,69 @@
+"""Caso de Uso: Servir la imagen de una foto del perfil."""
+
+from dataclasses import dataclass
+
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    PhotoNotFoundError,
+)
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+@dataclass(frozen=True)
+class PhotoImage:
+    """La imagen y lo que hace falta para cachearla."""
+
+    data: bytes
+    content_type: str
+    etag: str
+
+
+class GetProfilePhotoImageUseCase:
+    """
+    Los bytes de una foto, con lo necesario para no volver a pedirlos.
+
+    **El ETag es el id de la foto**, y puede serlo porque la imagen es
+    inmutable: no se edita una foto, se borra y se sube otra con otro id. Unos
+    bytes servidos bajo un id nunca van a cambiar, asi que el navegador puede
+    quedarselos indefinidamente.
+
+    Esto es lo que decide si la galeria es viable: cada foto la sirve el backend
+    ocupando un worker, y un perfil con diez fotos son diez peticiones. Sin
+    cache, cada visita al perfil las pide las diez otra vez.
+    """
+
+    def __init__(self, social_uow: SocialUnitOfWorkInterface):
+        self._social_uow = social_uow
+
+    async def execute(
+        self, viewer_id_raw: str, owner_id_raw: str, photo_id_raw: str
+    ) -> PhotoImage:
+        viewer_id = UserId(viewer_id_raw)
+        owner_id = UserId(owner_id_raw)
+        photo_id = ProfilePhotoId(photo_id_raw)
+
+        async with self._social_uow:
+            if viewer_id != owner_id and not await self._social_uow.friendships.are_friends(
+                viewer_id, owner_id
+            ):
+                raise ActivityNotVisibleError("Only friends can see this player's photos")
+
+            photo = await self._social_uow.profile_photos.find_by_id(photo_id)
+
+        # Se comprueba tambien que la foto sea de quien dice la ruta: sin esto,
+        # un id de foto valido serviria desde la ruta de cualquier amigo y se
+        # saltaria el guard del dueño real
+        if photo is None or not photo.belongs_to(owner_id):
+            raise PhotoNotFoundError("Photo not found")
+
+        return PhotoImage(
+            data=photo.image_data,
+            content_type=photo.content_type,
+            # Entrecomillado porque un ETag es una cadena entrecomillada segun
+            # la norma HTTP, y sin las comillas algunos proxies lo descartan
+            etag=f'"{photo.id.value}"',
+        )

--- a/src/modules/social/application/use_cases/upload_profile_photo_use_case.py
+++ b/src/modules/social/application/use_cases/upload_profile_photo_use_case.py
@@ -1,0 +1,100 @@
+"""Caso de Uso: Subir una foto a la galeria del perfil."""
+
+import asyncio
+
+from src.modules.social.application.dto.profile_photo_dto import ProfilePhotoDTO
+from src.modules.social.application.exceptions import ProfileGalleryFullError
+from src.modules.social.domain.entities.profile_photo import (
+    MAX_PHOTOS_PER_PROFILE,
+    ProfilePhoto,
+)
+from src.modules.social.domain.repositories.social_unit_of_work_interface import (
+    SocialUnitOfWorkInterface,
+)
+from src.modules.user.application.ports.image_processor_interface import IImageProcessor
+from src.modules.user.domain.errors.user_errors import (
+    AvatarUploadTooLargeError,
+    UserNotFoundError,
+)
+from src.modules.user.domain.repositories.user_unit_of_work_interface import (
+    UserUnitOfWorkInterface,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# Peso maximo del archivo ANTES de procesar. Rechazo temprano: evita gastar CPU
+# decodificando archivos absurdos, y es el mismo tope que ya tienen los avatares.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+
+class UploadProfilePhotoUseCase:
+    """
+    Sube una foto a la galeria del jugador.
+
+    Reutiliza la tuberia de imagenes de los avatares —validacion de formato,
+    tope de pixeles, correccion de orientacion EXIF y compresion— cambiando solo
+    el destino: 1080 px por el lado mayor y **sin recortar a cuadrado**, porque
+    una foto de una vuelta suele ser apaisada y el recorte central se comeria
+    medio campo.
+
+    **El tope es un rechazo, no una poda.** Los avatares borran el mas antiguo
+    al pasarse porque son historial de una misma cosa; aqui cada foto es una
+    decision del jugador, y borrarle una sin avisar para hacer sitio seria
+    perderle contenido. Al llegar a diez se le dice que borre alguna.
+    """
+
+    def __init__(
+        self,
+        social_uow: SocialUnitOfWorkInterface,
+        user_uow: UserUnitOfWorkInterface,
+        image_processor: IImageProcessor,
+    ):
+        self._social_uow = social_uow
+        self._user_uow = user_uow
+        self._image_processor = image_processor
+
+    async def execute(
+        self, user_id_raw: str, raw_bytes: bytes, caption: str | None = None
+    ) -> ProfilePhotoDTO:
+        if len(raw_bytes) > MAX_UPLOAD_BYTES:
+            raise AvatarUploadTooLargeError(
+                f"El archivo supera el tamaño máximo permitido "
+                f"({MAX_UPLOAD_BYTES // (1024 * 1024)}MB)"
+            )
+
+        user_id = UserId(user_id_raw)
+
+        async with self._user_uow:
+            user = await self._user_uow.users.find_by_id(user_id)
+            if user is None or not user.is_active:
+                raise UserNotFoundError(f"User with id {user_id_raw} not found")
+
+        async with self._social_uow:
+            ya_tiene = await self._social_uow.profile_photos.count_by_user(user_id)
+        if ya_tiene >= MAX_PHOTOS_PER_PROFILE:
+            raise ProfileGalleryFullError(
+                f"La galería está llena ({MAX_PHOTOS_PER_PROFILE} fotos). "
+                f"Borra alguna antes de subir otra."
+            )
+
+        # Procesado fuera de cualquier transaccion: es CPU-bound y no necesita la
+        # sesion abierta. Y en un hilo aparte porque Pillow es sincrono: sin eso,
+        # redimensionar una foto bloquearia TODAS las peticiones del proceso
+        # mientras dura
+        processed = await asyncio.to_thread(
+            self._image_processor.process_gallery_image, raw_bytes
+        )
+
+        photo = ProfilePhoto.create(
+            user_id=user_id, image_data=processed, content_type="image/jpeg", caption=caption
+        )
+
+        async with self._social_uow:
+            await self._social_uow.profile_photos.add(photo)
+
+        return ProfilePhotoDTO(
+            id=str(photo.id.value),
+            user_id=str(user_id.value),
+            caption=photo.caption,
+            created_at=photo.created_at,
+            url=f"/api/v1/users/{user_id.value}/photos/{photo.id.value}/image",
+        )

--- a/src/modules/social/domain/entities/profile_photo.py
+++ b/src/modules/social/domain/entities/profile_photo.py
@@ -5,9 +5,15 @@ from datetime import datetime
 from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
 from src.modules.user.domain.value_objects.user_id import UserId
 
-# Tope de fotos por perfil. A 375 KB cada una son ~3,7 MB por jugador; 200
-# jugadores ocupan unos 750 MB de los 10 GB contratados (BE #177).
-MAX_PHOTOS_PER_PROFILE = 10
+# Tope de fotos por perfil. A 375 KB cada una son ~7,3 MB por jugador: 200
+# jugadores ocupan 1,4 GB de los 10 GB contratados (BE #177).
+#
+# No lo limita el disco sino la señal acordada para sacar las imagenes de la
+# base de datos —tabla por encima de 2 GB—, que con este tope se alcanza sobre
+# los 280 jugadores en lugar de los 560 que daban 10 fotos. Sigue siendo margen
+# de sobra para una aplicacion entre amigos, y migrar entonces es mover bytes,
+# no rehacer nada.
+MAX_PHOTOS_PER_PROFILE = 20
 
 
 class ProfilePhoto:

--- a/src/modules/social/domain/entities/profile_photo.py
+++ b/src/modules/social/domain/entities/profile_photo.py
@@ -1,0 +1,123 @@
+"""Entidad: ProfilePhoto — una foto de la galeria de un jugador."""
+
+from datetime import datetime
+
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+# Tope de fotos por perfil. A 375 KB cada una son ~3,7 MB por jugador; 200
+# jugadores ocupan unos 750 MB de los 10 GB contratados (BE #177).
+MAX_PHOTOS_PER_PROFILE = 10
+
+
+class ProfilePhoto:
+    """
+    Una foto que un jugador ha subido a su perfil.
+
+    Vive en el modulo social y no junto a los avatares porque **su visibilidad
+    es una regla social**: la ficha de alguien la ve cualquiera, pero sus fotos
+    solo sus amigos. El avatar es lo contrario —identidad publica, hace falta
+    para reconocerlo en una busqueda— y por eso se quedan separados.
+
+    La imagen es inmutable: no se edita una foto, se borra y se sube otra. Eso
+    es lo que permite cachearla para siempre en el cliente, porque unos bytes
+    servidos bajo un id nunca van a cambiar.
+
+    El caption es lo unico editable, y es opcional: la mayoria de fotos no
+    necesitan pie.
+    """
+
+    def __init__(
+        self,
+        id: ProfilePhotoId | None,
+        user_id: UserId,
+        image_data: bytes,
+        content_type: str,
+        caption: str | None = None,
+        created_at: datetime | None = None,
+    ):
+        if not image_data:
+            raise ValueError("image_data cannot be empty")
+        if not isinstance(user_id, UserId):
+            raise TypeError("user_id must be a UserId")
+
+        self._id = id or ProfilePhotoId.generate()
+        self._user_id = user_id
+        self._image_data = image_data
+        self._content_type = content_type
+        self._caption = self._clean_caption(caption)
+        self._created_at = created_at or datetime.now()
+
+    @classmethod
+    def create(
+        cls,
+        user_id: UserId,
+        image_data: bytes,
+        content_type: str = "image/jpeg",
+        caption: str | None = None,
+    ) -> "ProfilePhoto":
+        return cls(
+            id=ProfilePhotoId.generate(),
+            user_id=user_id,
+            image_data=image_data,
+            content_type=content_type,
+            caption=caption,
+        )
+
+    @classmethod
+    def reconstruct(cls, **props) -> "ProfilePhoto":
+        return cls(**props)
+
+    # === Getters ===
+
+    @property
+    def id(self) -> ProfilePhotoId:
+        return self._id
+
+    @property
+    def user_id(self) -> UserId:
+        return self._user_id
+
+    @property
+    def image_data(self) -> bytes:
+        return self._image_data
+
+    @property
+    def content_type(self) -> str:
+        return self._content_type
+
+    @property
+    def caption(self) -> str | None:
+        return self._caption
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
+
+    # === Reglas ===
+
+    def belongs_to(self, user_id: UserId) -> bool:
+        """Si la foto es de ese jugador. Lo comprueba quien intenta borrarla."""
+        return self._user_id == user_id
+
+    @staticmethod
+    def _clean_caption(caption: str | None) -> str | None:
+        """
+        Un pie en blanco es lo mismo que no tener pie.
+
+        Se normaliza aqui para que la base de datos no acabe con una mezcla de
+        NULL y cadenas vacias que signifiquen lo mismo.
+        """
+        if caption is None:
+            return None
+        limpio = caption.strip()
+        return limpio or None
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ProfilePhoto) and self._id == other._id
+
+    def __hash__(self) -> int:
+        return hash(self._id)
+
+    def __repr__(self) -> str:
+        return f"<ProfilePhoto {self._id} user={self._user_id.value}>"

--- a/src/modules/social/domain/repositories/profile_photo_repository_interface.py
+++ b/src/modules/social/domain/repositories/profile_photo_repository_interface.py
@@ -14,8 +14,8 @@ class ProfilePhotoMetadata:
     """
     Una foto **sin sus bytes**.
 
-    Existe porque listar una galeria no necesita las imagenes: diez fotos son
-    casi cuatro megas, y pintarlas es cosa de diez peticiones aparte que el
+    Existe porque listar una galeria no necesita las imagenes: una galeria llena
+    son mas de siete megas, y pintarlas es cosa de peticiones aparte que el
     navegador cachea. Traerlas para enseñar una lista de miniaturas seria mover
     esos megas en cada visita al perfil para tirarlos acto seguido.
     """

--- a/src/modules/social/domain/repositories/profile_photo_repository_interface.py
+++ b/src/modules/social/domain/repositories/profile_photo_repository_interface.py
@@ -1,0 +1,53 @@
+"""Interfaz del repositorio de fotos de perfil."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.modules.social.domain.entities.profile_photo import ProfilePhoto
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+@dataclass(frozen=True)
+class ProfilePhotoMetadata:
+    """
+    Una foto **sin sus bytes**.
+
+    Existe porque listar una galeria no necesita las imagenes: diez fotos son
+    casi cuatro megas, y pintarlas es cosa de diez peticiones aparte que el
+    navegador cachea. Traerlas para enseñar una lista de miniaturas seria mover
+    esos megas en cada visita al perfil para tirarlos acto seguido.
+    """
+
+    id: ProfilePhotoId
+    user_id: UserId
+    caption: str | None
+    created_at: datetime
+
+
+class ProfilePhotoRepositoryInterface(ABC):
+    """Acceso a las fotos de perfil."""
+
+    @abstractmethod
+    async def add(self, photo: ProfilePhoto) -> None:
+        """Guarda una foto nueva."""
+
+    @abstractmethod
+    async def find_by_id(self, photo_id: ProfilePhotoId) -> ProfilePhoto | None:
+        """La foto entera, con sus bytes. Es lo que se sirve al pedir la imagen."""
+
+    @abstractmethod
+    async def find_metadata_by_user(self, user_id: UserId) -> list[ProfilePhotoMetadata]:
+        """
+        La galeria de un jugador, de la mas reciente a la mas antigua y **sin
+        los bytes de las imagenes**.
+        """
+
+    @abstractmethod
+    async def count_by_user(self, user_id: UserId) -> int:
+        """Cuantas fotos tiene ya. Lo consulta el tope por perfil."""
+
+    @abstractmethod
+    async def delete(self, photo_id: ProfilePhotoId) -> bool:
+        """Borra una foto. Devuelve si existia."""

--- a/src/modules/social/domain/repositories/social_unit_of_work_interface.py
+++ b/src/modules/social/domain/repositories/social_unit_of_work_interface.py
@@ -10,6 +10,7 @@ from src.shared.domain.repositories.unit_of_work_interface import UnitOfWorkInte
 
 from .activity_event_repository_interface import ActivityEventRepositoryInterface
 from .friendship_repository_interface import FriendshipRepositoryInterface
+from .profile_photo_repository_interface import ProfilePhotoRepositoryInterface
 
 
 class SocialUnitOfWorkInterface(UnitOfWorkInterface):
@@ -30,4 +31,10 @@ class SocialUnitOfWorkInterface(UnitOfWorkInterface):
     @abstractmethod
     def activity_events(self) -> ActivityEventRepositoryInterface:
         """Acceso al repositorio de eventos de actividad."""
+        pass
+
+    @property
+    @abstractmethod
+    def profile_photos(self) -> ProfilePhotoRepositoryInterface:
+        """Acceso al repositorio de fotos de perfil."""
         pass

--- a/src/modules/social/domain/value_objects/profile_photo_id.py
+++ b/src/modules/social/domain/value_objects/profile_photo_id.py
@@ -1,0 +1,37 @@
+"""Value Object: identificador de una foto de la galeria."""
+
+import uuid
+from dataclasses import dataclass
+
+
+class InvalidProfilePhotoIdError(Exception):
+    """El identificador de foto no es valido."""
+
+
+@dataclass(frozen=True)
+class ProfilePhotoId:
+    """Identificador unico de una foto del perfil."""
+
+    value: uuid.UUID
+
+    def __init__(self, value: uuid.UUID | str):
+        if isinstance(value, uuid.UUID):
+            val = value
+        elif isinstance(value, str):
+            try:
+                val = uuid.UUID(value)
+            except ValueError as error:
+                raise InvalidProfilePhotoIdError(f"'{value}' no es un UUID valido") from error
+        else:
+            raise InvalidProfilePhotoIdError(
+                f"Se esperaba un UUID o un string, se recibio {type(value)}"
+            )
+
+        object.__setattr__(self, "value", val)
+
+    @classmethod
+    def generate(cls) -> "ProfilePhotoId":
+        return cls(uuid.uuid4())
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -155,7 +155,7 @@ async def get_photo_image(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
     # Si el cliente ya la tiene, no se reenvian los bytes. Es lo que evita que
-    # abrir un perfil diez veces mueva cuarenta megas
+    # abrir un perfil diez veces mueva setenta megas
     if request.headers.get("if-none-match") == imagen.etag:
         return Response(
             status_code=status.HTTP_304_NOT_MODIFIED,

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -1,0 +1,189 @@
+"""
+Profile Photo Routes - API REST Layer (Infrastructure).
+
+Galeria de fotos del perfil (BE #177).
+"""
+
+import logging
+from uuid import UUID
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
+
+from src.config.dependencies import (
+    get_current_user,
+    get_delete_profile_photo_use_case,
+    get_profile_gallery_use_case,
+    get_profile_photo_image_use_case,
+    get_upload_profile_photo_use_case,
+)
+from src.config.rate_limit import limiter
+from src.modules.social.application.dto.profile_photo_dto import (
+    ProfileGalleryResponseDTO,
+    ProfilePhotoDTO,
+)
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    PhotoNotFoundError,
+    ProfileGalleryFullError,
+    ProfileNotVisibleError,
+)
+from src.modules.social.application.use_cases.delete_profile_photo_use_case import (
+    DeleteProfilePhotoUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_gallery_use_case import (
+    GetProfileGalleryUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_photo_image_use_case import (
+    GetProfilePhotoImageUseCase,
+)
+from src.modules.social.application.use_cases.upload_profile_photo_use_case import (
+    UploadProfilePhotoUseCase,
+)
+from src.modules.user.application.dto.user_dto import UserResponseDTO
+from src.modules.user.domain.errors.user_errors import (
+    AvatarUploadTooLargeError,
+    InvalidAvatarImageError,
+    UserNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# Un año, que es el maximo que recomienda la norma. Se puede ser tan agresivo
+# porque la imagen es inmutable: no se edita una foto, se borra y se sube otra
+# con otro id, asi que estos bytes bajo este id no van a cambiar nunca.
+# `private` porque las fotos son solo para amigos: una cache compartida no debe
+# quedarselas y servirselas a otro.
+PHOTO_CACHE_CONTROL = "private, max-age=31536000, immutable"
+
+
+@router.post(
+    "/users/me/photos",
+    response_model=ProfilePhotoDTO,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload a photo to my gallery",
+    description=(
+        "Adds a photo to your profile gallery. Resized to 1080px on its longest side and "
+        "recompressed, keeping its original proportions — no square crop. Rejected with "
+        "409 when the gallery is full rather than silently dropping your oldest photo."
+    ),
+)
+@limiter.limit("30/hour")
+async def upload_my_photo(
+    request: Request,  # noqa: ARG001 - Required by SlowAPI for rate limiting
+    file: UploadFile = File(..., description="Image file (JPEG, PNG or WEBP)"),
+    caption: str | None = Form(None, max_length=280),
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: UploadProfilePhotoUseCase = Depends(get_upload_profile_photo_use_case),
+):
+    raw = await file.read()
+    try:
+        return await use_case.execute(str(current_user.id), raw, caption=caption)
+    except ProfileGalleryFullError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except AvatarUploadTooLargeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(e)
+        ) from e
+    except InvalidAvatarImageError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.get(
+    "/users/{user_id}/photos",
+    response_model=ProfileGalleryResponseDTO,
+    summary="Get a player's photo gallery",
+    description=(
+        "The photos a friend has on their profile, newest first. Friends only: 403 "
+        "otherwise. Returns where to fetch each image, not the images themselves — ten "
+        "photos are nearly four megabytes, and the browser fetches and caches them "
+        "separately."
+    ),
+)
+async def get_player_gallery(
+    user_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetProfileGalleryUseCase = Depends(get_profile_gallery_use_case),
+):
+    try:
+        return await use_case.execute(str(current_user.id), str(user_id))
+    except ProfileNotVisibleError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found"
+        ) from e
+    except ActivityNotVisibleError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+
+
+@router.get(
+    "/users/{user_id}/photos/{photo_id}/image",
+    summary="Get a photo's image",
+    description=(
+        "The image bytes. Cached for a year with an ETag, because a photo never changes: "
+        "editing one means deleting it and uploading another with a different id. Sends "
+        "304 when the client already has it."
+    ),
+    responses={
+        200: {"content": {"image/jpeg": {}}, "description": "The image"},
+        304: {"description": "The client's cached copy is still good"},
+    },
+)
+async def get_photo_image(
+    user_id: UUID,
+    photo_id: UUID,
+    request: Request,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetProfilePhotoImageUseCase = Depends(get_profile_photo_image_use_case),
+):
+    try:
+        imagen = await use_case.execute(str(current_user.id), str(user_id), str(photo_id))
+    except ActivityNotVisibleError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except PhotoNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    # Si el cliente ya la tiene, no se reenvian los bytes. Es lo que evita que
+    # abrir un perfil diez veces mueva cuarenta megas
+    if request.headers.get("if-none-match") == imagen.etag:
+        return Response(
+            status_code=status.HTTP_304_NOT_MODIFIED,
+            headers={"ETag": imagen.etag, "Cache-Control": PHOTO_CACHE_CONTROL},
+        )
+
+    return Response(
+        content=imagen.data,
+        media_type=imagen.content_type,
+        headers={"ETag": imagen.etag, "Cache-Control": PHOTO_CACHE_CONTROL},
+    )
+
+
+@router.delete(
+    "/users/me/photos/{photo_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete one of my photos",
+    description=(
+        "Permanently deletes a photo from your gallery. Someone else's photo gives the "
+        "same 404 as one that does not exist."
+    ),
+)
+async def delete_my_photo(
+    photo_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: DeleteProfilePhotoUseCase = Depends(get_delete_profile_photo_use_case),
+):
+    try:
+        await use_case.execute(str(current_user.id), str(photo_id))
+    except PhotoNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_profile_photo_repository.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_profile_photo_repository.py
@@ -1,0 +1,38 @@
+"""In-Memory Profile Photo Repository para testing."""
+
+from src.modules.social.domain.entities.profile_photo import ProfilePhoto
+from src.modules.social.domain.repositories.profile_photo_repository_interface import (
+    ProfilePhotoMetadata,
+    ProfilePhotoRepositoryInterface,
+)
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class InMemoryProfilePhotoRepository(ProfilePhotoRepositoryInterface):
+    """Implementacion en memoria del repositorio de fotos de perfil."""
+
+    def __init__(self):
+        self._photos: dict[ProfilePhotoId, ProfilePhoto] = {}
+
+    async def add(self, photo: ProfilePhoto) -> None:
+        self._photos[photo.id] = photo
+
+    async def find_by_id(self, photo_id: ProfilePhotoId) -> ProfilePhoto | None:
+        return self._photos.get(photo_id)
+
+    async def find_metadata_by_user(self, user_id: UserId) -> list[ProfilePhotoMetadata]:
+        de_este = [p for p in self._photos.values() if p.user_id == user_id]
+        de_este.sort(key=lambda p: p.created_at, reverse=True)
+        return [
+            ProfilePhotoMetadata(
+                id=p.id, user_id=p.user_id, caption=p.caption, created_at=p.created_at
+            )
+            for p in de_este
+        ]
+
+    async def count_by_user(self, user_id: UserId) -> int:
+        return len([p for p in self._photos.values() if p.user_id == user_id])
+
+    async def delete(self, photo_id: ProfilePhotoId) -> bool:
+        return self._photos.pop(photo_id, None) is not None

--- a/src/modules/social/infrastructure/persistence/in_memory/in_memory_social_unit_of_work.py
+++ b/src/modules/social/infrastructure/persistence/in_memory/in_memory_social_unit_of_work.py
@@ -6,6 +6,9 @@ from src.modules.social.domain.repositories.activity_event_repository_interface 
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
+from src.modules.social.domain.repositories.profile_photo_repository_interface import (
+    ProfilePhotoRepositoryInterface,
+)
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
 )
@@ -15,6 +18,9 @@ from src.modules.social.infrastructure.persistence.in_memory.in_memory_activity_
 from src.modules.social.infrastructure.persistence.in_memory.in_memory_friendship_repository import (
     InMemoryFriendshipRepository,
 )
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_profile_photo_repository import (
+    InMemoryProfilePhotoRepository,
+)
 
 
 class InMemorySocialUnitOfWork(SocialUnitOfWorkInterface):
@@ -23,6 +29,7 @@ class InMemorySocialUnitOfWork(SocialUnitOfWorkInterface):
     def __init__(self):
         self._friendships = InMemoryFriendshipRepository()
         self._activity_events = InMemoryActivityEventRepository()
+        self._profile_photos = InMemoryProfilePhotoRepository()
         self.committed = False
 
     @property
@@ -32,6 +39,10 @@ class InMemorySocialUnitOfWork(SocialUnitOfWorkInterface):
     @property
     def activity_events(self) -> ActivityEventRepositoryInterface:
         return self._activity_events
+
+    @property
+    def profile_photos(self) -> ProfilePhotoRepositoryInterface:
+        return self._profile_photos
 
     async def __aenter__(self):
         self.committed = False

--- a/src/modules/social/infrastructure/persistence/mappers/profile_photo_mapper.py
+++ b/src/modules/social/infrastructure/persistence/mappers/profile_photo_mapper.py
@@ -1,0 +1,95 @@
+"""
+SQLAlchemy Mapper para ProfilePhoto (modulo Social).
+
+Tabla:
+- profile_photos
+"""
+
+import uuid
+from typing import Any
+
+import sqlalchemy.types
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    LargeBinary,
+    String,
+    Table,
+    inspect,
+)
+from sqlalchemy.dialects import postgresql
+
+from src.modules.social.domain.entities.profile_photo import ProfilePhoto
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (
+    SocialUserIdType,
+)
+from src.shared.infrastructure.persistence.sqlalchemy.base import mapper_registry, metadata
+
+
+class ProfilePhotoIdType(sqlalchemy.types.TypeDecorator[ProfilePhotoId]):
+    """TypeDecorator para ProfilePhotoId."""
+
+    impl = postgresql.UUID(as_uuid=True)
+    cache_ok = True
+
+    def process_bind_param(self, value: ProfilePhotoId | None, dialect: Any) -> uuid.UUID | None:
+        if value is None:
+            return None
+        return value.value
+
+    def process_result_value(self, value: Any, dialect: Any) -> ProfilePhotoId | None:
+        if value is None:
+            return None
+        return ProfilePhotoId(value)
+
+
+profile_photos_table = Table(
+    "profile_photos",
+    metadata,
+    Column("id", ProfilePhotoIdType, primary_key=True, default=uuid.uuid4),
+    Column(
+        "user_id",
+        SocialUserIdType,
+        # Al borrar la cuenta desaparecen sus fotos: no deben sobrevivir a su dueño
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    # Los bytes de la imagen ya procesada. Postgres guarda los BYTEA grandes
+    # comprimidos en una tabla auxiliar (TOAST), asi que su peso no penaliza a
+    # ninguna consulta que no pida esta columna — que es justo lo que hace el
+    # listado de la galeria
+    Column("image_data", LargeBinary, nullable=False),
+    Column("content_type", String(50), nullable=False),
+    Column("caption", String(280), nullable=True),
+    Column("created_at", DateTime, nullable=False),
+    # La galeria siempre se pide igual: las fotos de este jugador, de la mas
+    # reciente a la mas antigua
+    Index("ix_profile_photos_user_created", "user_id", "created_at"),
+)
+
+
+def start_profile_photo_mappers() -> None:
+    """
+    Inicia el mapeo de ProfilePhoto. Idempotente de verdad.
+
+    Se pregunta con `inspect(..., raiseerr=False)` y no con
+    `ProfilePhoto not in mapper_registry.mappers`: ese conjunto contiene objetos
+    `Mapper`, no clases, asi que la pregunta siempre da cierto y la segunda
+    llamada revienta (ver BE #179).
+    """
+    if inspect(ProfilePhoto, raiseerr=False) is None:
+        mapper_registry.map_imperatively(
+            ProfilePhoto,
+            profile_photos_table,
+            properties={
+                "_id": profile_photos_table.c.id,
+                "_user_id": profile_photos_table.c.user_id,
+                "_image_data": profile_photos_table.c.image_data,
+                "_content_type": profile_photos_table.c.content_type,
+                "_caption": profile_photos_table.c.caption,
+                "_created_at": profile_photos_table.c.created_at,
+            },
+        )

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/profile_photo_repository.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/profile_photo_repository.py
@@ -32,8 +32,8 @@ class SQLAlchemyProfilePhotoRepository(ProfilePhotoRepositoryInterface):
         La galeria sin las imagenes.
 
         Se seleccionan columnas sueltas en lugar de la entidad a proposito: pedir
-        `ProfilePhoto` traeria tambien `image_data`, y diez fotos son casi cuatro
-        megas movidos para enseñar una lista de pies de foto.
+        `ProfilePhoto` traeria tambien `image_data`, y una galeria llena son mas de
+        siete megas movidos para enseñar una lista de pies de foto.
         """
         stmt = (
             select(

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/profile_photo_repository.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/profile_photo_repository.py
@@ -1,0 +1,68 @@
+"""Profile Photo Repository - SQLAlchemy Implementation."""
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.social.domain.entities.profile_photo import ProfilePhoto
+from src.modules.social.domain.repositories.profile_photo_repository_interface import (
+    ProfilePhotoMetadata,
+    ProfilePhotoRepositoryInterface,
+)
+from src.modules.social.domain.value_objects.profile_photo_id import ProfilePhotoId
+from src.modules.social.infrastructure.persistence.mappers.profile_photo_mapper import (
+    profile_photos_table,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class SQLAlchemyProfilePhotoRepository(ProfilePhotoRepositoryInterface):
+    """Implementacion asincrona del repositorio de fotos de perfil."""
+
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def add(self, photo: ProfilePhoto) -> None:
+        self._session.add(photo)
+
+    async def find_by_id(self, photo_id: ProfilePhotoId) -> ProfilePhoto | None:
+        return await self._session.get(ProfilePhoto, photo_id)
+
+    async def find_metadata_by_user(self, user_id: UserId) -> list[ProfilePhotoMetadata]:
+        """
+        La galeria sin las imagenes.
+
+        Se seleccionan columnas sueltas en lugar de la entidad a proposito: pedir
+        `ProfilePhoto` traeria tambien `image_data`, y diez fotos son casi cuatro
+        megas movidos para enseñar una lista de pies de foto.
+        """
+        stmt = (
+            select(
+                profile_photos_table.c.id,
+                profile_photos_table.c.user_id,
+                profile_photos_table.c.caption,
+                profile_photos_table.c.created_at,
+            )
+            .where(profile_photos_table.c.user_id == user_id)
+            .order_by(profile_photos_table.c.created_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [
+            ProfilePhotoMetadata(
+                id=row.id, user_id=row.user_id, caption=row.caption, created_at=row.created_at
+            )
+            for row in result.all()
+        ]
+
+    async def count_by_user(self, user_id: UserId) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(profile_photos_table)
+            .where(profile_photos_table.c.user_id == user_id)
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def delete(self, photo_id: ProfilePhotoId) -> bool:
+        stmt = delete(profile_photos_table).where(profile_photos_table.c.id == photo_id)
+        result = await self._session.execute(stmt)
+        return bool(result.rowcount)

--- a/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
+++ b/src/modules/social/infrastructure/persistence/sqlalchemy/social_unit_of_work.py
@@ -12,6 +12,9 @@ from src.modules.social.domain.repositories.activity_event_repository_interface 
 from src.modules.social.domain.repositories.friendship_repository_interface import (
     FriendshipRepositoryInterface,
 )
+from src.modules.social.domain.repositories.profile_photo_repository_interface import (
+    ProfilePhotoRepositoryInterface,
+)
 from src.modules.social.domain.repositories.social_unit_of_work_interface import (
     SocialUnitOfWorkInterface,
 )
@@ -20,6 +23,9 @@ from src.modules.social.infrastructure.persistence.sqlalchemy.activity_event_rep
 )
 from src.modules.social.infrastructure.persistence.sqlalchemy.friendship_repository import (
     SQLAlchemyFriendshipRepository,
+)
+from src.modules.social.infrastructure.persistence.sqlalchemy.profile_photo_repository import (
+    SQLAlchemyProfilePhotoRepository,
 )
 
 UQ_FRIENDSHIP_PAIR_CONSTRAINT = "uq_friendship_pair"
@@ -32,6 +38,7 @@ class SQLAlchemySocialUnitOfWork(SocialUnitOfWorkInterface):
         self._session = session
         self._friendships = SQLAlchemyFriendshipRepository(session)
         self._activity_events = SQLAlchemyActivityEventRepository(session)
+        self._profile_photos = SQLAlchemyProfilePhotoRepository(session)
 
     @property
     def friendships(self) -> FriendshipRepositoryInterface:
@@ -40,6 +47,10 @@ class SQLAlchemySocialUnitOfWork(SocialUnitOfWorkInterface):
     @property
     def activity_events(self) -> ActivityEventRepositoryInterface:
         return self._activity_events
+
+    @property
+    def profile_photos(self) -> ProfilePhotoRepositoryInterface:
+        return self._profile_photos
 
     async def __aenter__(self):
         return self

--- a/src/modules/user/application/ports/image_processor_interface.py
+++ b/src/modules/user/application/ports/image_processor_interface.py
@@ -36,3 +36,28 @@ class IImageProcessor(ABC):
             InvalidAvatarImageError: Si no es una imagen válida/soportada
         """
         pass
+
+    @abstractmethod
+    def process_gallery_image(self, raw_bytes: bytes) -> bytes:
+        """
+        Valida y normaliza una imagen subida a la galería del perfil.
+
+        Se diferencia del avatar en dos cosas, y por eso es un método aparte y no
+        un parámetro de tamaño:
+
+        - **No recorta a cuadrado.** Una foto de una vuelta de golf es casi
+          siempre apaisada, y recortarla al centro se comería medio campo. Se
+          conserva la proporción original y se encaja el lado mayor en el límite.
+        - **Va a 1080 px** en vez de 512: estas fotos se miran, el avatar solo se
+          reconoce.
+
+        Args:
+            raw_bytes: Bytes tal cual los subió el cliente (aún sin validar)
+
+        Returns:
+            bytes: Imagen ya procesada (JPEG)
+
+        Raises:
+            InvalidAvatarImageError: Si no es una imagen válida/soportada
+        """
+        pass

--- a/src/modules/user/infrastructure/external/pillow_image_processor.py
+++ b/src/modules/user/infrastructure/external/pillow_image_processor.py
@@ -18,6 +18,11 @@ ALLOWED_INPUT_FORMATS = {"JPEG", "PNG", "WEBP"}
 # Dimensión final (cuadrada) del avatar
 AVATAR_TARGET_SIZE = 512
 
+# Lado mayor de las fotos de galeria. Medido con esta misma compresion: 512 px
+# pesa 85 KB, 1080 px pesa 375 KB y 1600 px pesa 818 KB. 1600 casi triplica el
+# peso de 1080 y en un telefono no se aprecia (BE #177).
+GALLERY_MAX_SIDE = 1080
+
 # Calidad de compresión JPEG de salida
 AVATAR_JPEG_QUALITY = 85
 
@@ -31,6 +36,51 @@ class PillowImageProcessor(IImageProcessor):
     """Procesa imágenes de avatar con Pillow: valida formato, crop centrado + resize + compresión."""
 
     def process_avatar_image(self, raw_bytes: bytes) -> bytes:
+        image = self._decode_and_validate(raw_bytes)
+
+        width, height = image.size
+        side = min(width, height)
+        left = (width - side) // 2
+        top = (height - side) // 2
+        image = image.crop((left, top, left + side, top + side))
+        image = image.resize((AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE), Image.Resampling.LANCZOS)
+
+        return self._to_jpeg(image)
+
+    def process_gallery_image(self, raw_bytes: bytes) -> bytes:
+        """
+        La misma validación que el avatar, pero sin recortar.
+
+        Se conserva la proporción y se encaja el lado mayor en `GALLERY_MAX_SIDE`.
+        Una foto que ya sea más pequeña se deja como está: ampliarla no añadiría
+        detalle, solo peso.
+        """
+        image = self._decode_and_validate(raw_bytes)
+
+        width, height = image.size
+        lado_mayor = max(width, height)
+        if lado_mayor > GALLERY_MAX_SIDE:
+            escala = GALLERY_MAX_SIDE / lado_mayor
+            nuevo = (max(1, round(width * escala)), max(1, round(height * escala)))
+            image = image.resize(nuevo, Image.Resampling.LANCZOS)
+
+        return self._to_jpeg(image)
+
+    @staticmethod
+    def _to_jpeg(image: Image.Image) -> bytes:
+        output = io.BytesIO()
+        image.save(output, "JPEG", quality=AVATAR_JPEG_QUALITY, optimize=True)
+        return output.getvalue()
+
+    def _decode_and_validate(self, raw_bytes: bytes) -> Image.Image:
+        """
+        Los pasos comunes a cualquier imagen que entre: comprobar que es una
+        imagen de un formato admitido, que no es una bomba de descompresión, y
+        dejarla en RGB con la orientación corregida.
+
+        Es compartido a proposito: la validacion es lo unico que protege al
+        servidor de lo que suba un cliente, y dos copias se separarian.
+        """
         try:
             probe = Image.open(io.BytesIO(raw_bytes))
             probe_format = probe.format
@@ -70,14 +120,4 @@ class PillowImageProcessor(IImageProcessor):
         if transposed is not None:
             image = transposed
 
-        image = image.convert("RGB")
-        width, height = image.size
-        side = min(width, height)
-        left = (width - side) // 2
-        top = (height - side) // 2
-        image = image.crop((left, top, left + side, top + side))
-        image = image.resize((AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE), Image.Resampling.LANCZOS)
-
-        output = io.BytesIO()
-        image.save(output, "JPEG", quality=AVATAR_JPEG_QUALITY, optimize=True)
-        return output.getvalue()
+        return image.convert("RGB")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,9 @@ from src.modules.social.infrastructure.persistence.mappers.activity_event_mapper
 from src.modules.social.infrastructure.persistence.mappers.friendship_mapper import (
     start_social_mappers,
 )
+from src.modules.social.infrastructure.persistence.mappers.profile_photo_mapper import (
+    start_profile_photo_mappers,
+)
 from src.modules.user.infrastructure.persistence.sqlalchemy.mappers import (
     metadata,
     start_mappers,
@@ -143,6 +146,7 @@ def pytest_configure(config):
         start_golf_course_mappers()  # Golf Course module
         start_social_mappers()  # Social module
         start_activity_event_mappers()  # Activity feed (depends on User)
+        start_profile_photo_mappers()  # Profile photo gallery (depends on User)
         start_quick_match_mappers()  # QuickMatch module
         # Marcamos que los mappers ya fueron iniciados para evitar reinicialización
         config.mappers_initialized = True
@@ -161,6 +165,7 @@ def pytest_configure(config):
             start_golf_course_mappers()
             start_social_mappers()
             start_activity_event_mappers()
+            start_profile_photo_mappers()
             start_quick_match_mappers()
         except Exception:
             # Es probable que falle si otro proceso ya lo hizo, lo ignoramos.

--- a/tests/unit/modules/social/application/use_cases/test_profile_photo_use_cases.py
+++ b/tests/unit/modules/social/application/use_cases/test_profile_photo_use_cases.py
@@ -1,0 +1,295 @@
+"""
+Tests de la galeria de fotos del perfil (BE #177).
+
+Tres reglas gobiernan estos tests: las fotos son **solo para amigos**, el tope
+**rechaza** en vez de borrar la mas antigua, y solo el dueño borra las suyas.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.social.application.exceptions import (
+    ActivityNotVisibleError,
+    PhotoNotFoundError,
+    ProfileGalleryFullError,
+    ProfileNotVisibleError,
+)
+from src.modules.social.application.use_cases.delete_profile_photo_use_case import (
+    DeleteProfilePhotoUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_gallery_use_case import (
+    GetProfileGalleryUseCase,
+)
+from src.modules.social.application.use_cases.get_profile_photo_image_use_case import (
+    GetProfilePhotoImageUseCase,
+)
+from src.modules.social.application.use_cases.upload_profile_photo_use_case import (
+    MAX_UPLOAD_BYTES,
+    UploadProfilePhotoUseCase,
+)
+from src.modules.social.domain.entities.friendship import Friendship
+from src.modules.social.domain.entities.profile_photo import MAX_PHOTOS_PER_PROFILE
+from src.modules.social.domain.value_objects.friendship_id import FriendshipId
+from src.modules.social.infrastructure.persistence.in_memory.in_memory_social_unit_of_work import (
+    InMemorySocialUnitOfWork,
+)
+from src.modules.user.application.ports.image_processor_interface import IImageProcessor
+from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import AvatarUploadTooLargeError
+from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork as InMemoryUserUnitOfWork,
+)
+
+pytestmark = pytest.mark.asyncio
+
+RAW = b"bytes-de-una-foto"
+
+
+class _FakeImageProcessor(IImageProcessor):
+    """Evita depender de Pillow: la tuberia real se prueba en su propio test."""
+
+    def process_avatar_image(self, raw_bytes: bytes) -> bytes:
+        return b"avatar-procesado"
+
+    def process_gallery_image(self, raw_bytes: bytes) -> bytes:
+        return b"foto-procesada-1080px"
+
+
+@pytest.fixture
+def social_uow():
+    return InMemorySocialUnitOfWork()
+
+
+@pytest.fixture
+def user_uow():
+    return InMemoryUserUnitOfWork()
+
+
+async def _create_user(user_uow) -> User:
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str=f"foto_{uuid4().hex[:8]}@test.com",
+        plain_password="SecureP@ssw0rd123",
+    )
+    async with user_uow:
+        await user_uow.users.save(user)
+    return user
+
+
+async def _hacer_amigos(social_uow, a: User, b: User) -> None:
+    friendship = Friendship.create(
+        id=FriendshipId(uuid4()), requester_id=a.id, addressee_id=b.id
+    )
+    friendship.accept()
+    async with social_uow:
+        await social_uow.friendships.add(friendship)
+
+
+def _subir(social_uow, user_uow):
+    return UploadProfilePhotoUseCase(social_uow, user_uow, _FakeImageProcessor())
+
+
+class TestSubir:
+    async def test_sube_una_foto_procesada(self, social_uow, user_uow):
+        """Given una imagen / When se sube / Then se guarda ya procesada."""
+        ana = await _create_user(user_uow)
+
+        foto = await _subir(social_uow, user_uow).execute(
+            str(ana.id.value), RAW, caption="En Valderrama"
+        )
+
+        assert foto.caption == "En Valderrama"
+        assert foto.url.endswith("/image")
+        async with social_uow:
+            guardada = await social_uow.profile_photos.find_by_id(
+                (await social_uow.profile_photos.find_metadata_by_user(ana.id))[0].id
+            )
+        assert guardada.image_data == b"foto-procesada-1080px"
+
+    async def test_un_pie_en_blanco_es_lo_mismo_que_no_tener_pie(self, social_uow, user_uow):
+        """Given un caption de espacios / When se sube / Then se guarda como None."""
+        ana = await _create_user(user_uow)
+
+        foto = await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW, caption="   ")
+
+        assert foto.caption is None
+
+    async def test_el_tope_rechaza_en_vez_de_borrar_la_mas_antigua(
+        self, social_uow, user_uow
+    ):
+        """
+        Given una galeria llena / When se sube otra / Then se rechaza y **no se
+        pierde ninguna**: cada foto es una decision del jugador, no historial.
+        """
+        ana = await _create_user(user_uow)
+        use_case = _subir(social_uow, user_uow)
+        for i in range(MAX_PHOTOS_PER_PROFILE):
+            await use_case.execute(str(ana.id.value), RAW, caption=f"foto {i}")
+
+        with pytest.raises(ProfileGalleryFullError):
+            await use_case.execute(str(ana.id.value), RAW)
+
+        async with social_uow:
+            assert await social_uow.profile_photos.count_by_user(ana.id) == MAX_PHOTOS_PER_PROFILE
+
+    async def test_un_archivo_enorme_se_rechaza_antes_de_procesarlo(
+        self, social_uow, user_uow
+    ):
+        """Given un archivo por encima del tope / When se sube / Then se rechaza."""
+        ana = await _create_user(user_uow)
+
+        with pytest.raises(AvatarUploadTooLargeError):
+            await _subir(social_uow, user_uow).execute(
+                str(ana.id.value), b"x" * (MAX_UPLOAD_BYTES + 1)
+            )
+
+
+class TestVerLaGaleria:
+    async def test_un_amigo_ve_la_galeria(self, social_uow, user_uow):
+        """Given un amigo con fotos / When pido su galeria / Then la veo."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, ana, luis)
+        await _subir(social_uow, user_uow).execute(str(luis.id.value), RAW)
+
+        galeria = await GetProfileGalleryUseCase(social_uow, user_uow).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert galeria.total == 1
+
+    async def test_un_desconocido_no_ve_la_galeria(self, social_uow, user_uow):
+        """Given dos sin amistad / When se pide la galeria / Then se rechaza."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        await _subir(social_uow, user_uow).execute(str(luis.id.value), RAW)
+
+        with pytest.raises(ActivityNotVisibleError):
+            await GetProfileGalleryUseCase(social_uow, user_uow).execute(
+                str(ana.id.value), str(luis.id.value)
+            )
+
+    async def test_el_listado_no_lleva_las_imagenes(self, social_uow, user_uow):
+        """
+        Given una galeria / When se lista / Then vienen los enlaces, no los bytes:
+        diez fotos son casi cuatro megas que el navegador pide aparte.
+        """
+        ana = await _create_user(user_uow)
+        await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW)
+
+        galeria = await GetProfileGalleryUseCase(social_uow, user_uow).execute(
+            str(ana.id.value), str(ana.id.value)
+        )
+
+        assert "image_data" not in galeria.photos[0].model_dump()
+
+    async def test_dice_cuantas_fotos_caben_todavia(self, social_uow, user_uow):
+        """Given 3 fotos / When se pide la galeria / Then quedan 7 huecos."""
+        ana = await _create_user(user_uow)
+        for _ in range(3):
+            await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW)
+
+        galeria = await GetProfileGalleryUseCase(social_uow, user_uow).execute(
+            str(ana.id.value), str(ana.id.value)
+        )
+
+        assert galeria.remaining_slots == MAX_PHOTOS_PER_PROFILE - 3
+
+    async def test_un_jugador_que_no_existe_da_otro_error(self, social_uow, user_uow):
+        """Given un id inventado / When se pide su galeria / Then no existe."""
+        ana = await _create_user(user_uow)
+
+        with pytest.raises(ProfileNotVisibleError):
+            await GetProfileGalleryUseCase(social_uow, user_uow).execute(
+                str(ana.id.value), str(uuid4())
+            )
+
+
+class TestServirLaImagen:
+    async def test_el_etag_es_estable_para_la_misma_foto(self, social_uow, user_uow):
+        """
+        Given una foto / When se pide dos veces / Then el ETag es el mismo: es lo
+        que permite al navegador quedarsela y no volver a bajarla.
+        """
+        ana = await _create_user(user_uow)
+        foto = await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW)
+        use_case = GetProfilePhotoImageUseCase(social_uow)
+
+        una = await use_case.execute(str(ana.id.value), str(ana.id.value), foto.id)
+        otra = await use_case.execute(str(ana.id.value), str(ana.id.value), foto.id)
+
+        assert una.etag == otra.etag
+        assert una.etag.startswith('"') and una.etag.endswith('"')
+
+    async def test_un_desconocido_no_baja_la_imagen(self, social_uow, user_uow):
+        """Given una foto de un extraño / When se pide la imagen / Then se rechaza."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        foto = await _subir(social_uow, user_uow).execute(str(luis.id.value), RAW)
+
+        with pytest.raises(ActivityNotVisibleError):
+            await GetProfilePhotoImageUseCase(social_uow).execute(
+                str(ana.id.value), str(luis.id.value), foto.id
+            )
+
+    async def test_una_foto_que_no_es_del_dueno_de_la_ruta_no_se_sirve(
+        self, social_uow, user_uow
+    ):
+        """
+        Given la foto de un amigo pedida bajo la ruta de otro amigo / When se
+        pide / Then no se sirve: sin esta comprobacion, un id valido se colaria
+        por la ruta de cualquiera y se saltaria el guard de su dueño real.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        marta = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, ana, luis)
+        await _hacer_amigos(social_uow, ana, marta)
+        de_marta = await _subir(social_uow, user_uow).execute(str(marta.id.value), RAW)
+
+        with pytest.raises(PhotoNotFoundError):
+            await GetProfilePhotoImageUseCase(social_uow).execute(
+                str(ana.id.value), str(luis.id.value), de_marta.id
+            )
+
+
+class TestBorrar:
+    async def test_el_dueno_borra_su_foto(self, social_uow, user_uow):
+        """Given una foto propia / When se borra / Then desaparece."""
+        ana = await _create_user(user_uow)
+        foto = await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW)
+
+        await DeleteProfilePhotoUseCase(social_uow).execute(str(ana.id.value), foto.id)
+
+        async with social_uow:
+            assert await social_uow.profile_photos.count_by_user(ana.id) == 0
+
+    async def test_un_amigo_no_puede_borrar_mis_fotos(self, social_uow, user_uow):
+        """Given una foto mia / When un amigo intenta borrarla / Then no puede."""
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, ana, luis)
+        foto = await _subir(social_uow, user_uow).execute(str(ana.id.value), RAW)
+
+        with pytest.raises(PhotoNotFoundError):
+            await DeleteProfilePhotoUseCase(social_uow).execute(str(luis.id.value), foto.id)
+
+        async with social_uow:
+            assert await social_uow.profile_photos.count_by_user(ana.id) == 1
+
+    async def test_borrar_hace_sitio_para_subir_otra(self, social_uow, user_uow):
+        """Given una galeria llena / When se borra una / Then ya cabe otra."""
+        ana = await _create_user(user_uow)
+        subir = _subir(social_uow, user_uow)
+        fotos = [
+            await subir.execute(str(ana.id.value), RAW)
+            for _ in range(MAX_PHOTOS_PER_PROFILE)
+        ]
+
+        await DeleteProfilePhotoUseCase(social_uow).execute(str(ana.id.value), fotos[0].id)
+        await subir.execute(str(ana.id.value), RAW)
+
+        async with social_uow:
+            assert await social_uow.profile_photos.count_by_user(ana.id) == MAX_PHOTOS_PER_PROFILE

--- a/tests/unit/modules/user/application/use_cases/test_upload_avatar_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_upload_avatar_use_case.py
@@ -38,6 +38,12 @@ class FakeImageProcessor(IImageProcessor):
             raise InvalidAvatarImageError("El archivo subido no es una imagen válida")
         return b"processed-jpeg-bytes"
 
+    def process_gallery_image(self, raw_bytes: bytes) -> bytes:
+        """La galería no se prueba aquí, pero el puerto la exige (BE #177)."""
+        if self.should_fail:
+            raise InvalidAvatarImageError("El archivo subido no es una imagen válida")
+        return b"processed-gallery-bytes"
+
 
 @pytest.fixture
 def uow():

--- a/tests/unit/modules/user/infrastructure/external/test_pillow_gallery_processing.py
+++ b/tests/unit/modules/user/infrastructure/external/test_pillow_gallery_processing.py
@@ -1,0 +1,100 @@
+"""
+Tests del procesado de fotos de galeria con Pillow (BE #177).
+
+La diferencia con el avatar es toda la razon de que exista un metodo aparte: la
+galeria **no recorta a cuadrado**, porque una foto de una vuelta suele ser
+apaisada y el recorte central se comeria medio campo.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+
+from src.modules.user.domain.errors.user_errors import InvalidAvatarImageError
+from src.modules.user.infrastructure.external.pillow_image_processor import (
+    GALLERY_MAX_SIDE,
+    PillowImageProcessor,
+)
+
+
+def _jpeg(width: int, height: int) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), (34, 139, 34)).save(buffer, "JPEG")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def processor():
+    return PillowImageProcessor()
+
+
+def test_conserva_la_proporcion_de_una_foto_apaisada(processor):
+    """Given una foto 4:3 / When se procesa / Then sigue siendo 4:3, no un cuadrado."""
+    resultado = processor.process_gallery_image(_jpeg(4000, 3000))
+
+    ancho, alto = Image.open(io.BytesIO(resultado)).size
+    assert (ancho, alto) == (GALLERY_MAX_SIDE, 810)
+    assert ancho != alto
+
+
+def test_conserva_la_proporcion_de_una_foto_vertical(processor):
+    """Given una foto vertical / When se procesa / Then el lado mayor es el alto."""
+    resultado = processor.process_gallery_image(_jpeg(1500, 3000))
+
+    ancho, alto = Image.open(io.BytesIO(resultado)).size
+    assert alto == GALLERY_MAX_SIDE
+    assert ancho < alto
+
+
+def test_no_amplia_una_foto_que_ya_es_pequena(processor):
+    """
+    Given una foto menor que el limite / When se procesa / Then se deja igual:
+    ampliarla no añadiria detalle, solo peso.
+    """
+    resultado = processor.process_gallery_image(_jpeg(400, 300))
+
+    assert Image.open(io.BytesIO(resultado)).size == (400, 300)
+
+
+def test_el_avatar_si_recorta_a_cuadrado(processor):
+    """Given la misma foto apaisada / When se procesa como avatar / Then sale cuadrada."""
+    resultado = processor.process_avatar_image(_jpeg(4000, 3000))
+
+    ancho, alto = Image.open(io.BytesIO(resultado)).size
+    assert ancho == alto
+
+
+def test_la_salida_siempre_es_jpeg(processor):
+    """Given un PNG / When se procesa / Then sale JPEG, que es lo que se guarda."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (800, 600), (10, 20, 30)).save(buffer, "PNG")
+
+    resultado = processor.process_gallery_image(buffer.getvalue())
+
+    assert Image.open(io.BytesIO(resultado)).format == "JPEG"
+
+
+def test_rechaza_lo_que_no_es_una_imagen(processor):
+    """Given un archivo cualquiera / When se procesa / Then se rechaza."""
+    with pytest.raises(InvalidAvatarImageError):
+        processor.process_gallery_image(b"esto no es una imagen")
+
+
+def test_rechaza_un_formato_no_admitido(processor):
+    """Given un GIF / When se procesa / Then se rechaza: solo JPEG, PNG y WEBP."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (100, 100)).save(buffer, "GIF")
+
+    with pytest.raises(InvalidAvatarImageError):
+        processor.process_gallery_image(buffer.getvalue())
+
+
+def test_una_foto_de_movil_pesa_lo_previsto(processor):
+    """
+    Given una foto de 12 megapixeles / When se procesa / Then queda por debajo
+    del medio mega que asume el calculo de espacio de la issue.
+    """
+    resultado = processor.process_gallery_image(_jpeg(4032, 3024))
+
+    assert len(resultado) < 500 * 1024


### PR DESCRIPTION
Closes #177

Twenty photos per profile, stored in the database like avatars, visible only to friends.

```
POST   /users/me/photos                       # upload
GET    /users/{id}/photos                     # gallery — friends only
GET    /users/{id}/photos/{photo}/image       # the bytes, cached for a year
DELETE /users/me/photos/{photo}               # owner only
```

## Decisions worth reviewing

**No square crop.** The pipeline is the avatars' — format validation, pixel ceiling, EXIF orientation, compression — with one deliberate difference, and that difference is why it is a separate method rather than a size parameter. A round of golf is almost always photographed landscape, and a centre crop would eat half the course. The longest side is fitted to 1080px and the proportions kept; anything already smaller is left alone, since upscaling adds weight and no detail.

**The cap rejects rather than prunes.** Avatars drop the oldest because they are history of one same thing; here each photo is a decision the player made, and silently deleting one to make room would lose them content. Hitting the limit returns 409.

**Twenty rather than ten** (raised during implementation): 7.3 MB per player, so 200 players take 1.4 GB of the 10 GB provisioned. The disk is not the constraint — the agreed signal for moving images out of the database is the table passing 2 GB, which now arrives around 280 players instead of 560. Ample room for an app among friends, and migrating then is moving bytes rather than rebuilding anything.

**Photos live in the social module**, not beside the avatars, because their visibility is a social rule: anyone can see a player's card, only friends see their photos. The avatar is the opposite — public identity, needed to recognise someone in a search.

## What makes it viable at all

Each image occupies a worker to serve, and a full profile is twenty requests. Two things keep that from being a problem:

**Listing never loads the images.** The repository selects columns rather than the entity, so a gallery listing returns captions and URLs — not the seven megabytes of image data behind them. The browser fetches each one separately, in parallel, and caches it.

**Serving sends a year-long immutable `Cache-Control` and an `ETag`**, and answers 304 when the client already has the image. The ETag is the photo id, which is sound because the image is immutable: editing a photo means deleting it and uploading another with a different id. `private`, because these are friends-only and a shared cache must not hand them to someone else.

## One guard worth pointing out

Serving checks the photo belongs to the user in the path. Without it, a valid photo id would serve from any friend's route and bypass its real owner's guard.

## Verification

- **2608** unit tests, **443** integration and security, 1 skipped
- `mypy` clean; `ruff` clean on everything touched
- Migration applied and rolled back against a real PostgreSQL on a throwaway database in the dev cluster; single Alembic head after the merge
- The Pillow pipeline is tested for real, not faked: proportions kept, no upscaling, JPEG output, rejected formats, and a 12-megapixel photo landing under 500 KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)