### PR TITLE
feat(social): Add the course name to the activity feed

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -1411,9 +1411,10 @@ def get_player_activity_use_case(
 def get_friends_feed_use_case(
     social_uow: SocialUnitOfWorkInterface = Depends(get_social_uow),
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
 ) -> GetFriendsFeedUseCase:
     """Proveedor del caso de uso GetFriendsFeedUseCase."""
-    return GetFriendsFeedUseCase(social_uow, user_uow)
+    return GetFriendsFeedUseCase(social_uow, user_uow, golf_course_uow)
 
 
 def get_mark_feed_as_seen_use_case(

--- a/src/modules/social/application/dto/profile_dto.py
+++ b/src/modules/social/application/dto/profile_dto.py
@@ -130,6 +130,15 @@ class FeedResponseDTO(BaseModel):
     authors: dict[str, FeedAuthorDTO] = Field(
         default_factory=dict, description="Autores de esta pagina, indexados por id"
     )
+    courses: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Nombre de cada campo citado en esta pagina, indexado por id. "
+            "El nombre va aparte y no dentro del `payload` del evento porque el "
+            "payload se escribio al publicar el logro: un campo renombrado dejaria "
+            "el feed contando el nombre viejo para siempre"
+        ),
+    )
     next_cursor: str | None = Field(
         default=None,
         description="Pasalo como `cursor` para la siguiente pagina. None cuando no hay mas",

--- a/src/modules/social/application/use_cases/get_friends_feed_use_case.py
+++ b/src/modules/social/application/use_cases/get_friends_feed_use_case.py
@@ -179,9 +179,13 @@ class GetFriendsFeedUseCase:
         autores: pintar el feed no debe costar una peticion por entrada. Se
         consulta cada campo una vez aunque salga en varias.
 
-        Un id que ya no existe se omite en lugar de romper la pagina: el feed
-        cuenta un logro, y el logro sigue siendo cierto aunque el campo se haya
-        borrado. La entrada se pinta sin el nombre.
+        Un id que no se puede resolver se omite en lugar de romper la pagina: el
+        feed cuenta un logro, y el logro sigue siendo cierto aunque el campo se
+        haya borrado. La entrada se pinta sin el nombre. Eso vale igual para un
+        campo que ya no existe que para un id ilegible — el `payload` es JSONB y
+        nada garantiza su forma anos despues de haberse escrito, asi que un
+        valor con el que no se puede ni construir un `GolfCourseId` no puede
+        costar la peticion entera.
         """
         ids = {
             evento.payload["golf_course_id"]
@@ -194,7 +198,11 @@ class GetFriendsFeedUseCase:
         campos: dict[str, str] = {}
         async with self._golf_course_uow:
             for course_id in ids:
-                campo = await self._golf_course_uow.golf_courses.find_by_id(GolfCourseId(course_id))
+                try:
+                    identificador = GolfCourseId(course_id)
+                except ValueError:
+                    continue
+                campo = await self._golf_course_uow.golf_courses.find_by_id(identificador)
                 if campo is not None:
                     campos[course_id] = campo.name
         return campos

--- a/src/modules/social/application/use_cases/get_friends_feed_use_case.py
+++ b/src/modules/social/application/use_cases/get_friends_feed_use_case.py
@@ -2,6 +2,10 @@
 
 from datetime import datetime
 
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.social.application.dto.profile_dto import (
     ActivityEventDTO,
     FeedAuthorDTO,
@@ -52,9 +56,11 @@ class GetFriendsFeedUseCase:
         self,
         social_uow: SocialUnitOfWorkInterface,
         user_uow: UserUnitOfWorkInterface,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
     ):
         self._social_uow = social_uow
         self._user_uow = user_uow
+        self._golf_course_uow = golf_course_uow
 
     async def execute(
         self, viewer_id_raw: str, limit: int = DEFAULT_PAGE_SIZE, cursor: str | None = None
@@ -93,10 +99,12 @@ class GetFriendsFeedUseCase:
             )
 
         autores = await self._autores(eventos)
+        campos = await self._campos(eventos)
 
         return FeedResponseDTO(
             events=[self._a_dto(e) for e in eventos],
             authors=autores,
+            courses=campos,
             next_cursor=build_cursor(eventos, limit),
             unseen_count=no_vistos,
         )
@@ -162,6 +170,35 @@ class GetFriendsFeedUseCase:
                 )
         return autores
 
+    async def _campos(self, eventos: list[ActivityEvent]) -> dict[str, str]:
+        """
+        Como se llama cada campo citado en esta pagina.
+
+        El `payload` solo guarda el `golf_course_id`, asi que el nombre se
+        resuelve al leer. Va en la respuesta por el mismo motivo que los
+        autores: pintar el feed no debe costar una peticion por entrada. Se
+        consulta cada campo una vez aunque salga en varias.
+
+        Un id que ya no existe se omite en lugar de romper la pagina: el feed
+        cuenta un logro, y el logro sigue siendo cierto aunque el campo se haya
+        borrado. La entrada se pinta sin el nombre.
+        """
+        ids = {
+            evento.payload["golf_course_id"]
+            for evento in eventos
+            if evento.payload.get("golf_course_id")
+        }
+        if not ids:
+            return {}
+
+        campos: dict[str, str] = {}
+        async with self._golf_course_uow:
+            for course_id in ids:
+                campo = await self._golf_course_uow.golf_courses.find_by_id(GolfCourseId(course_id))
+                if campo is not None:
+                    campos[course_id] = campo.name
+        return campos
+
     @staticmethod
     def _a_dto(evento: ActivityEvent) -> ActivityEventDTO:
         return ActivityEventDTO(
@@ -172,4 +209,3 @@ class GetFriendsFeedUseCase:
             payload=evento.payload,
             source_match_id=evento.source_match_id,
         )
-

--- a/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
@@ -506,6 +506,30 @@ class TestElCampo:
         assert len(feed.events) == 1
         assert feed.courses == {}
 
+    async def test_un_id_de_campo_ilegible_no_tumba_la_pagina(
+        self, social_uow, user_uow, golf_course_uow
+    ):
+        """
+        Given un logro cuyo `golf_course_id` no es un UUID / When pido el feed /
+        Then la entrada sale igual, sin nombre.
+
+        El payload es JSONB y nada garantiza su forma: un valor con el que no se
+        puede ni construir un `GolfCourseId` no puede costar la peticion entera.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(
+            social_uow, amigo, "match-1", payload={"golf_course_id": "not-a-uuid"}
+        )
+
+        feed = await _use_case(social_uow, user_uow, golf_course_uow).execute(
+            str(yo.id.value)
+        )
+
+        assert len(feed.events) == 1
+        assert feed.courses == {}
+
     async def test_un_logro_sin_campo_no_pide_nombres(self, social_uow, user_uow, golf_course_uow):
         """
         Given un logro sin `golf_course_id` / When pido el feed / Then no viene

--- a/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_get_friends_feed_use_case.py
@@ -11,6 +11,14 @@ from uuid import uuid4
 
 import pytest
 
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.infrastructure.persistence.in_memory.in_memory_golf_course_unit_of_work import (
+    InMemoryGolfCourseUnitOfWork,
+)
 from src.modules.social.application.use_cases.get_friends_feed_use_case import (
     GetFriendsFeedUseCase,
 )
@@ -25,10 +33,13 @@ from src.modules.user.domain.entities.user import User
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork as InMemoryUserUnitOfWork,
 )
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
 
 pytestmark = pytest.mark.asyncio
 
 CUANDO = datetime(2026, 8, 10, 12, 0)
+PAR = 4
 
 
 @pytest.fixture
@@ -39,6 +50,11 @@ def social_uow():
 @pytest.fixture
 def user_uow():
     return InMemoryUserUnitOfWork()
+
+
+@pytest.fixture
+def golf_course_uow():
+    return InMemoryGolfCourseUnitOfWork()
 
 
 async def _create_user(user_uow, share_activity: bool = True) -> User:
@@ -65,7 +81,13 @@ async def _hacer_amigos(social_uow, a: User, b: User) -> Friendship:
     return friendship
 
 
-async def _publica(social_uow, user: User, match_id: str, cuando: datetime = CUANDO):
+async def _publica(
+    social_uow,
+    user: User,
+    match_id: str,
+    cuando: datetime = CUANDO,
+    payload: dict | None = None,
+):
     async with social_uow:
         await social_uow.activity_events.add_many(
             [
@@ -74,13 +96,47 @@ async def _publica(social_uow, user: User, match_id: str, cuando: datetime = CUA
                     type=ActivityEventType.BIRDIE,
                     occurred_at=cuando,
                     source_match_id=match_id,
+                    payload=payload,
                 )
             ]
         )
 
 
-def _use_case(social_uow, user_uow):
-    return GetFriendsFeedUseCase(social_uow, user_uow)
+async def _create_course(golf_course_uow, creator_id, name: str = "Test Golf Club"):
+    """Campo de par 72: 18 hoyos de par 4."""
+    course = GolfCourse.create(
+        name=name,
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=[
+            Tee(
+                category=TeeCategory.AMATEUR,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+            ),
+            Tee(
+                category=TeeCategory.CHAMPIONSHIP,
+                gender=Gender.MALE,
+                identifier="White",
+                course_rating=72.0,
+                slope_rating=130,
+            ),
+        ],
+        holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+    )
+    course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(course)
+    return course
+
+
+def _use_case(social_uow, user_uow, golf_course_uow=None):
+    return GetFriendsFeedUseCase(
+        social_uow, user_uow, golf_course_uow or InMemoryGolfCourseUnitOfWork()
+    )
 
 
 class TestQueSeVe:
@@ -382,3 +438,85 @@ class TestCursorManipulado:
         )
 
         assert isinstance(feed.events, list)
+
+
+class TestElCampo:
+    """
+    El nombre del campo donde ocurrio cada logro.
+
+    El `payload` solo guarda el `golf_course_id`, asi que el nombre se resuelve
+    al leer y viaja en un diccionario aparte, igual que los autores.
+    """
+
+    async def test_el_feed_trae_el_nombre_del_campo(self, social_uow, user_uow, golf_course_uow):
+        """
+        Given un logro en un campo / When pido el feed / Then viene como se
+        llama, para no pedirlo entrada por entrada.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        campo = await _create_course(golf_course_uow, amigo.id, name="Real Club de Golf")
+        await _publica(
+            social_uow,
+            amigo,
+            "match-1",
+            payload={"golf_course_id": str(campo.id.value)},
+        )
+
+        feed = await _use_case(social_uow, user_uow, golf_course_uow).execute(str(yo.id.value))
+
+        assert feed.courses == {str(campo.id.value): "Real Club de Golf"}
+
+    async def test_un_campo_citado_dos_veces_viaja_una_sola_vez(
+        self, social_uow, user_uow, golf_course_uow
+    ):
+        """
+        Given dos logros en el mismo campo / When pido el feed / Then el nombre
+        va una vez, no uno por entrada.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        campo = await _create_course(golf_course_uow, amigo.id)
+        payload = {"golf_course_id": str(campo.id.value)}
+        await _publica(social_uow, amigo, "match-1", payload=payload)
+        await _publica(social_uow, amigo, "match-2", payload=payload)
+
+        feed = await _use_case(social_uow, user_uow, golf_course_uow).execute(str(yo.id.value))
+
+        assert len(feed.events) == 2
+        assert len(feed.courses) == 1
+
+    async def test_un_campo_borrado_no_tumba_la_pagina(self, social_uow, user_uow, golf_course_uow):
+        """
+        Given un logro cuyo campo ya no existe / When pido el feed / Then la
+        entrada sigue saliendo, solo que sin nombre.
+
+        El logro sigue siendo cierto aunque el campo se haya borrado; perder el
+        nombre no puede costar la pagina entera.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1", payload={"golf_course_id": str(uuid4())})
+
+        feed = await _use_case(social_uow, user_uow, golf_course_uow).execute(str(yo.id.value))
+
+        assert len(feed.events) == 1
+        assert feed.courses == {}
+
+    async def test_un_logro_sin_campo_no_pide_nombres(self, social_uow, user_uow, golf_course_uow):
+        """
+        Given un logro sin `golf_course_id` / When pido el feed / Then no viene
+        ningun campo.
+        """
+        yo = await _create_user(user_uow)
+        amigo = await _create_user(user_uow)
+        await _hacer_amigos(social_uow, yo, amigo)
+        await _publica(social_uow, amigo, "match-1")
+
+        feed = await _use_case(social_uow, user_uow, golf_course_uow).execute(str(yo.id.value))
+
+        assert len(feed.events) == 1
+        assert feed.courses == {}


### PR DESCRIPTION
## What

The feed now says **where** each achievement happened. `FeedResponseDTO` carries a `courses` map (id to name) alongside `authors`, and `GetFriendsFeedUseCase` resolves it on read.

## Why

The event payload only stores `golf_course_id`, so a card could never name the course. `NEW_COURSE` was the worst case: it announced that someone played a new course without saying which one.

The name is **not** written into the event payload on purpose. That payload is stamped when the achievement is published, so a renamed course would keep reporting its old name forever. Resolving on read also matches how authors already work, and for the same reason: painting the feed must not cost one request per entry. Each course is looked up once per page no matter how many entries cite it.

A course that no longer exists is omitted instead of failing the page — the achievement is still true, and losing a name must not cost the whole feed.

The dependency follows the existing precedent in `get_recent_matches_use_case`, which already injects `golf_course_uow` to resolve names the same way.

## Tests

Four new cases: the name arrives, a course cited twice travels once, a deleted course does not bring down the page, and an achievement with no course asks for nothing. Full social suite green (203 passed).

## Note for the frontend

Consuming this is a separate PR in RyderCupWeb: the card needs to read `courses` and print the name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Friends’ feed responses now include golf course names referenced by feed events.
  * Feed generation continues when referenced courses are unavailable, omitting only missing course details.
  * Course information is de-duplicated and provided separately from event payloads.

* **Bug Fixes**
  * Improved handling of achievements without an associated golf course.

* **Tests**
  * Added coverage for privacy, pagination, course-name resolution, missing courses, and duplicate references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->