### PR TITLE
feat(social): Show a friend's email on their profile

### DIFF
--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -37,10 +37,10 @@ class PlayerProfileResponseDTO(BaseModel):
     falta para encontrar a alguien por su nombre y reconocerlo antes de mandarle
     una solicitud, y no dice nada de el que no diga ya la busqueda.
 
-    **Solo los amigos ven lo de detras**: correo, handicap, estadisticas y
-    actividad. Esos campos llegan en None a quien no es amigo, no recortados ni
-    a cero — un cero se leeria como "juega fatal" en lugar de "no puedes ver
-    esto".
+    **Solo el propio jugador y sus amigos ven lo de detras**: correo, handicap,
+    estadisticas y actividad. Esos campos llegan en None a cualquier otro, no
+    recortados ni a cero — un cero se leeria como "juega fatal" en lugar de "no
+    puedes ver esto".
 
     El correo esta entre amigos porque una amistad aceptada aqui es un contacto
     de verdad, y poder escribirle fuera de la aplicacion es parte de eso. Lo que
@@ -74,18 +74,21 @@ class PlayerProfileResponseDTO(BaseModel):
     email: str | None = Field(
         default=None,
         description=(
-            "Solo entre amigos: una amistad aceptada es un contacto de verdad. "
-            "None cuando no lo sois"
+            "Solo uno mismo y sus amigos: una amistad aceptada es un contacto de "
+            "verdad. None para cualquier otro"
         ),
     )
     handicap: float | None = Field(
-        default=None, description="Solo entre amigos. None si no lo sois o si no lo ha fijado"
+        default=None,
+        description=(
+            "Solo uno mismo y sus amigos. None si no lo sois o si no lo ha fijado"
+        ),
     )
     stats: PlayerStatsResponseDTO | None = Field(
         default=None,
         description=(
-            "Solo entre amigos: el mismo resumen que su propio panel (BE #128, #167). "
-            "None cuando no sois amigos"
+            "Solo uno mismo y sus amigos: el mismo resumen que su propio panel "
+            "(BE #128, #167). None para cualquier otro"
         ),
     )
 

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -37,12 +37,16 @@ class PlayerProfileResponseDTO(BaseModel):
     falta para encontrar a alguien por su nombre y reconocerlo antes de mandarle
     una solicitud, y no dice nada de el que no diga ya la busqueda.
 
-    **Solo los amigos ven lo de detras**: handicap, estadisticas y actividad.
-    Esos campos llegan en None a quien no es amigo, no recortados ni a cero — un
-    cero se leeria como "juega fatal" en lugar de "no puedes ver esto".
+    **Solo los amigos ven lo de detras**: correo, handicap, estadisticas y
+    actividad. Esos campos llegan en None a quien no es amigo, no recortados ni
+    a cero — un cero se leeria como "juega fatal" en lugar de "no puedes ver
+    esto".
 
-    Nunca lleva correo ni datos de la cuenta, ni siquiera entre amigos: esto es
-    el perfil de golf de alguien, no su ficha de usuario.
+    El correo esta entre amigos porque una amistad aceptada aqui es un contacto
+    de verdad, y poder escribirle fuera de la aplicacion es parte de eso. Lo que
+    no puede pasar —y no pasa— es que se recolecten direcciones sin relacion
+    alguna: la busqueda por nombre no devuelve ninguna, y aqui hace falta que el
+    otro haya aceptado.
     """
 
     id: str
@@ -66,6 +70,13 @@ class PlayerProfileResponseDTO(BaseModel):
     )
     is_friend: bool = Field(
         default=False, description="Atajo de `friendship.status == ACCEPTED`"
+    )
+    email: str | None = Field(
+        default=None,
+        description=(
+            "Solo entre amigos: una amistad aceptada es un contacto de verdad. "
+            "None cuando no lo sois"
+        ),
     )
     handicap: float | None = Field(
         default=None, description="Solo entre amigos. None si no lo sois o si no lo ha fijado"

--- a/src/modules/social/application/use_cases/get_player_profile_use_case.py
+++ b/src/modules/social/application/use_cases/get_player_profile_use_case.py
@@ -77,6 +77,7 @@ class GetPlayerProfileUseCase:
                 "has_avatar_upload": user.active_avatar_upload_id is not None,
             }
             handicap = float(user.handicap.value) if user.handicap else None
+            email = user.email.value
 
         relacion, amigos = await self._relacion_y_amigos(viewer_id, target_id, propio)
         puede_ver_todo = propio or relacion.status == FriendshipStatus.ACCEPTED.value
@@ -90,6 +91,7 @@ class GetPlayerProfileUseCase:
             friends_count=amigos,
             friendship=relacion,
             is_friend=relacion.status == FriendshipStatus.ACCEPTED.value,
+            email=email if puede_ver_todo else None,
             handicap=handicap if puede_ver_todo else None,
             stats=stats,
         )

--- a/tests/integration/api/v1/test_profile_feed_endpoints.py
+++ b/tests/integration/api/v1/test_profile_feed_endpoints.py
@@ -48,8 +48,9 @@ class TestPerfil:
         assert datos["id"] == luis["user"]["id"]
         assert datos["first_name"] == "Luis"
         assert "stats" in datos
-        # El perfil de golf no lleva datos de la cuenta
-        assert "email" not in datos
+        # Entre amigos si se ve el correo: una amistad aceptada es un contacto
+        # de verdad, y poder escribirle fuera de la aplicacion es parte de eso
+        assert datos["email"] == luis["user"]["email"]
 
     @pytest.mark.asyncio
     async def test_un_desconocido_ve_la_ficha_pero_no_lo_privado(self, client: AsyncClient):
@@ -74,7 +75,9 @@ class TestPerfil:
         assert datos["friendship"]["status"] == "NONE"
         assert datos["stats"] is None
         assert datos["handicap"] is None
-        assert "email" not in datos
+        # El correo es de los campos privados: llega en None, no ausente
+        assert datos["email"] is None
+        assert luis["user"]["email"] not in respuesta.text
 
     @pytest.mark.asyncio
     async def test_una_cuenta_inventada_si_da_404(self, client: AsyncClient):

--- a/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
@@ -276,6 +276,20 @@ class TestLoQueDeVerdadNoEsta:
 
         assert perfil.email is None
 
+    async def test_uno_mismo_ve_su_correo(self, social_uow, user_uow, stats):
+        """
+        Given un jugador mirando su propia ficha / When se pide / Then ve su
+        correo. El caso de uso abre lo privado a `propio or ACCEPTED`, y sin
+        esta prueba la rama del dueño quedaba solo cubierta de rebote.
+        """
+        ana = await _create_user(user_uow)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(ana.id.value)
+        )
+
+        assert perfil.email == ana.email.value
+
 
 class TestContadorDeAmigos:
     async def test_cuenta_los_amigos_del_perfil_no_los_mios(

--- a/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_player_profile_use_case.py
@@ -245,11 +245,11 @@ class TestLoQueDeVerdadNoEsta:
                 str(ana.id.value), str(luis.id.value)
             )
 
-    async def test_el_perfil_nunca_lleva_el_correo(self, social_uow, user_uow, stats):
+    async def test_entre_amigos_si_se_ve_el_correo(self, social_uow, user_uow, stats):
         """
-        Given dos amigos / When uno mira el perfil del otro / Then no hay correo
-        ni siquiera entre amigos: esto es su perfil de golf, no su ficha de
-        usuario.
+        Given dos amigos / When uno mira el perfil del otro / Then ve su correo:
+        una amistad aceptada es un contacto de verdad, y poder escribirle fuera
+        de la aplicacion es parte de eso.
         """
         ana = await _create_user(user_uow)
         luis = await _create_user(user_uow)
@@ -259,7 +259,22 @@ class TestLoQueDeVerdadNoEsta:
             str(ana.id.value), str(luis.id.value)
         )
 
-        assert "email" not in perfil.model_dump()
+        assert perfil.email == luis.email.value
+
+    async def test_un_desconocido_no_ve_el_correo(self, social_uow, user_uow, stats):
+        """
+        Given dos sin amistad / When uno mira la ficha del otro / Then el correo
+        llega en None. Es lo que impide recolectar direcciones: la busqueda no
+        devuelve ninguna, y aqui hace falta que el otro haya aceptado.
+        """
+        ana = await _create_user(user_uow)
+        luis = await _create_user(user_uow)
+
+        perfil = await _use_case(social_uow, user_uow, stats).execute(
+            str(ana.id.value), str(luis.id.value)
+        )
+
+        assert perfil.email is None
 
 
 class TestContadorDeAmigos:


### PR DESCRIPTION
## What

A player profile now carries the owner's email when the viewer is an accepted friend, and `null` for anyone else.

An accepted friendship is a real contact, and being able to write to someone outside the app is part of that. The field follows the same rule as handicap and stats: present for friends, `null` otherwise — never blanked or faked.

## Why this reverses an earlier decision

The previous code stated the profile would never carry an email, *"not even between friends"*, with a test enforcing it. That was a decision about a golf profile versus a user record. The product call is that friends exchange contact details, so the rule and its test are replaced rather than left contradicting the code.

## No harvesting

The concern that motivated the original rule still holds and is still enforced elsewhere:

- Name search returns no addresses at all (`#180` removed them).
- This requires the other person to have **accepted** the friend request.

So an address is only ever visible to someone its owner explicitly approved.

## Changes

- `profile_dto.py` — optional `email`, documented as friends-only
- `get_player_profile_use_case.py` — populates it only on the friend branch
- Tests updated in both the use case and the API-level suite

Contributes to #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile responses now include an optional email field.
  * Email addresses are visible to profile owners and accepted friends.
  * For other viewers, the email field remains empty and the address is not exposed.

* **Tests**
  * Updated profile endpoint and use-case coverage for the new email visibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->