### PR TITLE
feat(social): Expose the activity sharing switch in the user response

### DIFF
--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -214,6 +214,14 @@ class UserResponseDTO(BaseModel):
     avatar_preset_id: int | None = Field(
         None, description="ID del preset activo (1-10), solo si avatar_source=PRESET."
     )
+    # Feed de actividad (BE #175)
+    share_activity: bool = Field(
+        default=True,
+        description=(
+            "Si los logros del usuario se publican en el feed de sus amigos. "
+            "Se cambia con PUT /social/activity-sharing."
+        ),
+    )
 
     # Configuración de Pydantic actualizada para V2
     model_config = ConfigDict(from_attributes=True)

--- a/tests/unit/modules/user/application/use_cases/test_get_current_user_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_current_user_use_case.py
@@ -211,3 +211,43 @@ class TestGetCurrentUserHasPassword:
 
         assert result is not None
         assert result.has_password is True
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUserShareActivity:
+    """
+    Tests para el campo share_activity en la respuesta.
+
+    Es lo único que permite al cliente pintar el interruptor en el estado en el
+    que está. Sin él solo se podría escribir, y una pantalla de ajustes que no
+    sabe lo que tiene guardado acaba apagando lo que el jugador había encendido.
+    """
+
+    async def test_share_activity_true_by_default(self, use_case, normal_user):
+        """
+        Test: share_activity es True para un usuario recién registrado.
+        Given: Usuario que nunca ha tocado el interruptor
+        When: Se obtiene el usuario actual
+        Then: share_activity es True, el valor por defecto de la columna
+        """
+        result = await use_case.execute(str(normal_user.id.value))
+
+        assert result is not None
+        assert result.share_activity is True
+
+    async def test_share_activity_false_after_turning_it_off(self, use_case, uow, normal_user):
+        """
+        Test: share_activity es False cuando el usuario lo apagó.
+        Given: Usuario que apagó la publicación de sus logros
+        When: Se obtiene el usuario actual
+        Then: share_activity es False
+        """
+        async with uow:
+            user = await uow.users.find_by_id(normal_user.id)
+            user.set_activity_sharing(False)
+            await uow.users.save(user)
+
+        result = await use_case.execute(str(normal_user.id.value))
+
+        assert result is not None
+        assert result.share_activity is False


### PR DESCRIPTION
`PUT /social/activity-sharing` already lets a player turn achievement publishing on and off. Nothing returned `share_activity`, though, so a client could write the switch and never read it.

That gap blocks the settings screen on the frontend: a switch that cannot see its own stored value renders a default, and the first time the player opens the page it shows "on" for someone who turned it off — and turns it back on if they touch anything.

## Where it goes

On `UserResponseDTO`, not on a `GET /social/activity-sharing` of its own. It is a preference of the user, it travels on the request the client already makes to know who it is, and the switch paints on first render without a second round trip.

## Exposure

That DTO is only ever returned to its owner. The four routes that use it as `response_model` are register, current-user, avatar and handicap — none of them serves another player's record — so this exposes nobody else's preference.

## Tests

Two on `GetCurrentUserUseCase`: the default is `True` for a new account, and it comes back `False` once the player turns it off.

Contributes to #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user preference to control whether achievements are shared to friends’ activity feeds.
  * Achievement sharing is enabled by default and can be turned off through the available update endpoint.

* **Tests**
  * Added coverage verifying the default enabled state and persistence after disabling the preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->