### PR TITLE
feat(golf-course): Add per-tee scorecards, colors and course-type ranges

### DIFF
--- a/alembic/versions/ba02ec557335_per_tee_scorecards_with_colors_and_.py
+++ b/alembic/versions/ba02ec557335_per_tee_scorecards_with_colors_and_.py
@@ -219,6 +219,22 @@ def downgrade() -> None:
 
     op.execute("DROP INDEX IF EXISTS uq_golf_course_tees_color_gender")
     op.execute("DROP INDEX IF EXISTS uq_golf_course_tees_identifier_gender")
+
+    # Con la unicidad por color, un campo puede tener dos salidas que comparten
+    # categoría y género (blancas y negras, ambas de campeonato masculino). El
+    # esquema anterior no las admite, así que hay que quedarse con una antes de
+    # recrear su índice: de lo contrario CREATE UNIQUE INDEX aborta y el
+    # downgrade falla en cualquier base que haya usado colores.
+    # Se conserva la salida más antigua de cada combinación. Es una pérdida
+    # inevitable: volver al esquema viejo implica que esas salidas no caben.
+    op.execute(
+        "DELETE FROM golf_course_tees t USING golf_course_tees keep "
+        "WHERE t.golf_course_id = keep.golf_course_id "
+        "AND t.tee_category = keep.tee_category "
+        "AND COALESCE(t.tee_gender, 'NONE') = COALESCE(keep.tee_gender, 'NONE') "
+        "AND t.id > keep.id"
+    )
+
     op.execute(
         "CREATE UNIQUE INDEX uq_golf_course_tees_cat_gender "
         "ON golf_course_tees (golf_course_id, tee_category, COALESCE(tee_gender, 'NONE'))"

--- a/alembic/versions/ba02ec557335_per_tee_scorecards_with_colors_and_.py
+++ b/alembic/versions/ba02ec557335_per_tee_scorecards_with_colors_and_.py
@@ -1,0 +1,244 @@
+"""per tee scorecards with colors and meters
+
+Los hoyos pasan a colgar de la salida y no del campo: el par, el índice de
+dificultad y la distancia dependen de la barra desde la que se juega. Esto
+ocurre en 77 de los 802 recorridos federados españoles, y en la mayoría la
+diferencia es entre colores del mismo género, no entre géneros.
+
+La tarjeta del campo (GolfCourse.holes) pasa a ser derivada: se calcula desde
+la primera salida al consultarla, así que golf_course_holes desaparece.
+
+Revision ID: ba02ec557335
+Revises: f7c2a9d4e6b8
+Create Date: 2026-08-11
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ba02ec557335"
+down_revision: str | None = "f7c2a9d4e6b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TEE_COLORS = (
+    "RED",
+    "YELLOW",
+    "BLUE",
+    "WHITE",
+    "GREEN",
+    "ORANGE",
+    "BLACK",
+    "PINK",
+    "GOLD",
+    "OTHER",
+)
+
+# Los campos existentes guardan el color como texto libre en `identifier`.
+# Este mapeo recupera esa información en vez de dejarlos todos en OTHER.
+IDENTIFIER_TO_COLOR = {
+    "RED": ("rojo", "rojas", "red"),
+    "YELLOW": ("amarillo", "amarillas", "yellow"),
+    "BLUE": ("azul", "azules", "blue"),
+    "WHITE": ("blanco", "blancas", "white"),
+    "GREEN": ("verde", "verdes", "green"),
+    "ORANGE": ("naranja", "naranjas", "orange"),
+    "BLACK": ("negro", "negras", "black"),
+    "PINK": ("rosa", "rosas", "pink"),
+    "GOLD": ("oro", "dorado", "doradas", "gold"),
+}
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Color de las barras
+    # ------------------------------------------------------------------
+    tee_color_enum = sa.Enum(*TEE_COLORS, name="tee_color_enum")
+    tee_color_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "golf_course_tees",
+        sa.Column(
+            "color",
+            tee_color_enum,
+            nullable=False,
+            server_default="OTHER",
+            comment="Color de las barras. Independiente de la categoría",
+        ),
+    )
+
+    # Recupera el color desde el identificador libre, que es donde se venía
+    # escribiendo ("Blanco", "Amarillo", ...).
+    for color, needles in IDENTIFIER_TO_COLOR.items():
+        conditions = " OR ".join(f"LOWER(TRIM(identifier)) = '{n}'" for n in needles)
+        op.execute(
+            f"UPDATE golf_course_tees SET color = '{color}'::tee_color_enum "
+            f"WHERE {conditions}"
+        )
+
+    # El identificador pasa a ser opcional: el color ya identifica la salida.
+    op.alter_column("golf_course_tees", "identifier", nullable=True)
+
+    # Una salida sin color reconocible necesita identificador para poder
+    # distinguirse de otra igual.
+    op.execute(
+        "UPDATE golf_course_tees SET identifier = 'Salida ' || id::text "
+        "WHERE color = 'OTHER' AND (identifier IS NULL OR TRIM(identifier) = '')"
+    )
+    op.create_check_constraint(
+        "ck_tees_other_color_needs_identifier",
+        "golf_course_tees",
+        "color <> 'OTHER' OR identifier IS NOT NULL",
+    )
+
+    # ------------------------------------------------------------------
+    # 2. Rangos de rating: los absolutos, unión de todos los tipos de campo.
+    #    El rango estricto de cada tipo lo valida el dominio, porque un CHECK
+    #    tendría que consultar golf_courses para conocer el tipo.
+    # ------------------------------------------------------------------
+    op.drop_constraint("ck_tees_course_rating_range", "golf_course_tees", type_="check")
+    op.drop_constraint("ck_tees_slope_rating_range", "golf_course_tees", type_="check")
+    op.create_check_constraint(
+        "ck_tees_course_rating_range",
+        "golf_course_tees",
+        "course_rating >= 45.0 AND course_rating <= 90.0",
+    )
+    op.create_check_constraint(
+        "ck_tees_slope_rating_range",
+        "golf_course_tees",
+        "slope_rating >= 40 AND slope_rating <= 160",
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Unicidad por salida: pasa de (categoría, género) a color o
+    #    identificador. Un campo puede tener blancas y negras y ser ambas de
+    #    campeonato masculino, así que la categoría ya no distingue.
+    # ------------------------------------------------------------------
+    #    Se resuelve con dos índices parciales en vez de una expresión CASE:
+    #    el cast de un enum a texto no es IMMUTABLE y PostgreSQL no lo admite
+    #    dentro de un índice.
+    op.execute("DROP INDEX IF EXISTS uq_golf_course_tees_cat_gender")
+    op.execute(
+        "CREATE UNIQUE INDEX uq_golf_course_tees_color_gender "
+        "ON golf_course_tees (golf_course_id, color, COALESCE(tee_gender, 'NONE')) "
+        "WHERE color <> 'OTHER'"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX uq_golf_course_tees_identifier_gender "
+        "ON golf_course_tees (golf_course_id, identifier, COALESCE(tee_gender, 'NONE')) "
+        "WHERE color = 'OTHER'"
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Tarjeta por salida
+    # ------------------------------------------------------------------
+    op.create_table(
+        "golf_course_tee_holes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("tee_id", sa.Integer(), nullable=False),
+        sa.Column("hole_number", sa.Integer(), nullable=False, comment="Número de hoyo (1-18)"),
+        sa.Column("par", sa.Integer(), nullable=False, comment="Par del hoyo (3-6)"),
+        sa.Column(
+            "stroke_index", sa.Integer(), nullable=False, comment="Índice de dificultad (1-18)"
+        ),
+        sa.Column(
+            "meters", sa.Integer(), nullable=True, comment="Distancia desde esta salida, en metros"
+        ),
+        sa.ForeignKeyConstraint(["tee_id"], ["golf_course_tees.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("hole_number >= 1 AND hole_number <= 18", name="ck_tee_holes_number_range"),
+        sa.CheckConstraint("par >= 3 AND par <= 6", name="ck_tee_holes_par_range"),
+        sa.CheckConstraint(
+            "stroke_index >= 1 AND stroke_index <= 18", name="ck_tee_holes_stroke_index_range"
+        ),
+        sa.CheckConstraint(
+            "meters IS NULL OR (meters >= 20 AND meters <= 700)", name="ck_tee_holes_meters_range"
+        ),
+        sa.UniqueConstraint("tee_id", "hole_number", name="uq_tee_holes_number"),
+        sa.UniqueConstraint("tee_id", "stroke_index", name="uq_tee_holes_stroke_index"),
+        comment="Hoyos de cada salida (18 por salida) con par, dificultad y distancia",
+    )
+    op.create_index("ix_tee_holes_tee_id", "golf_course_tee_holes", ["tee_id"])
+
+    # Replica la tarjeta del campo en cada una de sus salidas. Sin distancias,
+    # porque hasta ahora no se guardaban.
+    op.execute(
+        "INSERT INTO golf_course_tee_holes (tee_id, hole_number, par, stroke_index, meters) "
+        "SELECT t.id, h.hole_number, h.par, h.stroke_index, NULL "
+        "FROM golf_course_tees t "
+        "JOIN golf_course_holes h ON h.golf_course_id = t.golf_course_id"
+    )
+
+    # ------------------------------------------------------------------
+    # 5. La tarjeta del campo pasa a ser derivada
+    # ------------------------------------------------------------------
+    op.drop_table("golf_course_holes")
+
+
+def downgrade() -> None:
+    # Recrea la tarjeta a nivel de campo
+    op.create_table(
+        "golf_course_holes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("golf_course_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("hole_number", sa.Integer(), nullable=False),
+        sa.Column("par", sa.Integer(), nullable=False),
+        sa.Column("stroke_index", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["golf_course_id"], ["golf_courses.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("hole_number >= 1 AND hole_number <= 18", name="ck_holes_number_range"),
+        sa.CheckConstraint("par >= 3 AND par <= 5", name="ck_holes_par_range"),
+        sa.CheckConstraint(
+            "stroke_index >= 1 AND stroke_index <= 18", name="ck_holes_stroke_index_range"
+        ),
+        sa.UniqueConstraint("golf_course_id", "hole_number", name="uq_golf_course_holes_number"),
+        sa.UniqueConstraint(
+            "golf_course_id", "stroke_index", name="uq_golf_course_holes_stroke_index"
+        ),
+    )
+
+    # Reconstruye la tarjeta del campo desde una salida cualquiera, quedándose
+    # con el par más frecuente por hoyo. Los pares 6 no caben en el CHECK
+    # antiguo y se degradan a 5.
+    op.execute(
+        "INSERT INTO golf_course_holes (golf_course_id, hole_number, par, stroke_index) "
+        "SELECT DISTINCT ON (t.golf_course_id, th.hole_number) "
+        "t.golf_course_id, th.hole_number, LEAST(th.par, 5), th.stroke_index "
+        "FROM golf_course_tee_holes th "
+        "JOIN golf_course_tees t ON t.id = th.tee_id "
+        "ORDER BY t.golf_course_id, th.hole_number, th.id"
+    )
+
+    op.drop_index("ix_tee_holes_tee_id", table_name="golf_course_tee_holes")
+    op.drop_table("golf_course_tee_holes")
+
+    op.execute("DROP INDEX IF EXISTS uq_golf_course_tees_color_gender")
+    op.execute("DROP INDEX IF EXISTS uq_golf_course_tees_identifier_gender")
+    op.execute(
+        "CREATE UNIQUE INDEX uq_golf_course_tees_cat_gender "
+        "ON golf_course_tees (golf_course_id, tee_category, COALESCE(tee_gender, 'NONE'))"
+    )
+
+    op.drop_constraint("ck_tees_course_rating_range", "golf_course_tees", type_="check")
+    op.drop_constraint("ck_tees_slope_rating_range", "golf_course_tees", type_="check")
+    op.create_check_constraint(
+        "ck_tees_course_rating_range",
+        "golf_course_tees",
+        "course_rating >= 50.0 AND course_rating <= 90.0",
+    )
+    op.create_check_constraint(
+        "ck_tees_slope_rating_range",
+        "golf_course_tees",
+        "slope_rating >= 55 AND slope_rating <= 155",
+    )
+
+    op.drop_constraint("ck_tees_other_color_needs_identifier", "golf_course_tees", type_="check")
+    op.execute("UPDATE golf_course_tees SET identifier = 'Salida' WHERE identifier IS NULL")
+    op.alter_column("golf_course_tees", "identifier", nullable=False)
+    op.drop_column("golf_course_tees", "color")
+    sa.Enum(name="tee_color_enum").drop(op.get_bind(), checkfirst=True)

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -105,8 +105,8 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
                 selectinload(Competition._golf_courses)
                 .selectinload(CompetitionGolfCourse.golf_course)
                 .options(
+                    # Los hoyos llegan con las salidas: cuelgan de ellas
                     selectinload(GolfCourse._tees),
-                    selectinload(GolfCourse._holes),
                 )
             )
         )

--- a/src/modules/golf_course/application/dtos/golf_course_dtos.py
+++ b/src/modules/golf_course/application/dtos/golf_course_dtos.py
@@ -4,7 +4,7 @@ Golf Course DTOs - Request/Response for use cases.
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.modules.golf_course.domain.value_objects.course_type import CourseType
 from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
@@ -58,6 +58,23 @@ class TeeDTO(BaseModel):
             "Necesaria cuando el par, la dificultad o las distancias cambian entre barras"
         ),
     )
+
+    @model_validator(mode="after")
+    def check_color_and_identifier(self) -> "TeeDTO":
+        """
+        Una salida sin color reconocible necesita nombre.
+
+        La regla vive en el dominio, que es quien la hace cumplir. Se comprueba
+        también aquí para que el error salga como un fallo de validación del
+        campo concreto, y no como un rechazo genérico de la petición: omitir
+        ambos valores da OTHER sin identificador, que es la combinación que el
+        agregado no admite.
+        """
+        if self.color is TeeColor.OTHER and not (self.identifier or "").strip():
+            raise ValueError(
+                "identifier is required when color is OTHER (or set an explicit color)"
+            )
+        return self
 
     class Config:
         from_attributes = True

--- a/src/modules/golf_course/application/dtos/golf_course_dtos.py
+++ b/src/modules/golf_course/application/dtos/golf_course_dtos.py
@@ -7,10 +7,25 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 
 from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 
 # ============================================================================
 # Nested DTOs (Tee, Hole)
 # ============================================================================
+
+
+class HoleDTO(BaseModel):
+    """DTO para representar un hoyo."""
+
+    hole_number: int = Field(..., ge=1, le=18, description="Número de hoyo (1-18)")
+    par: int = Field(..., ge=3, le=6, description="Par del hoyo (3-6)")
+    stroke_index: int = Field(..., ge=1, le=18, description="Índice de dificultad (1-18)")
+    meters: int | None = Field(
+        None, ge=20, le=700, description="Distancia desde esta salida, en metros"
+    )
+
+    class Config:
+        from_attributes = True
 
 
 class TeeDTO(BaseModel):
@@ -20,22 +35,29 @@ class TeeDTO(BaseModel):
         ..., description="Categoría normalizada (CHAMPIONSHIP, AMATEUR, SENIOR, FORWARD, JUNIOR)"
     )
     tee_gender: str | None = Field(None, description="Género del tee (MALE/FEMALE/null)")
-    identifier: str = Field(
-        ..., description="Identificador libre del campo (Amarillo, Oro, 1, etc.)"
+    color: TeeColor = Field(
+        TeeColor.OTHER,
+        description="Color de las barras. Independiente de la categoría",
     )
-    course_rating: float = Field(..., ge=50.0, le=90.0, description="Course Rating WHS (50-90)")
-    slope_rating: int = Field(..., ge=55, le=155, description="Slope Rating WHS (55-155)")
-
-    class Config:
-        from_attributes = True
-
-
-class HoleDTO(BaseModel):
-    """DTO para representar un hoyo."""
-
-    hole_number: int = Field(..., ge=1, le=18, description="Número de hoyo (1-18)")
-    par: int = Field(..., ge=3, le=5, description="Par del hoyo (3-5)")
-    stroke_index: int = Field(..., ge=1, le=18, description="Índice de dificultad (1-18)")
+    identifier: str | None = Field(
+        None,
+        max_length=50,
+        description="Nombre libre opcional. Obligatorio si el color es OTHER",
+    )
+    # Los rangos son los absolutos de todos los tipos de campo. El rango
+    # estricto que corresponde a cada tipo lo aplica el dominio: acotarlo aquí
+    # impediría dar de alta pitch & putt, que WHS no valora en la misma escala.
+    course_rating: float = Field(..., ge=45.0, le=90.0, description="Course Rating WHS")
+    slope_rating: int = Field(..., ge=40, le=160, description="Slope Rating WHS")
+    holes: list[HoleDTO] | None = Field(
+        None,
+        min_length=18,
+        max_length=18,
+        description=(
+            "Tarjeta propia de esta salida. Si se omite, hereda la del campo. "
+            "Necesaria cuando el par, la dificultad o las distancias cambian entre barras"
+        ),
+    )
 
     class Config:
         from_attributes = True
@@ -54,7 +76,7 @@ class RequestGolfCourseRequestDTO(BaseModel):
         ..., min_length=2, max_length=2, description="Código ISO del país (ES, FR, etc.)"
     )
     course_type: CourseType = Field(..., description="Tipo de campo (STANDARD_18, etc.)")
-    tees: list[TeeDTO] = Field(..., min_length=2, max_length=10, description="2-10 tees")
+    tees: list[TeeDTO] = Field(..., min_length=1, max_length=14, description="1-14 salidas")
     holes: list[HoleDTO] = Field(
         ..., min_length=18, max_length=18, description="Exactamente 18 hoyos"
     )
@@ -189,7 +211,7 @@ class UpdateGolfCourseRequestDTO(BaseModel):
         ..., min_length=2, max_length=2, description="Código ISO del país (ES, FR, etc.)"
     )
     course_type: CourseType = Field(..., description="Tipo de campo (STANDARD_18, etc.)")
-    tees: list[TeeDTO] = Field(..., min_length=2, max_length=10, description="2-10 tees")
+    tees: list[TeeDTO] = Field(..., min_length=1, max_length=14, description="1-14 salidas")
     holes: list[HoleDTO] = Field(
         ..., min_length=18, max_length=18, description="Exactamente 18 hoyos"
     )

--- a/src/modules/golf_course/application/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/application/mappers/golf_course_mapper.py
@@ -8,22 +8,68 @@ from src.modules.golf_course.application.dtos.golf_course_dtos import (
     TeeDTO,
 )
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.shared.domain.value_objects.gender import Gender
 
 
 class GolfCourseMapper:
     """
-    Mapper para convertir GolfCourse entity a Response DTOs.
+    Mapper entre GolfCourse y sus DTOs, en ambos sentidos.
 
     Evita duplicación de código en los use cases.
     """
 
     @staticmethod
-    def to_response_dto(golf_course: GolfCourse) -> GolfCourseResponseDTO:
+    def to_domain_holes(hole_dtos: list[HoleDTO]) -> list[Hole]:
+        """Convierte una tarjeta recibida por la API en hoyos de dominio."""
+        return [
+            Hole(
+                number=hole_dto.hole_number,
+                par=hole_dto.par,
+                stroke_index=hole_dto.stroke_index,
+                meters=hole_dto.meters,
+            )
+            for hole_dto in hole_dtos
+        ]
+
+    @staticmethod
+    def to_domain_tees(tee_dtos: list[TeeDTO]) -> list[Tee]:
+        """
+        Convierte las salidas recibidas por la API en salidas de dominio.
+
+        Una salida puede traer su propia tarjeta o no traerla. Si no la trae,
+        el agregado le copia la del campo al construirse.
+        """
+        return [
+            Tee(
+                category=TeeCategory(tee_dto.tee_category),
+                gender=Gender(tee_dto.tee_gender) if tee_dto.tee_gender else None,
+                color=tee_dto.color,
+                identifier=tee_dto.identifier,
+                course_rating=tee_dto.course_rating,
+                slope_rating=tee_dto.slope_rating,
+                holes=(
+                    GolfCourseMapper.to_domain_holes(tee_dto.holes) if tee_dto.holes else []
+                ),
+            )
+            for tee_dto in tee_dtos
+        ]
+
+    @staticmethod
+    def to_response_dto(
+        golf_course: GolfCourse, *, include_tee_scorecards: bool = True
+    ) -> GolfCourseResponseDTO:
         """
         Mapea GolfCourse entity a GolfCourseResponseDTO.
 
         Args:
             golf_course: Entidad de dominio
+            include_tee_scorecards: Si es False, las salidas se devuelven sin su
+                tarjeta. Un campo puede tener hasta 14 salidas de 18 hoyos cada
+                una, así que en los listados se omiten para no devolver
+                centenares de hoyos por campo. El detalle sí las incluye.
 
         Returns:
             DTO de respuesta
@@ -38,17 +84,35 @@ class GolfCourseMapper:
                 TeeDTO(
                     tee_category=tee.category.value,
                     tee_gender=tee.gender.value if tee.gender else None,
+                    color=tee.color,
                     identifier=tee.identifier,
                     course_rating=tee.course_rating,
                     slope_rating=tee.slope_rating,
+                    holes=(
+                        [
+                            HoleDTO(
+                                hole_number=hole.number,
+                                par=hole.par,
+                                stroke_index=hole.stroke_index,
+                                meters=hole.meters,
+                            )
+                            for hole in sorted(tee.holes, key=lambda h: h.number)
+                        ]
+                        if include_tee_scorecards and tee.holes
+                        else None
+                    ),
                 )
                 for tee in golf_course.tees
             ],
+            # Tarjeta de referencia del campo, derivada de la primera salida.
+            # Se mantiene para los consumidores que no necesitan el detalle por
+            # barra (estadísticas, emparejamientos, partidas rápidas).
             holes=[
                 HoleDTO(
                     hole_number=hole.number,
                     par=hole.par,
                     stroke_index=hole.stroke_index,
+                    meters=hole.meters,
                 )
                 for hole in golf_course.holes
             ],

--- a/src/modules/golf_course/application/use_cases/create_direct_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/create_direct_golf_course_use_case.py
@@ -8,15 +8,11 @@ from src.modules.golf_course.application.dtos.golf_course_dtos import (
 )
 from src.modules.golf_course.application.mappers.golf_course_mapper import GolfCourseMapper
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
-from src.modules.golf_course.domain.entities.hole import Hole
-from src.modules.golf_course.domain.entities.tee import Tee
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
-from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.value_objects.country_code import CountryCode
-from src.shared.domain.value_objects.gender import Gender
 
 
 class CreateDirectGolfCourseUseCase:
@@ -77,26 +73,10 @@ class CreateDirectGolfCourseUseCase:
                 raise ValueError(f"Country with code '{request.country_code}' not found")
 
             # 3. Crear Tees
-            tees = [
-                Tee(
-                    category=TeeCategory(tee_dto.tee_category),
-                    gender=Gender(tee_dto.tee_gender) if tee_dto.tee_gender else None,
-                    identifier=tee_dto.identifier,
-                    course_rating=tee_dto.course_rating,
-                    slope_rating=tee_dto.slope_rating,
-                )
-                for tee_dto in request.tees
-            ]
+            tees = GolfCourseMapper.to_domain_tees(request.tees)
 
             # 4. Crear Holes
-            holes = [
-                Hole(
-                    number=hole_dto.hole_number,
-                    par=hole_dto.par,
-                    stroke_index=hole_dto.stroke_index,
-                )
-                for hole_dto in request.holes
-            ]
+            holes = GolfCourseMapper.to_domain_holes(request.holes)
 
             # 5. Crear GolfCourse (estado PENDING_APPROVAL primero)
             golf_course = GolfCourse.create(

--- a/src/modules/golf_course/application/use_cases/list_approved_golf_courses_use_case.py
+++ b/src/modules/golf_course/application/use_cases/list_approved_golf_courses_use_case.py
@@ -46,7 +46,13 @@ class ListApprovedGolfCoursesUseCase:
             )
 
             # 2. Mapear a Response DTOs
-            response_dtos = [GolfCourseMapper.to_response_dto(gc) for gc in golf_courses]
+            # Sin las tarjetas por salida: un campo puede tener 14 salidas de
+            # 18 hoyos, y un listado las multiplicaría por cada campo. El
+            # detalle de un campo sí las devuelve.
+            response_dtos = [
+                GolfCourseMapper.to_response_dto(gc, include_tee_scorecards=False)
+                for gc in golf_courses
+            ]
 
             return ListApprovedGolfCoursesResponseDTO(
                 golf_courses=response_dtos,

--- a/src/modules/golf_course/application/use_cases/list_pending_golf_courses_use_case.py
+++ b/src/modules/golf_course/application/use_cases/list_pending_golf_courses_use_case.py
@@ -46,7 +46,13 @@ class ListPendingGolfCoursesUseCase:
             golf_courses = await self._uow.golf_courses.find_pending_approval()
 
             # 2. Mapear a Response DTOs
-            response_dtos = [GolfCourseMapper.to_response_dto(gc) for gc in golf_courses]
+            # Sin las tarjetas por salida: un campo puede tener 14 salidas de
+            # 18 hoyos, y un listado las multiplicaría por cada campo. El
+            # detalle de un campo sí las devuelve.
+            response_dtos = [
+                GolfCourseMapper.to_response_dto(gc, include_tee_scorecards=False)
+                for gc in golf_courses
+            ]
 
             return ListPendingGolfCoursesResponseDTO(
                 golf_courses=response_dtos,

--- a/src/modules/golf_course/application/use_cases/request_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/request_golf_course_use_case.py
@@ -8,15 +8,11 @@ from src.modules.golf_course.application.dtos.golf_course_dtos import (
 )
 from src.modules.golf_course.application.mappers.golf_course_mapper import GolfCourseMapper
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
-from src.modules.golf_course.domain.entities.hole import Hole
-from src.modules.golf_course.domain.entities.tee import Tee
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
-from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.value_objects.country_code import CountryCode
-from src.shared.domain.value_objects.gender import Gender
 
 
 class RequestGolfCourseUseCase:
@@ -73,26 +69,10 @@ class RequestGolfCourseUseCase:
                 raise ValueError(f"Country with code '{request.country_code}' not found")
 
             # 3. Crear Tees
-            tees = [
-                Tee(
-                    category=TeeCategory(tee_dto.tee_category),
-                    gender=Gender(tee_dto.tee_gender) if tee_dto.tee_gender else None,
-                    identifier=tee_dto.identifier,
-                    course_rating=tee_dto.course_rating,
-                    slope_rating=tee_dto.slope_rating,
-                )
-                for tee_dto in request.tees
-            ]
+            tees = GolfCourseMapper.to_domain_tees(request.tees)
 
             # 4. Crear Holes
-            holes = [
-                Hole(
-                    number=hole_dto.hole_number,
-                    par=hole_dto.par,
-                    stroke_index=hole_dto.stroke_index,
-                )
-                for hole_dto in request.holes
-            ]
+            holes = GolfCourseMapper.to_domain_holes(request.holes)
 
             # 5. Crear GolfCourse (estado PENDING_APPROVAL)
             golf_course = GolfCourse.create(

--- a/src/modules/golf_course/application/use_cases/update_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/update_golf_course_use_case.py
@@ -7,17 +7,13 @@ from src.modules.golf_course.application.dtos.golf_course_dtos import (
     UpdateGolfCourseResponseDTO,
 )
 from src.modules.golf_course.application.mappers.golf_course_mapper import GolfCourseMapper
-from src.modules.golf_course.domain.entities.hole import Hole
-from src.modules.golf_course.domain.entities.tee import Tee
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
 from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
-from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.value_objects.country_code import CountryCode
-from src.shared.domain.value_objects.gender import Gender
 
 
 class UpdateGolfCourseUseCase:
@@ -63,25 +59,9 @@ class UpdateGolfCourseUseCase:
                 raise ValueError(f"Country with code '{request.country_code}' not found")
 
             # 4. Crear Tees y Holes desde DTOs
-            tees = [
-                Tee(
-                    category=TeeCategory(tee_dto.tee_category),
-                    gender=Gender(tee_dto.tee_gender) if tee_dto.tee_gender else None,
-                    identifier=tee_dto.identifier,
-                    course_rating=tee_dto.course_rating,
-                    slope_rating=tee_dto.slope_rating,
-                )
-                for tee_dto in request.tees
-            ]
+            tees = GolfCourseMapper.to_domain_tees(request.tees)
 
-            holes = [
-                Hole(
-                    number=hole_dto.hole_number,
-                    par=hole_dto.par,
-                    stroke_index=hole_dto.stroke_index,
-                )
-                for hole_dto in request.holes
-            ]
+            holes = GolfCourseMapper.to_domain_holes(request.holes)
 
             # 5. Delegar decisión de negocio al dominio
             # apply_update retorna None (in-place) o GolfCourse clone (proposal)

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -378,24 +378,23 @@ class GolfCourse:
             new_tee = TeeEntity(
                 category=tee.category,
                 gender=tee.gender,
+                color=tee.color,
                 identifier=tee.identifier,
                 course_rating=tee.course_rating,
                 slope_rating=tee.slope_rating,
+                holes=[replace(hole) for hole in tee.holes],
             )
             self._tees.append(new_tee)
 
         del self._holes[:]  # Elimina todos los elementos in-place
-        from src.modules.golf_course.domain.entities.hole import Hole as HoleEntity
-
         for hole in holes:
-            new_hole = HoleEntity(
-                number=hole.number,
-                par=hole.par,
-                stroke_index=hole.stroke_index,
-            )
-            self._holes.append(new_hole)
+            self._holes.append(replace(hole))
 
         self._updated_at = datetime.now(UTC).replace(tzinfo=None)
+
+        # Reconciliar tarjetas antes de validar: si las salidas llegan sin la
+        # suya, heredan la del campo
+        self._sync_holes_and_tees()
 
         # Validar invariantes
         self._validate_holes()
@@ -525,34 +524,29 @@ class GolfCourse:
         # porque los objetos del clone ya tienen golf_course_id asignado
         del self._tees[:]  # Elimina todos los elementos in-place
         for tee in clone._tees:
-            # Crear nuevo Tee con los mismos datos
-            from src.modules.golf_course.domain.entities.tee import Tee
-
+            # Crear nuevo Tee con los mismos datos, incluida su tarjeta
             new_tee = Tee(
                 category=tee.category,
                 gender=tee.gender,
+                color=tee.color,
                 identifier=tee.identifier,
                 course_rating=tee.course_rating,
                 slope_rating=tee.slope_rating,
+                holes=[replace(hole) for hole in tee.holes],
             )
             self._tees.append(new_tee)
 
         del self._holes[:]  # Elimina todos los elementos in-place
         for hole in clone._holes:
-            # Crear nuevo Hole con los mismos datos
-            from src.modules.golf_course.domain.entities.hole import Hole
-
-            new_hole = Hole(
-                number=hole.number,
-                par=hole.par,
-                stroke_index=hole.stroke_index,
-            )
-            self._holes.append(new_hole)
+            self._holes.append(replace(hole))
 
         self._updated_at = datetime.now(UTC).replace(tzinfo=None)
 
         # Quitar marca de pending update
         self._is_pending_update = False
+
+        # Reconciliar tarjetas antes de validar
+        self._sync_holes_and_tees()
 
         # Validar invariantes
         self._validate_holes()
@@ -576,14 +570,22 @@ class GolfCourse:
                 f"Golf course must have exactly {HOLES_PER_ROUND} holes, got {len(self._holes)}"
             )
 
-        stroke_indices = [h.stroke_index for h in self._holes]
-        expected_indices = set(range(1, HOLES_PER_ROUND + 1))
-        if set(stroke_indices) != expected_indices or len(stroke_indices) != len(
-            set(stroke_indices)
-        ):
+        # Los números de hoyo también deben ser 1-18 sin repetir. La tarjeta de
+        # referencia se copia a las salidas asignando la lista, lo que no pasa
+        # por el validador de Tee, así que si no se comprueba aquí una tarjeta
+        # con hoyos repetidos acabaría propagándose a todas las salidas.
+        hole_numbers = sorted(h.number for h in self._holes)
+        if hole_numbers != list(range(1, HOLES_PER_ROUND + 1)):
+            raise ValueError(
+                f"Hole numbers must be exactly 1-{HOLES_PER_ROUND} without "
+                f"duplicates, got {hole_numbers}"
+            )
+
+        stroke_indices = sorted(h.stroke_index for h in self._holes)
+        if stroke_indices != list(range(1, HOLES_PER_ROUND + 1)):
             raise ValueError(
                 f"Stroke indices must be exactly 1-{HOLES_PER_ROUND} without "
-                f"duplicates, got {sorted(stroke_indices)}"
+                f"duplicates, got {stroke_indices}"
             )
 
         min_par, max_par = PAR_RANGE_BY_COURSE_TYPE[self._course_type]

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -63,18 +63,20 @@ class GolfCourse:
 
     Responsabilidades:
     - Gestionar información del campo (nombre, país, tipo)
-    - Gestionar tees (2-6 salidas con ratings WHS)
-    - Gestionar hoyos (18 hoyos con par y stroke index)
+    - Gestionar salidas (1-14, cada una con sus ratings WHS y su tarjeta)
     - Workflow de aprobación Admin
 
     Business Rules:
-    - Exactamente 18 hoyos
-    - Stroke indices únicos (1-18)
-    - Par total entre 66 y 76
-    - 2-10 tees (5 categorías x 2 géneros max)
-    - Unique (category, gender) combinations
-    - No mezclar gendered/non-gendered tees de la misma categoría
+    - Cada salida tiene sus 18 hoyos, con par, stroke index y distancia propios
+    - Números de hoyo y stroke indices 1-18 sin repetir
+    - Par total, slope y course rating dentro del rango de su tipo de campo
+    - 1-14 salidas, únicas por color (o por identificador si el color es OTHER)
+    - No mezclar salidas con y sin género para un mismo color
     - Estados inmutables: APPROVED/REJECTED
+
+    La tarjeta del campo (`holes`) es derivada: no se persiste, se toma de la
+    primera salida. Existe para los consumidores que no necesitan el detalle
+    por barra.
 
     Example:
         >>> course = GolfCourse.create(
@@ -162,7 +164,7 @@ class GolfCourse:
         funcionando, y quien necesite la distancia o el índice exactos de una
         barra concreta los pide a su Tee.
         """
-        if not self._holes:
+        if not getattr(self, "_holes", None):
             for tee in self._tees:
                 if tee.holes:
                     self._holes = [replace(hole) for hole in tee.holes]
@@ -537,7 +539,7 @@ class GolfCourse:
             self._tees.append(new_tee)
 
         del self._holes[:]  # Elimina todos los elementos in-place
-        for hole in clone._holes:
+        for hole in clone.holes:
             self._holes.append(replace(hole))
 
         self._updated_at = datetime.now(UTC).replace(tzinfo=None)
@@ -565,23 +567,24 @@ class GolfCourse:
         Raises:
             ValueError: Si la validación falla
         """
-        if len(self._holes) != HOLES_PER_ROUND:
+        reference_card = self.holes
+        if len(reference_card) != HOLES_PER_ROUND:
             raise ValueError(
-                f"Golf course must have exactly {HOLES_PER_ROUND} holes, got {len(self._holes)}"
+                f"Golf course must have exactly {HOLES_PER_ROUND} holes, got {len(reference_card)}"
             )
 
         # Los números de hoyo también deben ser 1-18 sin repetir. La tarjeta de
         # referencia se copia a las salidas asignando la lista, lo que no pasa
         # por el validador de Tee, así que si no se comprueba aquí una tarjeta
         # con hoyos repetidos acabaría propagándose a todas las salidas.
-        hole_numbers = sorted(h.number for h in self._holes)
+        hole_numbers = sorted(h.number for h in reference_card)
         if hole_numbers != list(range(1, HOLES_PER_ROUND + 1)):
             raise ValueError(
                 f"Hole numbers must be exactly 1-{HOLES_PER_ROUND} without "
                 f"duplicates, got {hole_numbers}"
             )
 
-        stroke_indices = sorted(h.stroke_index for h in self._holes)
+        stroke_indices = sorted(h.stroke_index for h in reference_card)
         if stroke_indices != list(range(1, HOLES_PER_ROUND + 1)):
             raise ValueError(
                 f"Stroke indices must be exactly 1-{HOLES_PER_ROUND} without "
@@ -589,7 +592,7 @@ class GolfCourse:
             )
 
         min_par, max_par = PAR_RANGE_BY_COURSE_TYPE[self._course_type]
-        total_par = sum(h.par for h in self._holes)
+        total_par = sum(h.par for h in reference_card)
         if not (min_par <= total_par <= max_par):
             raise ValueError(
                 f"Total par for a {self._course_type} course must be between "
@@ -707,7 +710,23 @@ class GolfCourse:
 
     @property
     def holes(self) -> list[Hole]:
-        return sorted(self._holes, key=lambda h: h.number)
+        """
+        Tarjeta de referencia del campo.
+
+        No se persiste: la tarjeta real vive en cada salida, y esta se deriva
+        de la primera que tenga una. Se calcula al consultarla y no al cargar
+        el agregado porque durante el evento de carga de SQLAlchemy las
+        relaciones eager todavía no están garantizadas.
+        """
+        own_holes = getattr(self, "_holes", None)
+        if own_holes:
+            return sorted(own_holes, key=lambda h: h.number)
+
+        for tee in self._tees:
+            if tee.holes:
+                return sorted((replace(hole) for hole in tee.holes), key=lambda h: h.number)
+
+        return []
 
     @property
     def approval_status(self) -> ApprovalStatus:
@@ -727,8 +746,8 @@ class GolfCourse:
 
     @property
     def total_par(self) -> int:
-        """Retorna el par total del campo."""
-        return sum(h.par for h in self._holes)
+        """Retorna el par total del campo, según su tarjeta de referencia."""
+        return sum(h.par for h in self.holes)
 
     @property
     def original_golf_course_id(self) -> GolfCourseId | None:

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -5,6 +5,8 @@ Workflow: PENDING_APPROVAL → APPROVED/REJECTED (inmutable después)
 Ver ADR-032 para detalles del workflow de aprobación.
 """
 
+from collections import defaultdict
+from dataclasses import replace
 from datetime import UTC, datetime
 
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -21,6 +23,38 @@ from ..value_objects.golf_course_id import GolfCourseId
 from ..value_objects.tee_category import TeeCategory
 from .hole import Hole
 from .tee import Tee
+
+HOLES_PER_ROUND = 18
+
+# Un campo federado puede tener desde una sola salida hasta catorce (el Old
+# Course de Atalaya tiene doce, y hay un recorrido con catorce).
+MIN_TEES = 1
+MAX_TEES = 14
+
+# Rangos por tipo de campo. Los estándar mantienen el rigor de WHS; los cortos
+# usan márgenes más amplios porque el sistema no los valora en la misma escala.
+PAR_RANGE_BY_COURSE_TYPE: dict[CourseType, tuple[int, int]] = {
+    CourseType.STANDARD_18: (66, 76),
+    CourseType.EXECUTIVE: (61, 65),
+    CourseType.PITCH_AND_PUTT: (54, 60),
+}
+
+# El techo de slope de los campos estándar se sube a 160 pese a que WHS define
+# 155 como máximo: hay campos federados publicados por encima (el Villa de
+# Madrid, negras de mujeres, está en 157) y rechazarlos por un redondeo ajeno
+# sería perder campos reales. El suelo sí se mantiene estricto, porque es lo
+# que permite detectar erratas de origen.
+SLOPE_RANGE_BY_COURSE_TYPE: dict[CourseType, tuple[int, int]] = {
+    CourseType.STANDARD_18: (55, 160),
+    CourseType.EXECUTIVE: (40, 155),
+    CourseType.PITCH_AND_PUTT: (40, 155),
+}
+
+RATING_RANGE_BY_COURSE_TYPE: dict[CourseType, tuple[float, float]] = {
+    CourseType.STANDARD_18: (50.0, 90.0),
+    CourseType.EXECUTIVE: (45.0, 90.0),
+    CourseType.PITCH_AND_PUTT: (45.0, 90.0),
+}
 
 
 class GolfCourse:
@@ -106,9 +140,37 @@ class GolfCourse:
         self._is_pending_update = is_pending_update
         self._domain_events: list[DomainEvent] = domain_events or []
 
+        # Reconciliar la tarjeta del campo con la de cada salida antes de validar
+        self._sync_holes_and_tees()
+
         # Validar invariantes
         self._validate_holes()
         self._validate_tees()
+
+    def _sync_holes_and_tees(self) -> None:
+        """
+        Reconcilia la tarjeta de referencia del campo con la de cada salida.
+
+        Un campo puede describirse de dos maneras, y ambas siguen siendo válidas:
+
+        - Con una sola tarjeta para todo el campo (como se creaba hasta ahora):
+          esos hoyos se copian a las salidas que no traigan tarjeta propia.
+        - Con una tarjeta por salida (lo que publica la RFEG): en ese caso la
+          tarjeta de referencia del campo se toma de la primera salida.
+
+        Así los consumidores que solo leen `golf_course.holes` siguen
+        funcionando, y quien necesite la distancia o el índice exactos de una
+        barra concreta los pide a su Tee.
+        """
+        if not self._holes:
+            for tee in self._tees:
+                if tee.holes:
+                    self._holes = [replace(hole) for hole in tee.holes]
+                    break
+
+        for tee in self._tees:
+            if not tee.holes and self._holes:
+                tee.holes = [replace(hole) for hole in self._holes]
 
     @classmethod
     def create(
@@ -498,62 +560,101 @@ class GolfCourse:
 
     def _validate_holes(self) -> None:
         """
-        Valida que haya exactamente 18 hoyos con índices únicos y par válido.
+        Valida la tarjeta de referencia: 18 hoyos, índices únicos y par en rango.
+
+        El rango de par depende del tipo de campo, y se comprueba sobre la
+        tarjeta de referencia y no sobre cada salida: hay recorridos federados
+        donde el par varía entre barras (un hoyo que es par 5 desde las de
+        atrás y par 4 desde las de delante), y exigir el mismo rango a todas
+        dejaría fuera campos perfectamente válidos.
 
         Raises:
             ValueError: Si la validación falla
         """
-        # Debe tener exactamente 18 hoyos
-        if len(self._holes) != 18:  # noqa: PLR2004
-            raise ValueError(f"Golf course must have exactly 18 holes, got {len(self._holes)}")
+        if len(self._holes) != HOLES_PER_ROUND:
+            raise ValueError(
+                f"Golf course must have exactly {HOLES_PER_ROUND} holes, got {len(self._holes)}"
+            )
 
-        # Stroke indices deben ser únicos (1-18)
         stroke_indices = [h.stroke_index for h in self._holes]
-        if len(stroke_indices) != len(set(stroke_indices)):
-            raise ValueError("Stroke indices must be unique (1-18)")
+        expected_indices = set(range(1, HOLES_PER_ROUND + 1))
+        if set(stroke_indices) != expected_indices or len(stroke_indices) != len(
+            set(stroke_indices)
+        ):
+            raise ValueError(
+                f"Stroke indices must be exactly 1-{HOLES_PER_ROUND} without "
+                f"duplicates, got {sorted(stroke_indices)}"
+            )
 
-        expected_indices = set(range(1, 19))
-        actual_indices = set(stroke_indices)
-        if expected_indices != actual_indices:
-            raise ValueError(f"Stroke indices must be exactly 1-18, got {sorted(actual_indices)}")
-
-        # Par total debe estar entre 66 y 76
+        min_par, max_par = PAR_RANGE_BY_COURSE_TYPE[self._course_type]
         total_par = sum(h.par for h in self._holes)
-        if not (66 <= total_par <= 76):  # noqa: PLR2004
-            raise ValueError(f"Total par must be between 66 and 76, got {total_par}")
+        if not (min_par <= total_par <= max_par):
+            raise ValueError(
+                f"Total par for a {self._course_type} course must be between "
+                f"{min_par} and {max_par}, got {total_par}"
+            )
 
     def _validate_tees(self) -> None:
         """
-        Valida tees: cantidad 2-10, unicidad (category, gender), consistencia gendered.
+        Valida las salidas: cantidad, unicidad por color y género, y ratings.
+
+        La unicidad va por (color, género) y no por (categoría, género): con
+        campos de hasta catorce salidas, varias comparten categoría — un campo
+        puede tener blancas y negras y ambas ser CHAMPIONSHIP. Lo que identifica
+        físicamente una salida es su color.
 
         Raises:
             ValueError: Si la validación falla
         """
-        if not (2 <= len(self._tees) <= 10):  # noqa: PLR2004
-            raise ValueError(f"Golf course must have between 2 and 10 tees, got {len(self._tees)}")
+        if not (MIN_TEES <= len(self._tees) <= MAX_TEES):
+            raise ValueError(
+                f"Golf course must have between {MIN_TEES} and {MAX_TEES} tees, "
+                f"got {len(self._tees)}"
+            )
 
-        # Unicidad: combinación (category, gender) debe ser única
         seen_combos: set[tuple[str, str | None]] = set()
         for tee in self._tees:
-            gender_val = tee.gender.value if tee.gender else None
-            combo = (tee.category.value, gender_val)
+            combo = tee.unique_key
             if combo in seen_combos:
-                raise ValueError(
-                    f"Duplicate tee combination: ({tee.category.value}, {gender_val or 'None'})"
-                )
+                raise ValueError(f"Duplicate tee: {tee.display_name} ({combo[1] or 'no gender'})")
             seen_combos.add(combo)
 
-        # Consistencia: para una misma categoría, no mezclar gendered y non-gendered
-        from collections import defaultdict
-
-        gender_by_category: dict[str, set[str | None]] = defaultdict(set)
+        # Consistencia: para una misma salida, no mezclar con y sin género
+        genders_by_tee: dict[str, set[str | None]] = defaultdict(set)
         for tee in self._tees:
-            gender_val = tee.gender.value if tee.gender else None
-            gender_by_category[tee.category.value].add(gender_val)
+            genders_by_tee[tee.unique_key[0]].add(tee.gender.value if tee.gender else None)
 
-        for cat, genders in gender_by_category.items():
+        for tee_key, genders in genders_by_tee.items():
             if None in genders and len(genders) > 1:
-                raise ValueError(f"Category '{cat}' cannot mix gendered and non-gendered tees")
+                raise ValueError(f"Tee '{tee_key}' cannot mix gendered and non-gendered tees")
+
+        self._validate_tee_ratings()
+
+    def _validate_tee_ratings(self) -> None:
+        """
+        Comprueba que los ratings WHS caen en el rango propio del tipo de campo.
+
+        Los campos estándar mantienen el rigor de WHS. Los cortos (pitch & putt
+        y ejecutivos) usan márgenes más amplios porque el sistema no los valora
+        en la misma escala: hay pitch & putt federados con slope por debajo de
+        55 y course rating por debajo de 50.
+        """
+        min_slope, max_slope = SLOPE_RANGE_BY_COURSE_TYPE[self._course_type]
+        min_rating, max_rating = RATING_RANGE_BY_COURSE_TYPE[self._course_type]
+
+        for tee in self._tees:
+            if not (min_slope <= tee.slope_rating <= max_slope):
+                raise ValueError(
+                    f"Slope rating for a {self._course_type} course must be between "
+                    f"{min_slope} and {max_slope}, got {tee.slope_rating} "
+                    f"on tee {tee.display_name}"
+                )
+            if not (min_rating <= tee.course_rating <= max_rating):
+                raise ValueError(
+                    f"Course rating for a {self._course_type} course must be between "
+                    f"{min_rating} and {max_rating}, got {tee.course_rating} "
+                    f"on tee {tee.display_name}"
+                )
 
     # Domain Events Management
 

--- a/src/modules/golf_course/domain/entities/hole.py
+++ b/src/modules/golf_course/domain/entities/hole.py
@@ -4,38 +4,58 @@ Hole Entity - Hoyo individual de un campo de golf.
 
 from dataclasses import dataclass
 
+MIN_HOLE_NUMBER = 1
+MAX_HOLE_NUMBER = 18
+VALID_PARS = (3, 4, 5, 6)
+MIN_METERS = 20
+MAX_METERS = 700
+
 
 @dataclass
 class Hole:
     """
-    Hoyo de un campo de golf.
+    Hoyo de un campo de golf, tal y como se juega desde una salida concreta.
+
+    Los hoyos cuelgan del Tee y no del campo, porque el par, el índice de
+    dificultad y la distancia dependen de la barra desde la que se juega. En
+    los campos federados españoles esto ocurre en 77 de 802 recorridos, y en la
+    mayoría la diferencia es entre colores del mismo género, no entre géneros.
 
     Attributes:
         number: Número del hoyo (1-18)
-        par: Par del hoyo (3, 4, 5)
-        stroke_index: Índice de dificultad (1-18, único por campo)
-
-    Validations:
-        - number: 1-18
-        - par: 3, 4, o 5
-        - stroke_index: 1-18 (debe ser único en el campo)
-        - Total par del campo: 66-76
+        par: Par del hoyo (3-6)
+        stroke_index: Índice de dificultad (1-18, único dentro de la salida)
+        meters: Distancia en metros desde esta salida (opcional)
 
     Example:
-        >>> hole = Hole(number=1, par=4, stroke_index=5)
+        >>> hole = Hole(number=1, par=4, stroke_index=5, meters=351)
     """
 
     number: int
     par: int
     stroke_index: int
+    meters: int | None = None
 
     def __post_init__(self) -> None:
         """Valida los valores del hoyo."""
-        if not (1 <= self.number <= 18):  # noqa: PLR2004
-            raise ValueError(f"Hole number must be between 1 and 18, got {self.number}")
+        if not (MIN_HOLE_NUMBER <= self.number <= MAX_HOLE_NUMBER):
+            raise ValueError(
+                f"Hole number must be between {MIN_HOLE_NUMBER} and "
+                f"{MAX_HOLE_NUMBER}, got {self.number}"
+            )
 
-        if self.par not in [3, 4, 5]:
-            raise ValueError(f"Par must be 3, 4, or 5, got {self.par}")
+        if self.par not in VALID_PARS:
+            raise ValueError(
+                f"Par must be one of {', '.join(str(p) for p in VALID_PARS)}, got {self.par}"
+            )
 
-        if not (1 <= self.stroke_index <= 18):  # noqa: PLR2004
-            raise ValueError(f"Stroke index must be between 1 and 18, got {self.stroke_index}")
+        if not (MIN_HOLE_NUMBER <= self.stroke_index <= MAX_HOLE_NUMBER):
+            raise ValueError(
+                f"Stroke index must be between {MIN_HOLE_NUMBER} and "
+                f"{MAX_HOLE_NUMBER}, got {self.stroke_index}"
+            )
+
+        if self.meters is not None and not (MIN_METERS <= self.meters <= MAX_METERS):
+            raise ValueError(
+                f"Meters must be between {MIN_METERS} and {MAX_METERS}, got {self.meters}"
+            )

--- a/src/modules/golf_course/domain/entities/tee.py
+++ b/src/modules/golf_course/domain/entities/tee.py
@@ -1,25 +1,42 @@
 """
-Tee Entity - Salida de un campo de golf con ratings WHS.
+Tee Entity - Salida de un campo de golf con ratings WHS y su tarjeta de hoyos.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from src.shared.domain.value_objects.gender import Gender
 
 from ..value_objects.tee_category import TeeCategory
+from ..value_objects.tee_color import TeeColor
+from .hole import Hole
+
+# Rangos absolutos, unión de los de todos los tipos de campo. El rango estricto
+# que corresponde a cada tipo lo valida GolfCourse, que es quien conoce su
+# course_type. Aquí solo se descarta lo que no puede ser válido en ningún caso.
+MIN_SLOPE_RATING = 40
+MAX_SLOPE_RATING = 160
+MIN_COURSE_RATING = 45.0
+MAX_COURSE_RATING = 90.0
+MAX_IDENTIFIER_LENGTH = 50
+HOLES_PER_ROUND = 18
 
 
 @dataclass
 class Tee:
     """
-    Tee (salida) de un campo de golf.
+    Tee (salida) de un campo de golf, con su tarjeta completa.
+
+    Cada salida lleva sus propios hoyos porque el par, el índice de dificultad
+    y la distancia dependen de la barra desde la que se juega.
 
     Attributes:
         category: Categoría normalizada (CHAMPIONSHIP, AMATEUR, SENIOR, FORWARD, JUNIOR)
         gender: Género del tee (MALE/FEMALE/None). Nullable para todas las categorías.
-        identifier: Identificador libre del tee (ej: "Amarillo", "Blanco", "Rojo")
-        slope_rating: Slope Rating WHS (55-155, típico 113)
+        color: Color de las barras. Independiente de la categoría.
+        slope_rating: Slope Rating WHS (típico 113)
         course_rating: Course Rating WHS (decimal, ej: 71.5)
+        holes: Los 18 hoyos tal y como se juegan desde esta salida
+        identifier: Nombre libre opcional, para matices como "azules cortas"
 
     WHS Formula:
         Playing Handicap = (HI * SR / 113) + (CR - Par)
@@ -28,29 +45,88 @@ class Tee:
         >>> tee = Tee(
         ...     category=TeeCategory.AMATEUR,
         ...     gender=Gender.MALE,
-        ...     identifier="Amarillo",
+        ...     color=TeeColor.YELLOW,
         ...     slope_rating=126,
-        ...     course_rating=71.5
+        ...     course_rating=71.5,
+        ...     holes=[...],
         ... )
     """
 
     category: TeeCategory
     gender: Gender | None  # MALE, FEMALE, or None (gender-neutral)
-    identifier: str  # Color o nombre del tee (libre)
-    slope_rating: int  # 55-155 (WHS)
-    course_rating: float  # Course Rating (WHS)
+    slope_rating: int
+    course_rating: float
+    color: TeeColor = TeeColor.OTHER
+    holes: list[Hole] = field(default_factory=list)
+    identifier: str | None = None
 
     def __post_init__(self) -> None:
-        """Valida los ratings WHS."""
-        if not (55 <= self.slope_rating <= 155):  # noqa: PLR2004
-            raise ValueError(f"Slope rating must be between 55 and 155, got {self.slope_rating}")
+        """Valida los ratings WHS y la tarjeta de hoyos."""
+        if self.color is TeeColor.OTHER and not self.identifier:
+            raise ValueError("A tee with color OTHER must have an identifier")
 
-        if not (50.0 <= self.course_rating <= 90.0):  # noqa: PLR2004
+        if not (MIN_SLOPE_RATING <= self.slope_rating <= MAX_SLOPE_RATING):
             raise ValueError(
-                f"Course rating must be between 50.0 and 90.0, got {self.course_rating}"
+                f"Slope rating must be between {MIN_SLOPE_RATING} and "
+                f"{MAX_SLOPE_RATING}, got {self.slope_rating}"
             )
 
-        if not (1 <= len(self.identifier) <= 50):  # noqa: PLR2004
+        if not (MIN_COURSE_RATING <= self.course_rating <= MAX_COURSE_RATING):
             raise ValueError(
-                f"Tee identifier must be between 1 and 50 characters, got {len(self.identifier)}"
+                f"Course rating must be between {MIN_COURSE_RATING} and "
+                f"{MAX_COURSE_RATING}, got {self.course_rating}"
             )
+
+        if self.identifier is not None and not (1 <= len(self.identifier) <= MAX_IDENTIFIER_LENGTH):
+            raise ValueError(
+                f"Tee identifier must be between 1 and {MAX_IDENTIFIER_LENGTH} "
+                f"characters, got {len(self.identifier)}"
+            )
+
+        if self.holes:
+            self._validate_holes()
+
+    def _validate_holes(self) -> None:
+        """La tarjeta debe tener los 18 hoyos, sin repetir número ni índice."""
+        if len(self.holes) != HOLES_PER_ROUND:
+            raise ValueError(f"A tee must have {HOLES_PER_ROUND} holes, got {len(self.holes)}")
+
+        numbers = sorted(hole.number for hole in self.holes)
+        if numbers != list(range(1, HOLES_PER_ROUND + 1)):
+            raise ValueError("Hole numbers must be 1..18 without duplicates")
+
+        stroke_indices = sorted(hole.stroke_index for hole in self.holes)
+        if stroke_indices != list(range(1, HOLES_PER_ROUND + 1)):
+            raise ValueError("Stroke indices must be 1..18 without duplicates")
+
+    @property
+    def par_total(self) -> int:
+        """Par total de la vuelta desde esta salida."""
+        return sum(hole.par for hole in self.holes)
+
+    @property
+    def meters_total(self) -> int | None:
+        """Distancia total desde esta salida, o None si falta algún hoyo."""
+        if not self.holes or any(hole.meters is None for hole in self.holes):
+            return None
+        return sum(hole.meters for hole in self.holes if hole.meters is not None)
+
+    @property
+    def display_name(self) -> str:
+        """Nombre para mostrar: el identificador libre si lo hay, si no el color."""
+        return self.identifier or str(self.color)
+
+    @property
+    def unique_key(self) -> tuple[str, str | None]:
+        """
+        Clave que identifica la salida dentro de un campo.
+
+        Normalmente basta el color, que es lo que distingue físicamente una
+        salida de otra. Cuando el color es OTHER —el cajón de sastre para
+        salidas cuyo nombre no es un color— se usa el identificador, porque
+        OTHER puede repetirse legítimamente en un mismo campo.
+        """
+        gender_value = self.gender.value if self.gender else None
+        if self.color is TeeColor.OTHER:
+            return (f"identifier:{self.identifier}", gender_value)
+        return (f"color:{self.color.value}", gender_value)

--- a/src/modules/golf_course/domain/value_objects/tee_color.py
+++ b/src/modules/golf_course/domain/value_objects/tee_color.py
@@ -1,0 +1,36 @@
+"""
+TeeColor Value Object - Color de las barras de salida.
+
+Es independiente de TeeCategory: el color identifica físicamente la salida en
+el campo, mientras que la categoría la clasifica por dificultad. Un mismo color
+puede corresponder a categorías distintas según el campo, y hay campos con
+varias salidas del mismo color en recorridos diferentes.
+"""
+
+from enum import StrEnum
+
+
+class TeeColor(StrEnum):
+    """
+    Colores de barras de salida.
+
+    La lista sale de los colores realmente usados por los campos federados
+    españoles (802 recorridos de la RFEG). El orden es el de frecuencia de uso.
+
+    OTHER cubre las salidas cuyo nombre no es un color, para no forzar datos
+    reales dentro de una lista cerrada.
+    """
+
+    RED = "RED"
+    YELLOW = "YELLOW"
+    BLUE = "BLUE"
+    WHITE = "WHITE"
+    GREEN = "GREEN"
+    ORANGE = "ORANGE"
+    BLACK = "BLACK"
+    PINK = "PINK"
+    GOLD = "GOLD"
+    OTHER = "OTHER"
+
+    def __str__(self) -> str:
+        return self.value

--- a/src/modules/golf_course/infrastructure/__init__.py
+++ b/src/modules/golf_course/infrastructure/__init__.py
@@ -1,7 +1,7 @@
 """Golf Course Infrastructure Layer."""
 
 from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapper import (
-    golf_course_holes_table,
+    golf_course_tee_holes_table,
     golf_course_tees_table,
     golf_courses_table,
     mapper_registry,
@@ -12,7 +12,7 @@ from src.modules.golf_course.infrastructure.persistence.repositories.golf_course
 
 __all__ = [
     "GolfCourseRepository",
-    "golf_course_holes_table",
+    "golf_course_tee_holes_table",
     "golf_course_tees_table",
     "golf_courses_table",
     "mapper_registry",

--- a/src/modules/golf_course/infrastructure/persistence/__init__.py
+++ b/src/modules/golf_course/infrastructure/persistence/__init__.py
@@ -1,7 +1,7 @@
 """Golf Course Persistence Layer."""
 
 from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapper import (
-    golf_course_holes_table,
+    golf_course_tee_holes_table,
     golf_course_tees_table,
     golf_courses_table,
     mapper_registry,
@@ -12,7 +12,7 @@ from src.modules.golf_course.infrastructure.persistence.repositories.golf_course
 
 __all__ = [
     "GolfCourseRepository",
-    "golf_course_holes_table",
+    "golf_course_tee_holes_table",
     "golf_course_tees_table",
     "golf_courses_table",
     "mapper_registry",

--- a/src/modules/golf_course/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/__init__.py
@@ -1,14 +1,14 @@
 """SQLAlchemy Mappers for Golf Course module."""
 
 from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapper import (
-    golf_course_holes_table,
+    golf_course_tee_holes_table,
     golf_course_tees_table,
     golf_courses_table,
     mapper_registry,
 )
 
 __all__ = [
-    "golf_course_holes_table",
+    "golf_course_tee_holes_table",
     "golf_course_tees_table",
     "golf_courses_table",
     "mapper_registry",

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -4,7 +4,7 @@ SQLAlchemy Mapper for GolfCourse aggregate.
 Tablas:
 - golf_courses (agregado raíz)
 - golf_course_tees (value object collection)
-- golf_course_holes (value object collection)
+- golf_course_tee_holes (tarjeta de cada salida)
 """
 
 import uuid
@@ -37,6 +37,7 @@ from src.modules.golf_course.domain.value_objects.approval_status import Approva
 from src.modules.golf_course.domain.value_objects.course_type import CourseType
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.value_objects.country_code import CountryCode
 from src.shared.domain.value_objects.gender import Gender
@@ -200,53 +201,77 @@ golf_course_tees_table = Table(
         comment="Género del tee (MALE, FEMALE, o NULL para gender-neutral)",
     ),
     Column(
+        "color",
+        SQLEnum(TeeColor, name="tee_color_enum", create_type=False),
+        nullable=False,
+        server_default=TeeColor.OTHER.value,
+        comment="Color de las barras. Independiente de la categoría",
+    ),
+    Column(
         "identifier",
         String(50),
-        nullable=False,
-        comment="Identificador libre del campo (Amarillo, Oro, 1, etc.)",
+        nullable=True,
+        comment="Nombre libre opcional, para matices como 'azules cortas'",
     ),
     Column(
         "course_rating",
         Float,
         nullable=False,
-        comment="Course Rating WHS (50.0-90.0)",
+        comment="Course Rating WHS. El rango estricto por tipo de campo lo valida el dominio",
     ),
     Column(
         "slope_rating",
         Integer,
         nullable=False,
-        comment="Slope Rating WHS (55-155)",
+        comment="Slope Rating WHS. El rango estricto por tipo de campo lo valida el dominio",
+    ),
+    # Los rangos aquí son los absolutos, unión de los de todos los tipos de
+    # campo. El rango que corresponde a cada tipo no se puede expresar en un
+    # CHECK porque exigiría consultar golf_courses, así que lo valida el
+    # agregado, que es donde vive esa regla.
+    CheckConstraint(
+        "course_rating >= 45.0 AND course_rating <= 90.0", name="ck_tees_course_rating_range"
     ),
     CheckConstraint(
-        "course_rating >= 50.0 AND course_rating <= 90.0", name="ck_tees_course_rating_range"
+        "slope_rating >= 40 AND slope_rating <= 160", name="ck_tees_slope_rating_range"
     ),
     CheckConstraint(
-        "slope_rating >= 55 AND slope_rating <= 155", name="ck_tees_slope_rating_range"
+        "color <> 'OTHER' OR identifier IS NOT NULL", name="ck_tees_other_color_needs_identifier"
     ),
-    # Unique index on (golf_course_id, tee_category, COALESCE(tee_gender, 'NONE'))
-    # created in Alembic migration c3d5e7f9a1b2 as functional index
+    # Unique index funcional sobre (golf_course_id, color o identifier, género)
+    # creado en la migración de tarjetas por barra
     comment="Tees (salidas) de campos de golf con ratings WHS",
 )
 
-golf_course_holes_table = Table(
-    "golf_course_holes",
+# Los hoyos cuelgan de la salida, no del campo: el par, el índice de dificultad
+# y la distancia dependen de la barra desde la que se juega. La tarjeta del
+# campo (GolfCourse.holes) es derivada, se reconstruye desde la primera salida
+# al cargar el agregado.
+golf_course_tee_holes_table = Table(
+    "golf_course_tee_holes",
     metadata,
     Column("id", Integer, primary_key=True, autoincrement=True),
     Column(
-        "golf_course_id",
-        GolfCourseIdType,
-        ForeignKey("golf_courses.id", ondelete="CASCADE"),
+        "tee_id",
+        Integer,
+        ForeignKey("golf_course_tees.id", ondelete="CASCADE"),
         nullable=False,
     ),
     Column("hole_number", Integer, nullable=False, comment="Número de hoyo (1-18)"),
-    Column("par", Integer, nullable=False, comment="Par del hoyo (3-5)"),
+    Column("par", Integer, nullable=False, comment="Par del hoyo (3-6)"),
     Column("stroke_index", Integer, nullable=False, comment="Índice de dificultad (1-18)"),
-    CheckConstraint("hole_number >= 1 AND hole_number <= 18", name="ck_holes_number_range"),
-    CheckConstraint("par >= 3 AND par <= 5", name="ck_holes_par_range"),
-    CheckConstraint("stroke_index >= 1 AND stroke_index <= 18", name="ck_holes_stroke_index_range"),
-    UniqueConstraint("golf_course_id", "hole_number", name="uq_golf_course_holes_number"),
-    UniqueConstraint("golf_course_id", "stroke_index", name="uq_golf_course_holes_stroke_index"),
-    comment="Hoyos de campos de golf (18 por campo)",
+    Column("meters", Integer, nullable=True, comment="Distancia desde esta salida, en metros"),
+    CheckConstraint("hole_number >= 1 AND hole_number <= 18", name="ck_tee_holes_number_range"),
+    CheckConstraint("par >= 3 AND par <= 6", name="ck_tee_holes_par_range"),
+    CheckConstraint(
+        "stroke_index >= 1 AND stroke_index <= 18", name="ck_tee_holes_stroke_index_range"
+    ),
+    CheckConstraint(
+        "meters IS NULL OR (meters >= 20 AND meters <= 700)", name="ck_tee_holes_meters_range"
+    ),
+    UniqueConstraint("tee_id", "hole_number", name="uq_tee_holes_number"),
+    UniqueConstraint("tee_id", "stroke_index", name="uq_tee_holes_stroke_index"),
+    comment="Hoyos de cada salida (18 por salida) con par, dificultad y distancia",
 )
 
 # ============================================================================
@@ -265,6 +290,17 @@ def start_golf_course_mappers():
     - Tee value object → golf_course_tees table
     - Hole value object → golf_course_holes table
     """
+    # Mapear Hole (value object collection) — cuelga de la salida
+    if Hole not in mapper_registry.mappers:
+        mapper_registry.map_imperatively(
+            Hole,
+            golf_course_tee_holes_table,
+            properties={
+                # Map database column hole_number to entity attribute number
+                "number": golf_course_tee_holes_table.c.hole_number,
+            },
+        )
+
     # Mapear Tee (value object collection)
     if Tee not in mapper_registry.mappers:
         mapper_registry.map_imperatively(
@@ -275,35 +311,14 @@ def start_golf_course_mappers():
                 "category": golf_course_tees_table.c.tee_category,
                 # Map database column tee_gender to entity attribute gender
                 "gender": golf_course_tees_table.c.tee_gender,
+                "holes": relationship(
+                    Hole,
+                    cascade="all, delete-orphan",
+                    lazy="joined",  # Eager loading
+                    order_by=golf_course_tee_holes_table.c.hole_number,
+                ),
             },
         )
-
-        # Event listener: SQLAlchemy hidrata los objetos sin pasar por
-        # __init__, así que el default_factory de `holes` no llega a
-        # ejecutarse y el atributo no existe en los Tee cargados de BD.
-        @event.listens_for(Tee, "load")
-        def _init_tee_holes(target, _context):
-            if not hasattr(target, "holes"):
-                target.holes = []
-
-    # Mapear Hole (value object collection)
-    if Hole not in mapper_registry.mappers:
-        mapper_registry.map_imperatively(
-            Hole,
-            golf_course_holes_table,
-            properties={
-                # Map database column hole_number to entity attribute number
-                "number": golf_course_holes_table.c.hole_number,
-            },
-        )
-
-        # Mismo motivo que en Tee: al hidratar sin pasar por __init__, los
-        # hoyos cargados de BD se quedan sin el atributo `meters` mientras la
-        # columna no exista, y dataclasses.replace() lo necesita para copiarlos.
-        @event.listens_for(Hole, "load")
-        def _init_hole_meters(target, _context):
-            if not hasattr(target, "meters"):
-                target.meters = None
 
     # Mapear GolfCourse (aggregate root)
     if GolfCourse not in mapper_registry.mappers:
@@ -333,12 +348,8 @@ def start_golf_course_mappers():
                     lazy="joined",  # Eager loading
                     # No order_by needed - tees don't have a meaningful order
                 ),
-                "_holes": relationship(
-                    Hole,
-                    cascade="all, delete-orphan",
-                    lazy="joined",  # Eager loading
-                    order_by=golf_course_holes_table.c.hole_number,  # DB column name
-                ),
+                # _holes NO se persiste: la tarjeta del campo es derivada de la
+                # primera salida y se reconstruye en el listener de carga.
             },
         )
 
@@ -348,3 +359,11 @@ def start_golf_course_mappers():
         def _init_golf_course_domain_events(target, _context):
             if not hasattr(target, "_domain_events"):
                 target._domain_events = []
+
+            # La tarjeta del campo no se persiste: la propiedad `holes` la
+            # deriva de la primera salida al consultarla. Aquí solo se asegura
+            # que el atributo exista, porque SQLAlchemy hidrata sin pasar por
+            # __init__. No se deriva en este punto a propósito: durante el
+            # evento de carga las relaciones eager aún no están garantizadas.
+            if not hasattr(target, "_holes"):
+                target._holes = []

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -278,6 +278,14 @@ def start_golf_course_mappers():
             },
         )
 
+        # Event listener: SQLAlchemy hidrata los objetos sin pasar por
+        # __init__, así que el default_factory de `holes` no llega a
+        # ejecutarse y el atributo no existe en los Tee cargados de BD.
+        @event.listens_for(Tee, "load")
+        def _init_tee_holes(target, _context):
+            if not hasattr(target, "holes"):
+                target.holes = []
+
     # Mapear Hole (value object collection)
     if Hole not in mapper_registry.mappers:
         mapper_registry.map_imperatively(
@@ -288,6 +296,14 @@ def start_golf_course_mappers():
                 "number": golf_course_holes_table.c.hole_number,
             },
         )
+
+        # Mismo motivo que en Tee: al hidratar sin pasar por __init__, los
+        # hoyos cargados de BD se quedan sin el atributo `meters` mientras la
+        # columna no exista, y dataclasses.replace() lo necesita para copiarlos.
+        @event.listens_for(Hole, "load")
+        def _init_hole_meters(target, _context):
+            if not hasattr(target, "meters"):
+                target.meters = None
 
     # Mapear GolfCourse (aggregate root)
     if GolfCourse not in mapper_registry.mappers:

--- a/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
@@ -11,7 +11,6 @@ from src.modules.golf_course.domain.repositories.golf_course_repository import I
 from src.modules.golf_course.domain.value_objects.approval_status import ApprovalStatus
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapper import (
-    golf_course_holes_table,
     golf_course_tees_table,
     golf_courses_table,
 )
@@ -49,20 +48,11 @@ class GolfCourseRepository(IGolfCourseRepository):
             # IMPORTANTE: Solo borrar colecciones si realmente cambiaron.
             # Raw SQL DELETE desincroniza la session identity map, causando que
             # los hijos se pierdan en updates de solo atributos escalares (ej: approve).
+            # Los hoyos cuelgan de las salidas, así que basta con borrar estas:
+            # sus hoyos caen por ON DELETE CASCADE. La tarjeta del campo no se
+            # persiste, es derivada, y por eso no se inspecciona aquí.
             insp = inspect(golf_course)
-            if insp is None:
-                holes_changed = False
-                tees_changed = False
-            else:
-                holes_changed = insp.attrs._holes.history.has_changes()
-                tees_changed = insp.attrs._tees.history.has_changes()
-
-            if holes_changed:
-                await self._session.execute(
-                    delete(golf_course_holes_table).where(
-                        golf_course_holes_table.c.golf_course_id == golf_course._id
-                    )
-                )
+            tees_changed = insp is not None and insp.attrs._tees.history.has_changes()
 
             if tees_changed:
                 await self._session.execute(
@@ -70,8 +60,6 @@ class GolfCourseRepository(IGolfCourseRepository):
                         golf_course_tees_table.c.golf_course_id == golf_course._id
                     )
                 )
-
-            if holes_changed or tees_changed:
                 await self._session.flush()
 
         # Ahora sí, agregar/actualizar el aggregate
@@ -93,7 +81,6 @@ class GolfCourseRepository(IGolfCourseRepository):
             .where(golf_courses_table.c.id == golf_course_id)
             .options(
                 joinedload(GolfCourse._tees),
-                joinedload(GolfCourse._holes),
             )
         )
         result = await self._session.execute(stmt)
@@ -115,7 +102,6 @@ class GolfCourseRepository(IGolfCourseRepository):
             .where(golf_courses_table.c.approval_status == approval_status)
             .options(
                 joinedload(GolfCourse._tees),
-                joinedload(GolfCourse._holes),
             )
             .order_by(golf_courses_table.c.created_at.desc())
         )
@@ -138,7 +124,6 @@ class GolfCourseRepository(IGolfCourseRepository):
             .where(golf_courses_table.c.approval_status == ApprovalStatus.APPROVED)
             .options(
                 joinedload(GolfCourse._tees),
-                joinedload(GolfCourse._holes),
             )
             .order_by(golf_courses_table.c.created_at.desc())
         )
@@ -176,7 +161,6 @@ class GolfCourseRepository(IGolfCourseRepository):
             .where(golf_courses_table.c.creator_id == creator_id)
             .options(
                 joinedload(GolfCourse._tees),
-                joinedload(GolfCourse._holes),
             )
             .order_by(golf_courses_table.c.created_at.desc())
         )

--- a/tests/integration/api/v1/test_golf_course_tee_scorecards.py
+++ b/tests/integration/api/v1/test_golf_course_tee_scorecards.py
@@ -1,0 +1,250 @@
+"""
+Tests E2E de las tarjetas por salida.
+
+Verifican el camino completo por la API de lo que se añadió para poder importar
+los campos federados de la RFEG: color de barras, distancias por hoyo y
+tarjetas que difieren entre salidas del mismo campo.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_authenticated_user
+
+PAR_72 = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+
+
+def build_holes(meters: int, pars: list[int] | None = None, shift_index: bool = False):
+    """Construye la tarjeta de una salida."""
+    pars = pars or PAR_72
+    holes = []
+    for i in range(18):
+        stroke_index = i + 1
+        if shift_index and i < 2:
+            # Intercambia la dificultad de los dos primeros hoyos
+            stroke_index = 2 - i
+        holes.append(
+            {
+                "hole_number": i + 1,
+                "par": pars[i],
+                "stroke_index": stroke_index,
+                "meters": meters,
+            }
+        )
+    return holes
+
+
+class TestTeeScorecards:
+    """POST /api/v1/golf-courses/request con tarjeta por salida"""
+
+    @pytest.mark.asyncio
+    async def test_create_course_with_per_tee_scorecards(self, client: AsyncClient):
+        """
+        GIVEN: Un campo cuyas salidas tienen distancias y dificultades distintas
+        WHEN: Se solicita por la API y se consulta después
+        THEN: Cada salida conserva su color, sus metros y sus índices
+        """
+        # Given
+        user = await create_authenticated_user(
+            client, "scorecards@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+        payload = {
+            "name": "Campo con tarjetas por barra",
+            "country_code": "ES",
+            "course_type": "STANDARD_18",
+            "tees": [
+                {
+                    "tee_category": "CHAMPIONSHIP",
+                    "tee_gender": "MALE",
+                    "color": "WHITE",
+                    "course_rating": 73.5,
+                    "slope_rating": 135,
+                    "holes": build_holes(meters=400),
+                },
+                {
+                    "tee_category": "FORWARD",
+                    "tee_gender": "FEMALE",
+                    "color": "RED",
+                    "course_rating": 70.0,
+                    "slope_rating": 120,
+                    "holes": build_holes(meters=300, shift_index=True),
+                },
+            ],
+            "holes": [
+                {"hole_number": i + 1, "par": PAR_72[i], "stroke_index": i + 1} for i in range(18)
+            ],
+        }
+
+        # When
+        response = await client.post(
+            "/api/v1/golf-courses/request", json=payload, cookies=user["cookies"]
+        )
+
+        # Then
+        assert response.status_code == 201, response.text
+        course_id = response.json()["id"]
+
+        detail = await client.get(
+            f"/api/v1/golf-courses/{course_id}", cookies=user["cookies"]
+        )
+        assert detail.status_code == 200, detail.text
+        tees = detail.json()["tees"]
+
+        by_color = {tee["color"]: tee for tee in tees}
+        assert set(by_color) == {"WHITE", "RED"}
+
+        # Cada salida mantiene su distancia
+        assert all(hole["meters"] == 400 for hole in by_color["WHITE"]["holes"])
+        assert all(hole["meters"] == 300 for hole in by_color["RED"]["holes"])
+
+        # Y su propia dificultad por hoyo
+        assert [h["stroke_index"] for h in by_color["WHITE"]["holes"][:2]] == [1, 2]
+        assert [h["stroke_index"] for h in by_color["RED"]["holes"][:2]] == [2, 1]
+
+    @pytest.mark.asyncio
+    async def test_tees_without_scorecard_inherit_the_course_one(self, client: AsyncClient):
+        """
+        GIVEN: Un campo creado con una única tarjeta, como se hacía hasta ahora
+        WHEN: Se solicita por la API
+        THEN: Cada salida hereda esa tarjeta
+
+        Es el caso de compatibilidad: los clientes que no envían tarjeta por
+        salida siguen funcionando igual.
+        """
+        # Given
+        user = await create_authenticated_user(
+            client, "inherit@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+        payload = {
+            "name": "Campo con tarjeta unica",
+            "country_code": "ES",
+            "course_type": "STANDARD_18",
+            "tees": [
+                {
+                    "tee_category": "CHAMPIONSHIP",
+                    "tee_gender": "MALE",
+                    "color": "WHITE",
+                    "course_rating": 73.5,
+                    "slope_rating": 135,
+                },
+                {
+                    "tee_category": "AMATEUR",
+                    "tee_gender": "MALE",
+                    "color": "YELLOW",
+                    "course_rating": 71.0,
+                    "slope_rating": 128,
+                },
+            ],
+            "holes": [
+                {"hole_number": i + 1, "par": PAR_72[i], "stroke_index": i + 1} for i in range(18)
+            ],
+        }
+
+        # When
+        response = await client.post(
+            "/api/v1/golf-courses/request", json=payload, cookies=user["cookies"]
+        )
+
+        # Then
+        assert response.status_code == 201, response.text
+        course_id = response.json()["id"]
+
+        detail = await client.get(
+            f"/api/v1/golf-courses/{course_id}", cookies=user["cookies"]
+        )
+        tees = detail.json()["tees"]
+        assert len(tees) == 2
+        assert all(len(tee["holes"]) == 18 for tee in tees)
+
+    @pytest.mark.asyncio
+    async def test_pitch_and_putt_is_accepted(self, client: AsyncClient):
+        """
+        GIVEN: Un pitch & putt con par 54 y ratings por debajo de la escala WHS
+        WHEN: Se solicita por la API
+        THEN: Se acepta
+
+        Antes quedaba fuera: el DTO exigía slope 55-155 y par de campo largo.
+        """
+        # Given
+        user = await create_authenticated_user(
+            client, "pitchputt@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+        payload = {
+            "name": "Pitch and Putt Municipal",
+            "country_code": "ES",
+            "course_type": "PITCH_AND_PUTT",
+            "tees": [
+                {
+                    "tee_category": "AMATEUR",
+                    "tee_gender": "MALE",
+                    "color": "GREEN",
+                    "course_rating": 46.8,
+                    "slope_rating": 47,
+                },
+                {
+                    "tee_category": "FORWARD",
+                    "tee_gender": "FEMALE",
+                    "color": "RED",
+                    "course_rating": 47.8,
+                    "slope_rating": 53,
+                },
+            ],
+            "holes": [
+                {"hole_number": i + 1, "par": 3, "stroke_index": i + 1, "meters": 100}
+                for i in range(18)
+            ],
+        }
+
+        # When
+        response = await client.post(
+            "/api/v1/golf-courses/request", json=payload, cookies=user["cookies"]
+        )
+
+        # Then
+        assert response.status_code == 201, response.text
+        assert response.json()["total_par"] == 54
+
+    @pytest.mark.asyncio
+    async def test_other_color_without_identifier_is_rejected(self, client: AsyncClient):
+        """
+        GIVEN: Una salida de color OTHER sin identificador
+        WHEN: Se solicita por la API
+        THEN: Se rechaza con 400
+
+        Sin identificador, dos salidas OTHER serían indistinguibles.
+        """
+        # Given
+        user = await create_authenticated_user(
+            client, "nocolor@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+        payload = {
+            "name": "Campo sin color ni nombre",
+            "country_code": "ES",
+            "course_type": "STANDARD_18",
+            "tees": [
+                {
+                    "tee_category": "CHAMPIONSHIP",
+                    "tee_gender": "MALE",
+                    "course_rating": 73.5,
+                    "slope_rating": 135,
+                },
+                {
+                    "tee_category": "AMATEUR",
+                    "tee_gender": "MALE",
+                    "color": "YELLOW",
+                    "course_rating": 71.0,
+                    "slope_rating": 128,
+                },
+            ],
+            "holes": [
+                {"hole_number": i + 1, "par": PAR_72[i], "stroke_index": i + 1} for i in range(18)
+            ],
+        }
+
+        # When
+        response = await client.post(
+            "/api/v1/golf-courses/request", json=payload, cookies=user["cookies"]
+        )
+
+        # Then
+        assert response.status_code == 400, response.text

--- a/tests/integration/api/v1/test_golf_course_tee_scorecards.py
+++ b/tests/integration/api/v1/test_golf_course_tee_scorecards.py
@@ -207,11 +207,13 @@ class TestTeeScorecards:
     @pytest.mark.asyncio
     async def test_other_color_without_identifier_is_rejected(self, client: AsyncClient):
         """
-        GIVEN: Una salida de color OTHER sin identificador
+        GIVEN: Una salida sin color ni identificador
         WHEN: Se solicita por la API
-        THEN: Se rechaza con 400
+        THEN: Se rechaza como error de validación (422)
 
-        Sin identificador, dos salidas OTHER serían indistinguibles.
+        Sin identificador, dos salidas OTHER serían indistinguibles. La regla la
+        hace cumplir el dominio; el DTO la comprueba antes para señalar el campo
+        concreto en vez de devolver un rechazo genérico.
         """
         # Given
         user = await create_authenticated_user(
@@ -247,4 +249,5 @@ class TestTeeScorecards:
         )
 
         # Then
-        assert response.status_code == 400, response.text
+        assert response.status_code == 422, response.text
+        assert "identifier" in response.text

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
@@ -583,9 +583,14 @@ async def test_delete_golf_course(db_session, creator_id, valid_tees, valid_hole
     )
     assert result_tees.scalar() == 0, "Tees should be cascade deleted"
 
-    # Assert - Cascade delete: Holes eliminados
+    # Assert - Cascade delete: los hoyos cuelgan de las salidas, así que el
+    # borrado tiene que propagarse dos niveles
     result_holes = await db_session.execute(
-        text("SELECT count(*) FROM golf_course_holes WHERE golf_course_id = :gc_id"),
+        text(
+            "SELECT count(*) FROM golf_course_tee_holes th "
+            "JOIN golf_course_tees t ON t.id = th.tee_id "
+            "WHERE t.golf_course_id = :gc_id"
+        ),
         {"gc_id": str(golf_course.id.value)},
     )
     assert result_holes.scalar() == 0, "Holes should be cascade deleted"

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
@@ -569,6 +569,18 @@ async def test_delete_golf_course(db_session, creator_id, valid_tees, valid_hole
     # Verificar que existe
     assert await repository.find_by_id(golf_course.id) is not None
 
+    # Los ids de las salidas hay que capturarlos antes del borrado: después no
+    # hay forma de llegar a sus hoyos para comprobar que también cayeron.
+    tee_ids = list(
+        (
+            await db_session.execute(
+                text("SELECT id FROM golf_course_tees WHERE golf_course_id = :gc_id"),
+                {"gc_id": str(golf_course.id.value)},
+            )
+        ).scalars()
+    )
+    assert tee_ids, "Precondición: el campo debe tener salidas persistidas"
+
     # Act
     await repository.delete(golf_course.id)
     await db_session.commit()
@@ -584,14 +596,12 @@ async def test_delete_golf_course(db_session, creator_id, valid_tees, valid_hole
     assert result_tees.scalar() == 0, "Tees should be cascade deleted"
 
     # Assert - Cascade delete: los hoyos cuelgan de las salidas, así que el
-    # borrado tiene que propagarse dos niveles
+    # borrado tiene que propagarse dos niveles. Se buscan por los ids
+    # capturados antes: un JOIN con las salidas ya borradas daría cero aunque
+    # quedaran hoyos huérfanos.
     result_holes = await db_session.execute(
-        text(
-            "SELECT count(*) FROM golf_course_tee_holes th "
-            "JOIN golf_course_tees t ON t.id = th.tee_id "
-            "WHERE t.golf_course_id = :gc_id"
-        ),
-        {"gc_id": str(golf_course.id.value)},
+        text("SELECT count(*) FROM golf_course_tee_holes WHERE tee_id = ANY(:tee_ids)"),
+        {"tee_ids": tee_ids},
     )
     assert result_holes.scalar() == 0, "Holes should be cascade deleted"
 

--- a/tests/unit/modules/golf_course/domain/entities/test_golf_course.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_golf_course.py
@@ -211,7 +211,7 @@ def test_create_golf_course_duplicate_stroke_indices(valid_tees):
     ]
 
     # When/Then
-    with pytest.raises(ValueError, match="Stroke indices must be unique"):
+    with pytest.raises(ValueError, match="Stroke indices must be exactly"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
@@ -236,7 +236,7 @@ def test_create_golf_course_invalid_stroke_indices_range(valid_tees):
     ]
 
     # When/Then - La validación de duplicados ocurre antes que la de rango
-    with pytest.raises(ValueError, match="Stroke indices must be unique"):
+    with pytest.raises(ValueError, match="Stroke indices must be exactly"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
@@ -260,7 +260,7 @@ def test_create_golf_course_invalid_par_total_too_low(valid_tees):
     ]
 
     # When/Then
-    with pytest.raises(ValueError, match="Total par must be between 66 and 76"):
+    with pytest.raises(ValueError, match="Total par for a"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
@@ -284,7 +284,7 @@ def test_create_golf_course_invalid_par_total_too_high(valid_tees):
     ]
 
     # When/Then
-    with pytest.raises(ValueError, match="Total par must be between 66 and 76"):
+    with pytest.raises(ValueError, match="Total par for a"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
@@ -297,72 +297,58 @@ def test_create_golf_course_invalid_par_total_too_high(valid_tees):
 
 def test_create_golf_course_invalid_tees_count_too_few(valid_holes):
     """
-    GIVEN: Menos de 2 tees
+    GIVEN: Un campo sin ninguna salida
     WHEN: Se intenta crear un GolfCourse
     THEN: Se lanza ValueError
+
+    Una sola salida sí es válida: hay recorridos federados que solo publican
+    una. Lo que no tiene sentido es un campo sin ninguna.
     """
     # Given
-    only_one_tee = [
-        Tee(
-            category=TeeCategory.CHAMPIONSHIP,
-            gender=Gender.MALE,
-            identifier="Blanco",
-            course_rating=73.5,
-            slope_rating=135,
-        )
-    ]
+    no_tees: list[Tee] = []
 
     # When/Then
-    with pytest.raises(ValueError, match="Golf course must have between 2 and 10 tees"):
+    with pytest.raises(ValueError, match="Golf course must have between 1 and 14 tees"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
             course_type=CourseType.STANDARD_18,
             creator_id=UserId.generate(),
-            tees=only_one_tee,
+            tees=no_tees,
             holes=valid_holes,
         )
 
 
 def test_create_golf_course_invalid_tees_count_too_many(valid_holes):
     """
-    GIVEN: Más de 10 tees
+    GIVEN: Más de 14 salidas
     WHEN: Se intenta crear un GolfCourse
     THEN: Se lanza ValueError
+
+    El máximo es 14 porque es lo que llega a publicar un campo federado. Las
+    salidas llevan identificador propio, así que las 15 son distintas entre sí:
+    lo que falla es el número, no la unicidad.
     """
-    # Given - 5 categories x 2 genders = 10 unique combos + 1 extra = 11 tees
-    category_gender_combos = [
-        (TeeCategory.CHAMPIONSHIP, Gender.MALE),
-        (TeeCategory.CHAMPIONSHIP, Gender.FEMALE),
-        (TeeCategory.AMATEUR, Gender.MALE),
-        (TeeCategory.AMATEUR, Gender.FEMALE),
-        (TeeCategory.SENIOR, Gender.MALE),
-        (TeeCategory.SENIOR, Gender.FEMALE),
-        (TeeCategory.FORWARD, Gender.MALE),
-        (TeeCategory.FORWARD, Gender.FEMALE),
-        (TeeCategory.JUNIOR, Gender.MALE),
-        (TeeCategory.JUNIOR, Gender.FEMALE),
-        (TeeCategory.CHAMPIONSHIP, Gender.MALE),  # Repeated to make 11
-    ]
-    eleven_tees = [
+    # Given - 15 salidas únicas
+    fifteen_tees = [
         Tee(
-            category=cat,
-            gender=gender,
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE if i % 2 == 0 else Gender.FEMALE,
             identifier=f"Tee {i}",
             course_rating=70.0,
             slope_rating=120,
         )
-        for i, (cat, gender) in enumerate(category_gender_combos)
+        for i in range(15)
     ]
 
     # When/Then
-    with pytest.raises(ValueError, match="Golf course must have between 2 and 10 tees"):
+    with pytest.raises(ValueError, match="Golf course must have between 1 and 14 tees"):
         GolfCourse.create(
             name="Test Course",
             country_code=CountryCode("ES"),
             course_type=CourseType.STANDARD_18,
             creator_id=UserId.generate(),
-            tees=eleven_tees,
+            tees=fifteen_tees,
             holes=valid_holes,
         )
 

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -1,0 +1,487 @@
+"""
+Tests de la tarjeta por salida: color, metros y rangos por tipo de campo.
+
+Cubre lo que se añadió para poder importar los campos federados de la RFEG:
+cada salida lleva su propia tarjeta, porque el par, el índice de dificultad y
+la distancia dependen de la barra desde la que se juega.
+"""
+
+import pytest
+
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_category import TeeCategory
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+PAR_72 = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+
+
+def build_holes(pars: list[int] | None = None, meters: int | None = 350) -> list[Hole]:
+    """Construye una tarjeta de 18 hoyos con índices 1-18."""
+    pars = pars or PAR_72
+    return [
+        Hole(number=i + 1, par=pars[i], stroke_index=i + 1, meters=meters)
+        for i in range(18)
+    ]
+
+
+def build_course(
+    tees: list[Tee],
+    course_type: CourseType = CourseType.STANDARD_18,
+    holes: list[Hole] | None = None,
+) -> GolfCourse:
+    """Crea un campo con las salidas dadas."""
+    return GolfCourse.create(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=course_type,
+        creator_id=UserId.generate(),
+        tees=tees,
+        holes=holes if holes is not None else build_holes(),
+    )
+
+
+# ============================================================================
+# Tests: metros en el hoyo
+# ============================================================================
+
+
+def test_hole_accepts_meters():
+    """
+    GIVEN: Un hoyo con distancia en metros
+    WHEN: Se construye
+    THEN: Conserva la distancia
+    """
+    hole = Hole(number=1, par=4, stroke_index=7, meters=351)
+
+    assert hole.meters == 351
+
+
+def test_hole_meters_is_optional():
+    """
+    GIVEN: Un hoyo sin distancia
+    WHEN: Se construye
+    THEN: La distancia queda a None y el hoyo es válido
+    """
+    hole = Hole(number=1, par=4, stroke_index=7)
+
+    assert hole.meters is None
+
+
+def test_hole_rejects_out_of_range_meters():
+    """
+    GIVEN: Un hoyo con una distancia imposible
+    WHEN: Se construye
+    THEN: Se lanza ValueError
+    """
+    with pytest.raises(ValueError, match="Meters must be between"):
+        Hole(number=1, par=4, stroke_index=7, meters=1200)
+
+
+def test_hole_accepts_par_6():
+    """
+    GIVEN: Un hoyo de par 6
+    WHEN: Se construye
+    THEN: Es válido
+
+    El hoyo 9 de La Marquesa (644 metros) es par 6 y está federado.
+    """
+    hole = Hole(number=9, par=6, stroke_index=1, meters=644)
+
+    assert hole.par == 6
+
+
+def test_hole_rejects_par_7():
+    """
+    GIVEN: Un hoyo de par 7
+    WHEN: Se construye
+    THEN: Se lanza ValueError
+    """
+    with pytest.raises(ValueError, match="Par must be one of"):
+        Hole(number=1, par=7, stroke_index=1)
+
+
+# ============================================================================
+# Tests: tarjeta por salida
+# ============================================================================
+
+
+def test_tee_computes_par_and_meters_totals():
+    """
+    GIVEN: Una salida con su tarjeta completa
+    WHEN: Se consultan los totales
+    THEN: Se calculan sumando los hoyos
+    """
+    tee = Tee(
+        category=TeeCategory.AMATEUR,
+        gender=Gender.MALE,
+        color=TeeColor.YELLOW,
+        course_rating=71.5,
+        slope_rating=126,
+        holes=build_holes(meters=350),
+    )
+
+    assert tee.par_total == sum(PAR_72)
+    assert tee.meters_total == 350 * 18
+
+
+def test_tee_meters_total_is_none_when_a_hole_lacks_distance():
+    """
+    GIVEN: Una salida a la que le falta la distancia de un hoyo
+    WHEN: Se consulta la distancia total
+    THEN: Devuelve None en vez de un total incompleto
+    """
+    holes = build_holes()
+    holes[5].meters = None
+
+    tee = Tee(
+        category=TeeCategory.AMATEUR,
+        gender=Gender.MALE,
+        color=TeeColor.YELLOW,
+        course_rating=71.5,
+        slope_rating=126,
+        holes=holes,
+    )
+
+    assert tee.meters_total is None
+
+
+def test_tees_can_have_different_pars_and_stroke_indices():
+    """
+    GIVEN: Dos salidas del mismo campo con par e índices distintos
+    WHEN: Se crea el campo
+    THEN: Cada salida conserva su propia tarjeta
+
+    Ocurre en 77 de los 802 recorridos federados españoles.
+    """
+    # Given - las blancas tienen un par 5 donde las rojas tienen un par 4
+    pars_white = list(PAR_72)
+    pars_red = list(PAR_72)
+    pars_red[1] = 4
+
+    white = Tee(
+        category=TeeCategory.CHAMPIONSHIP,
+        gender=Gender.MALE,
+        color=TeeColor.WHITE,
+        course_rating=73.5,
+        slope_rating=135,
+        holes=build_holes(pars_white, meters=400),
+    )
+    red = Tee(
+        category=TeeCategory.FORWARD,
+        gender=Gender.FEMALE,
+        color=TeeColor.RED,
+        course_rating=70.0,
+        slope_rating=120,
+        holes=build_holes(pars_red, meters=300),
+    )
+
+    # When
+    course = build_course([white, red])
+
+    # Then
+    assert course.tees[0].par_total == course.tees[1].par_total + 1
+    assert course.tees[0].meters_total == 400 * 18
+    assert course.tees[1].meters_total == 300 * 18
+
+
+def test_course_holes_are_propagated_to_tees_without_scorecard():
+    """
+    GIVEN: Un campo con tarjeta única y salidas sin tarjeta propia
+    WHEN: Se crea el campo
+    THEN: Cada salida recibe una copia de la tarjeta del campo
+
+    Es lo que mantiene funcionando a quien crea campos como hasta ahora.
+    """
+    # Given
+    tees = [
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=73.5,
+            slope_rating=135,
+        ),
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.YELLOW,
+            course_rating=71.0,
+            slope_rating=128,
+        ),
+    ]
+
+    # When
+    course = build_course(tees)
+
+    # Then
+    assert all(len(tee.holes) == 18 for tee in course.tees)
+    assert course.tees[0].par_total == sum(PAR_72)
+
+
+def test_course_holes_are_derived_from_first_tee_when_absent():
+    """
+    GIVEN: Un campo descrito solo con tarjetas por salida
+    WHEN: Se crea sin tarjeta de campo
+    THEN: La tarjeta de referencia sale de la primera salida
+
+    Así los consumidores que leen golf_course.holes siguen funcionando.
+    """
+    # Given
+    tees = [
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=73.5,
+            slope_rating=135,
+            holes=build_holes(meters=400),
+        ),
+        Tee(
+            category=TeeCategory.FORWARD,
+            gender=Gender.FEMALE,
+            color=TeeColor.RED,
+            course_rating=70.0,
+            slope_rating=120,
+            holes=build_holes(meters=300),
+        ),
+    ]
+
+    # When
+    course = build_course(tees, holes=[])
+
+    # Then
+    assert len(course.holes) == 18
+    assert course.total_par == sum(PAR_72)
+
+
+# ============================================================================
+# Tests: unicidad por color
+# ============================================================================
+
+
+def test_two_tees_can_share_category_with_different_colors():
+    """
+    GIVEN: Dos salidas del mismo campo con la misma categoría y género
+    WHEN: Tienen colores distintos
+    THEN: El campo es válido
+
+    Un campo puede tener blancas y negras, ambas de campeonato masculino.
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.BLACK,
+            course_rating=74.5,
+            slope_rating=140,
+        ),
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=73.5,
+            slope_rating=135,
+        ),
+    ]
+
+    course = build_course(tees)
+
+    assert len(course.tees) == 2
+
+
+def test_duplicate_color_and_gender_is_rejected():
+    """
+    GIVEN: Dos salidas con el mismo color y género
+    WHEN: Se crea el campo
+    THEN: Se lanza ValueError
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=74.5,
+            slope_rating=140,
+        ),
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=73.5,
+            slope_rating=135,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate tee"):
+        build_course(tees)
+
+
+def test_tee_with_other_color_requires_identifier():
+    """
+    GIVEN: Una salida de color OTHER sin identificador
+    WHEN: Se construye
+    THEN: Se lanza ValueError
+
+    Sin identificador, dos salidas OTHER serían indistinguibles.
+    """
+    with pytest.raises(ValueError, match="must have an identifier"):
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.OTHER,
+            course_rating=71.0,
+            slope_rating=128,
+        )
+
+
+# ============================================================================
+# Tests: rangos por tipo de campo
+# ============================================================================
+
+
+def test_pitch_and_putt_accepts_low_ratings():
+    """
+    GIVEN: Un pitch & putt con slope y rating por debajo de la escala WHS
+    WHEN: Se crea el campo
+    THEN: Es válido
+
+    Arruzafa Golf tiene slope 47 y rating 46,8 desde verdes masculinas.
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.GREEN,
+            course_rating=46.8,
+            slope_rating=47,
+        ),
+        Tee(
+            category=TeeCategory.FORWARD,
+            gender=Gender.FEMALE,
+            color=TeeColor.RED,
+            course_rating=47.8,
+            slope_rating=53,
+        ),
+    ]
+
+    course = build_course(
+        tees,
+        course_type=CourseType.PITCH_AND_PUTT,
+        holes=build_holes([3] * 18, meters=100),
+    )
+
+    assert course.total_par == 54
+
+
+def test_tee_rejects_impossible_slope():
+    """
+    GIVEN: Una salida con el slope 11 que la RFEG publica para Golf Xaz
+    WHEN: Se construye
+    THEN: Se lanza ValueError
+
+    Es la primera barrera: un slope así no es válido en ningún tipo de campo,
+    así que lo corta el propio Tee sin necesidad de conocer el tipo.
+    """
+    with pytest.raises(ValueError, match="Slope rating must be between 40 and 160"):
+        Tee(
+            category=TeeCategory.FORWARD,
+            gender=Gender.MALE,
+            color=TeeColor.RED,
+            course_rating=63.6,
+            slope_rating=11,
+        )
+
+
+def test_standard_course_rejects_pitch_and_putt_slope():
+    """
+    GIVEN: Un campo estándar con el slope de un pitch & putt
+    WHEN: Se crea
+    THEN: Se lanza ValueError
+
+    Segunda barrera: 45 es un slope legítimo para un campo corto, pero no para
+    uno estándar. Solo el agregado puede juzgarlo, porque es quien conoce el
+    tipo de campo.
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.FORWARD,
+            gender=Gender.MALE,
+            color=TeeColor.RED,
+            course_rating=63.6,
+            slope_rating=45,
+        ),
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.YELLOW,
+            course_rating=69.3,
+            slope_rating=121,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="Slope rating for a STANDARD_18"):
+        build_course(tees)
+
+
+def test_standard_course_accepts_slope_above_whs_maximum():
+    """
+    GIVEN: Un campo estándar con slope 157
+    WHEN: Se crea
+    THEN: Es válido
+
+    El Real Club de Campo Villa de Madrid publica 157 desde negras de mujeres.
+    Rechazarlo por un redondeo ajeno sería perder un campo real.
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.FEMALE,
+            color=TeeColor.BLACK,
+            course_rating=82.6,
+            slope_rating=157,
+        ),
+        Tee(
+            category=TeeCategory.CHAMPIONSHIP,
+            gender=Gender.MALE,
+            color=TeeColor.WHITE,
+            course_rating=74.7,
+            slope_rating=143,
+        ),
+    ]
+
+    course = build_course(tees)
+
+    assert course.tees[0].slope_rating == 157
+
+
+def test_pitch_and_putt_rejects_standard_par():
+    """
+    GIVEN: Un pitch & putt con par 72
+    WHEN: Se crea
+    THEN: Se lanza ValueError
+    """
+    tees = [
+        Tee(
+            category=TeeCategory.AMATEUR,
+            gender=Gender.MALE,
+            color=TeeColor.GREEN,
+            course_rating=50.0,
+            slope_rating=60,
+        ),
+        Tee(
+            category=TeeCategory.FORWARD,
+            gender=Gender.FEMALE,
+            color=TeeColor.RED,
+            course_rating=52.0,
+            slope_rating=62,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="Total par for a PITCH_AND_PUTT"):
+        build_course(tees, course_type=CourseType.PITCH_AND_PUTT)

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -159,10 +159,17 @@ def test_tees_can_have_different_pars_and_stroke_indices():
 
     Ocurre en 77 de los 802 recorridos federados españoles.
     """
-    # Given - las blancas tienen un par 5 donde las rojas tienen un par 4
+    # Given - las blancas tienen un par 5 donde las rojas tienen un par 4, y
+    # además los dos primeros hoyos cambian de dificultad entre unas y otras
     pars_white = list(PAR_72)
     pars_red = list(PAR_72)
     pars_red[1] = 4
+
+    red_holes = build_holes(pars_red, meters=300)
+    red_holes[0].stroke_index, red_holes[1].stroke_index = (
+        red_holes[1].stroke_index,
+        red_holes[0].stroke_index,
+    )
 
     white = Tee(
         category=TeeCategory.CHAMPIONSHIP,
@@ -178,16 +185,18 @@ def test_tees_can_have_different_pars_and_stroke_indices():
         color=TeeColor.RED,
         course_rating=70.0,
         slope_rating=120,
-        holes=build_holes(pars_red, meters=300),
+        holes=red_holes,
     )
 
     # When
     course = build_course([white, red])
 
-    # Then
+    # Then - cada salida conserva su par, sus metros y sus índices
     assert course.tees[0].par_total == course.tees[1].par_total + 1
     assert course.tees[0].meters_total == 400 * 18
     assert course.tees[1].meters_total == 300 * 18
+    assert [h.stroke_index for h in course.tees[0].holes[:2]] == [1, 2]
+    assert [h.stroke_index for h in course.tees[1].holes[:2]] == [2, 1]
 
 
 def test_course_holes_are_propagated_to_tees_without_scorecard():
@@ -258,6 +267,80 @@ def test_course_holes_are_derived_from_first_tee_when_absent():
     # Then
     assert len(course.holes) == 18
     assert course.total_par == sum(PAR_72)
+
+
+def test_course_rejects_duplicate_hole_numbers():
+    """
+    GIVEN: Una tarjeta con números de hoyo repetidos pero índices correctos
+    WHEN: Se crea el campo
+    THEN: Se lanza ValueError
+
+    La tarjeta de referencia se copia a las salidas asignando la lista, lo que
+    no pasa por el validador de Tee. Sin esta comprobación, una tarjeta con
+    hoyos repetidos se propagaría a todas las salidas del campo.
+    """
+    # Given - todos los hoyos son el número 1, pero los índices son 1-18
+    holes = [Hole(number=1, par=4, stroke_index=i + 1, meters=350) for i in range(18)]
+
+    # When/Then
+    with pytest.raises(ValueError, match="Hole numbers must be exactly"):
+        build_course(
+            [
+                Tee(
+                    category=TeeCategory.AMATEUR,
+                    gender=Gender.MALE,
+                    color=TeeColor.YELLOW,
+                    course_rating=71.0,
+                    slope_rating=128,
+                ),
+            ],
+            holes=holes,
+        )
+
+
+def test_update_preserves_tee_colors_and_distances():
+    """
+    GIVEN: Un campo con colores y distancias por salida
+    WHEN: Se actualiza
+    THEN: Conserva colores, distancias y tarjetas propias
+
+    Al reconstruir las salidas en update() es fácil perder los campos nuevos, y
+    una salida de color conocido degradada a OTHER sin identificador ni siquiera
+    llegaría a construirse.
+    """
+    # Given
+    white = Tee(
+        category=TeeCategory.CHAMPIONSHIP,
+        gender=Gender.MALE,
+        color=TeeColor.WHITE,
+        course_rating=73.5,
+        slope_rating=135,
+        holes=build_holes(meters=400),
+    )
+    red = Tee(
+        category=TeeCategory.FORWARD,
+        gender=Gender.FEMALE,
+        color=TeeColor.RED,
+        course_rating=70.0,
+        slope_rating=120,
+        holes=build_holes(meters=300),
+    )
+    course = build_course([white, red])
+
+    # When
+    course.update(
+        name="Updated Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=[white, red],
+        holes=build_holes(meters=400),
+    )
+
+    # Then
+    assert course.name == "Updated Course"
+    assert [tee.color for tee in course.tees] == [TeeColor.WHITE, TeeColor.RED]
+    assert course.tees[0].meters_total == 400 * 18
+    assert course.tees[1].meters_total == 300 * 18
 
 
 # ============================================================================


### PR DESCRIPTION
## Context

Groundwork for importing the golf courses published by the Spanish federation
(RFEG): **802 courses across 442 clubs**, with per-hole distances and GPS
coordinates. The data was extracted and analysed first; this PR widens the
domain model so it can actually hold it.

**This PR covers the domain layer only.** Persistence (SQLAlchemy mapper and the
Alembic migration) and the API DTOs come next, in this same branch. Opening it
early to get review feedback on the modelling decisions.

## What changes

- **New `TeeColor` value object** with the 9 colors actually used by Spanish
  federated courses (red, yellow, blue, white, green, orange, black, pink, gold)
  plus `OTHER`. Independent of `TeeCategory`, which is deliberately left
  untouched: it is referenced by 24 backend files outside this module and it is
  what identifies the tee a player chooses.
- **`Hole` gains an optional `meters` distance** and accepts **par 3-6**. Hole 9
  at La Marquesa is a 644 m par 6.
- **`Tee` now carries its own 18-hole scorecard.** Par, stroke index and distance
  depend on the tee played from. This differs across tees in **77 of the 802**
  federated courses, and in 54 of those it differs between colors of the same
  gender, so splitting by gender alone would not have been enough.
- **`GolfCourse` validates against ranges that depend on the course type.**
  Standard courses keep WHS rigour; pitch & putt and executive courses use wider
  margins because WHS does not rate them on the same scale.

## Modelling decisions worth reviewing

**Backwards compatibility.** `golf_course.holes` is consumed in five places
outside this module (player stats, quick matches, match generation). Rather than
touch all of them, the constructor reconciles both representations: a
course-wide scorecard is copied to tees that lack one, and when only per-tee
scorecards are supplied the reference one is taken from the first tee.

**Tee uniqueness** moves from `(category, gender)` to color, falling back to the
free identifier when the color is `OTHER`. Two reasons: a course can legitimately
have white and black tees both classified as championship, and existing courses
default to `OTHER`, which would otherwise collide en masse. A tee with color
`OTHER` now requires an identifier, since it would be indistinguishable
otherwise.

**Two validation layers.** `Tee` rejects what is impossible for any course type
(slope outside 40-160); `GolfCourse` applies the stricter range for its own type.
This is what catches the impossible slope 11 that RFEG publishes for the men's
red tees at Golf Xaz, while still accepting slope 45 on a pitch & putt.

**Slope ceiling raised to 160 for standard courses**, above the WHS maximum of
155. Real Club de Campo Villa de Madrid publishes 157 from the women's black
tees; rejecting it over someone else's rounding would mean losing a real course.
The floor stays strict, because that is what surfaces source errors.

## Verification

- **2,635 unit tests pass**, 18 of them new.
- `ruff check`: clean. `mypy`: no issues across 49 source files.
- The 6 tests that failed were asserting the old invariants and were updated.

New tests use real cases from the dataset: the par 6 at La Marquesa, slope 157 at
Villa de Madrid, slope 47 at Arruzafa, and the impossible slope 11 at Golf Xaz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zNP5wsvS7RymLJsRsurbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tee colors, optional identifiers, and tee-specific scorecards.
  * Added hole distances and expanded par options, including par 6.
  * Scorecards can synchronize between course and tee layouts.
  * Added tee totals for par and distance, plus clearer tee names.

* **Bug Fixes**
  * Improved validation for holes, tees, ratings, slope, par, and course-type-specific rules.
  * Expanded supported course configurations, including pitch-and-putt courses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->