### PR TITLE
feat(golf-course): Add location data to golf courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Los campos de golf guardan dónde están** (issue #105): coordenadas, dirección postal, localidad y provincia, todo opcional, en el agregado, la API y la migración `c4d8e1a72b93`. Es la base para proponer campos cercanos a la ubicación del dispositivo al crear una partida rápida; la búsqueda por cercanía en sí queda fuera de esta entrega. **Latitud y longitud van juntas o no van**: media coordenada no sitúa nada en un mapa y una búsqueda por proximidad que la aceptara devolvería resultados arbitrarios. La regla la hacen cumplir el Value Object, el DTO y un CHECK en la base de datos, porque la importación masiva de campos federados escribe miles de filas de golpe y un dato a medias pasaría inadvertido. La ubicación se persiste en columnas sueltas y no como Value Object compuesto: es opcional, y `composite()` de SQLAlchemy no admite NULL. **Editar un campo sin enviar ubicación la conserva**; para borrarla hay que mandar el objeto con todos sus valores a `null`. Sin eso, el formulario de edición actual —que es anterior a esta funcionalidad y no manda el dato— habría borrado las coordenadas de un campo al cambiarle el nombre. Un campo sin ubicación la devuelve como `null` y no como un objeto con cinco nulos dentro, para que el cliente distinga de un vistazo si se sabe dónde está.
+
 ## [2.7.0] - 2026-08-11
 
 ### Added

--- a/alembic/versions/c4d8e1a72b93_add_location_to_golf_courses.py
+++ b/alembic/versions/c4d8e1a72b93_add_location_to_golf_courses.py
@@ -1,0 +1,94 @@
+"""add location to golf courses
+
+Los campos de golf pasan a guardar dónde están: coordenadas, dirección postal,
+localidad y provincia. Es la base para proponer campos cercanos a la ubicación
+del dispositivo en las partidas rápidas.
+
+Todo es opcional. Los campos que ya existen se quedan sin ubicación, y las
+federaciones tampoco la publican siempre (11 de los 442 clubes federados
+españoles no traen coordenadas).
+
+Las coordenadas van juntas o no van: media coordenada no sitúa nada en un mapa
+y una búsqueda por cercanía que la aceptara devolvería resultados arbitrarios.
+Lo garantiza un CHECK, no solo el dominio, porque la importación masiva escribe
+muchas filas de golpe y un dato a medias pasaría inadvertido.
+
+Revision ID: c4d8e1a72b93
+Revises: 91fb1f95660b
+Create Date: 2026-08-12
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d8e1a72b93"
+down_revision: str | None = "91fb1f95660b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "golf_courses",
+        sa.Column("latitude", sa.Float(), nullable=True, comment="Latitud en grados decimales"),
+    )
+    op.add_column(
+        "golf_courses",
+        sa.Column("longitude", sa.Float(), nullable=True, comment="Longitud en grados decimales"),
+    )
+    op.add_column(
+        "golf_courses",
+        sa.Column("address", sa.String(300), nullable=True, comment="Dirección postal completa"),
+    )
+    op.add_column(
+        "golf_courses",
+        sa.Column("city", sa.String(100), nullable=True, comment="Localidad"),
+    )
+    op.add_column(
+        "golf_courses",
+        sa.Column("province", sa.String(100), nullable=True, comment="Provincia o región"),
+    )
+
+    op.create_check_constraint(
+        "ck_golf_courses_latitude_range",
+        "golf_courses",
+        "latitude IS NULL OR (latitude >= -90 AND latitude <= 90)",
+    )
+    op.create_check_constraint(
+        "ck_golf_courses_longitude_range",
+        "golf_courses",
+        "longitude IS NULL OR (longitude >= -180 AND longitude <= 180)",
+    )
+    op.create_check_constraint(
+        "ck_golf_courses_coordinates_together",
+        "golf_courses",
+        "(latitude IS NULL) = (longitude IS NULL)",
+    )
+
+    # Índice para la búsqueda por cercanía. Es un filtro por caja (un rango de
+    # latitud y otro de longitud) antes de calcular distancias reales, que es
+    # como se resuelve "campos cerca de mí" sin PostGIS. Parcial, porque las
+    # filas sin coordenadas nunca entran en esa consulta.
+    op.create_index(
+        "ix_golf_courses_coordinates",
+        "golf_courses",
+        ["latitude", "longitude"],
+        postgresql_where=sa.text("latitude IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_golf_courses_coordinates", table_name="golf_courses")
+    op.drop_constraint("ck_golf_courses_coordinates_together", "golf_courses", type_="check")
+    op.drop_constraint("ck_golf_courses_longitude_range", "golf_courses", type_="check")
+    op.drop_constraint("ck_golf_courses_latitude_range", "golf_courses", type_="check")
+    op.drop_column("golf_courses", "province")
+    op.drop_column("golf_courses", "city")
+    op.drop_column("golf_courses", "address")
+    op.drop_column("golf_courses", "longitude")
+    op.drop_column("golf_courses", "latitude")

--- a/src/modules/golf_course/application/dtos/golf_course_dtos.py
+++ b/src/modules/golf_course/application/dtos/golf_course_dtos.py
@@ -28,6 +28,32 @@ class HoleDTO(BaseModel):
         from_attributes = True
 
 
+class LocationDTO(BaseModel):
+    """
+    DTO para la ubicación de un campo.
+
+    Todo es opcional, pero latitud y longitud van juntas: la regla la hace
+    cumplir el dominio, y se comprueba también aquí para que el error salga
+    como fallo de validación del campo concreto.
+    """
+
+    latitude: float | None = Field(None, ge=-90.0, le=90.0, description="Latitud en grados")
+    longitude: float | None = Field(None, ge=-180.0, le=180.0, description="Longitud en grados")
+    address: str | None = Field(None, max_length=300, description="Dirección postal completa")
+    city: str | None = Field(None, max_length=100, description="Localidad")
+    province: str | None = Field(None, max_length=100, description="Provincia o región")
+
+    @model_validator(mode="after")
+    def check_coordinates_together(self) -> "LocationDTO":
+        """Media coordenada no sitúa nada en un mapa."""
+        if (self.latitude is None) != (self.longitude is None):
+            raise ValueError("latitude and longitude must be provided together")
+        return self
+
+    class Config:
+        from_attributes = True
+
+
 class TeeDTO(BaseModel):
     """DTO para representar un tee (salida)."""
 
@@ -94,6 +120,9 @@ class RequestGolfCourseRequestDTO(BaseModel):
     holes: list[HoleDTO] = Field(
         ..., min_length=18, max_length=18, description="Exactamente 18 hoyos"
     )
+    location: LocationDTO | None = Field(
+        None, description="Ubicación del campo. Opcional: sin ella el campo no sale por cercanía"
+    )
 
     # NOTA: Las validaciones de reglas de negocio (stroke_index únicos, hole_numbers, etc.)
     # están en el dominio (GolfCourse._validate_holes), no aquí.
@@ -157,6 +186,7 @@ class GolfCourseResponseDTO(BaseModel):
     is_pending_update: bool = Field(
         False, description="TRUE si este campo tiene un clone pendiente de aprobación"
     )
+    location: LocationDTO | None = Field(None, description="Ubicación del campo, si se conoce")
 
     class Config:
         from_attributes = True
@@ -228,6 +258,13 @@ class UpdateGolfCourseRequestDTO(BaseModel):
     tees: list[TeeDTO] = Field(..., min_length=1, max_length=14, description="1-14 salidas")
     holes: list[HoleDTO] = Field(
         ..., min_length=18, max_length=18, description="Exactamente 18 hoyos"
+    )
+    location: LocationDTO | None = Field(
+        None,
+        description=(
+            "Nueva ubicación. Omitirla conserva la actual; para borrarla, "
+            "enviar el objeto con todos sus valores a null"
+        ),
     )
 
 

--- a/src/modules/golf_course/application/dtos/golf_course_dtos.py
+++ b/src/modules/golf_course/application/dtos/golf_course_dtos.py
@@ -259,11 +259,17 @@ class UpdateGolfCourseRequestDTO(BaseModel):
     holes: list[HoleDTO] = Field(
         ..., min_length=18, max_length=18, description="Exactamente 18 hoyos"
     )
+    # La ubicación se reemplaza entera, igual que `tees` y `holes` en esta misma
+    # petición: lo que no venga dentro del objeto queda a null. No es un parcheo
+    # campo a campo, así que un cliente que mande solo la localidad borra las
+    # coordenadas. Omitir el objeto es lo único que conserva lo guardado.
     location: LocationDTO | None = Field(
         None,
         description=(
-            "Nueva ubicación. Omitirla conserva la actual; para borrarla, "
-            "enviar el objeto con todos sus valores a null"
+            "Nueva ubicación, que REEMPLAZA la actual por completo: los campos "
+            "que no se envíen quedan vacíos. Omitir este objeto conserva la "
+            "ubicación guardada; enviarlo vacío o con todos sus valores a null "
+            "la borra"
         ),
     )
 

--- a/src/modules/golf_course/application/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/application/mappers/golf_course_mapper.py
@@ -5,11 +5,13 @@ Golf Course Mapper - Mapea entidades de dominio a DTOs.
 from src.modules.golf_course.application.dtos.golf_course_dtos import (
     GolfCourseResponseDTO,
     HoleDTO,
+    LocationDTO,
     TeeDTO,
 )
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
 from src.modules.golf_course.domain.entities.hole import Hole
 from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_location import CourseLocation
 from src.shared.domain.value_objects.gender import Gender
 
 
@@ -54,6 +56,25 @@ class GolfCourseMapper:
             )
             for tee_dto in tee_dtos
         ]
+
+    @staticmethod
+    def to_domain_location(location_dto: LocationDTO | None) -> CourseLocation | None:
+        """
+        Convierte la ubicación recibida por la API en Value Object.
+
+        Devuelve None cuando el cliente no manda ubicación, que en una edición
+        significa "no la toques". Un objeto con todos sus valores a null sí
+        llega como CourseLocation vacío, que es la forma de borrarla.
+        """
+        if location_dto is None:
+            return None
+        return CourseLocation(
+            latitude=location_dto.latitude,
+            longitude=location_dto.longitude,
+            address=location_dto.address,
+            city=location_dto.city,
+            province=location_dto.province,
+        )
 
     @staticmethod
     def to_response_dto(
@@ -124,4 +145,18 @@ class GolfCourseMapper:
                 else None
             ),
             is_pending_update=golf_course.is_pending_update,
+            # Un campo sin ubicación devuelve null, y no un objeto con cinco
+            # nulos dentro, para que el cliente distinga de un vistazo si sabe
+            # dónde está el campo.
+            location=(
+                LocationDTO(
+                    latitude=golf_course.location.latitude,
+                    longitude=golf_course.location.longitude,
+                    address=golf_course.location.address,
+                    city=golf_course.location.city,
+                    province=golf_course.location.province,
+                )
+                if not golf_course.location.is_empty
+                else None
+            ),
         )

--- a/src/modules/golf_course/application/use_cases/create_direct_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/create_direct_golf_course_use_case.py
@@ -86,6 +86,7 @@ class CreateDirectGolfCourseUseCase:
                 creator_id=creator_id,
                 tees=tees,
                 holes=holes,
+                location=GolfCourseMapper.to_domain_location(request.location),
             )
 
             # 6. Aprobar inmediatamente (Admin privilege)

--- a/src/modules/golf_course/application/use_cases/request_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/request_golf_course_use_case.py
@@ -82,6 +82,7 @@ class RequestGolfCourseUseCase:
                 creator_id=creator_id,
                 tees=tees,
                 holes=holes,
+                location=GolfCourseMapper.to_domain_location(request.location),
             )
 
             # 6. Persistir

--- a/src/modules/golf_course/application/use_cases/update_golf_course_use_case.py
+++ b/src/modules/golf_course/application/use_cases/update_golf_course_use_case.py
@@ -72,6 +72,7 @@ class UpdateGolfCourseUseCase:
                 tees=tees,
                 holes=holes,
                 is_admin=is_admin,
+                location=GolfCourseMapper.to_domain_location(request.location),
             )
 
             # 6. Guardar

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -18,6 +18,7 @@ from ..events.golf_course_approved_event import GolfCourseApprovedEvent
 from ..events.golf_course_rejected_event import GolfCourseRejectedEvent
 from ..events.golf_course_requested_event import GolfCourseRequestedEvent
 from ..value_objects.approval_status import ApprovalStatus
+from ..value_objects.course_location import CourseLocation
 from ..value_objects.course_type import CourseType
 from ..value_objects.golf_course_id import GolfCourseId
 from ..value_objects.tee_color import TeeColor
@@ -106,6 +107,7 @@ class GolfCourse:
         updated_at: datetime,
         original_golf_course_id: GolfCourseId | None = None,
         is_pending_update: bool = False,
+        location: CourseLocation | None = None,
         domain_events: list[DomainEvent] | None = None,
     ) -> None:
         """
@@ -125,6 +127,7 @@ class GolfCourse:
             updated_at: Fecha de última actualización
             original_golf_course_id: Si no es None, este es un clone/update proposal del original
             is_pending_update: TRUE si este campo tiene un clone pendiente de aprobación
+            location: Ubicación del campo (opcional)
             domain_events: Eventos de dominio (opcional)
         """
         self._id = id
@@ -142,12 +145,31 @@ class GolfCourse:
         self._is_pending_update = is_pending_update
         self._domain_events: list[DomainEvent] = domain_events or []
 
+        # La ubicación se guarda desglosada en escalares, no como Value Object
+        # compuesto: es opcional, y `composite()` no admite NULL (falla en el
+        # constructor del VO al hidratar). El VO se recompone al leer.
+        self._set_location(location)
+
         # Reconciliar la tarjeta del campo con la de cada salida antes de validar
         self._sync_holes_and_tees()
 
         # Validar invariantes
         self._validate_holes()
         self._validate_tees()
+
+    def _set_location(self, location: CourseLocation | None) -> None:
+        """
+        Vuelca la ubicación a los atributos que se persisten, uno por columna.
+
+        Args:
+            location: Ubicación a guardar. None deja el campo sin ubicación.
+        """
+        location = location or CourseLocation()
+        self._latitude = location.latitude
+        self._longitude = location.longitude
+        self._address = location.address
+        self._city = location.city
+        self._province = location.province
 
     def _sync_holes_and_tees(self) -> None:
         """
@@ -183,6 +205,7 @@ class GolfCourse:
         creator_id: UserId,
         tees: list[Tee],
         holes: list[Hole],
+        location: CourseLocation | None = None,
     ) -> "GolfCourse":
         """
         Factory method para crear un nuevo campo de golf.
@@ -196,6 +219,7 @@ class GolfCourse:
             creator_id: Usuario que solicita el campo
             tees: Lista de salidas (2-6)
             holes: Lista de hoyos (18)
+            location: Ubicación del campo (opcional)
 
         Returns:
             GolfCourse: Campo creado en estado PENDING_APPROVAL
@@ -222,6 +246,7 @@ class GolfCourse:
             rejection_reason=None,
             created_at=now,
             updated_at=now,
+            location=location,
         )
 
         # Registrar evento de creación
@@ -251,6 +276,7 @@ class GolfCourse:
         updated_at: datetime,
         original_golf_course_id: GolfCourseId | None = None,
         is_pending_update: bool = False,
+        location: CourseLocation | None = None,
     ) -> "GolfCourse":
         """
         Reconstruye un GolfCourse desde persistencia.
@@ -271,6 +297,7 @@ class GolfCourse:
             updated_at=updated_at,
             original_golf_course_id=original_golf_course_id,
             is_pending_update=is_pending_update,
+            location=location,
         )
 
     def approve(self) -> None:
@@ -343,6 +370,7 @@ class GolfCourse:
         course_type: CourseType,
         tees: list[Tee],
         holes: list[Hole],
+        location: CourseLocation | None = None,
     ) -> None:
         """
         Actualiza los campos del golf course.
@@ -357,6 +385,12 @@ class GolfCourse:
             course_type: Nuevo tipo de campo
             tees: Nueva lista de tees
             holes: Nueva lista de hoyos
+            location: Nueva ubicación. None **conserva** la actual; para
+                borrarla hay que pasar un CourseLocation() vacío. Se hace así
+                porque los clientes que no conocen la ubicación (el formulario
+                de edición, que es anterior) omiten el dato, y tratar esa
+                omisión como un borrado vaciaría las coordenadas de un campo
+                al editarle el nombre.
 
         Raises:
             ValueError: Si los datos no son válidos
@@ -369,6 +403,8 @@ class GolfCourse:
         self._name = name
         self._country_code = country_code
         self._course_type = course_type
+        if location is not None:
+            self._set_location(location)
 
         # Actualizar colecciones rastreadas por SQLAlchemy
         # IMPORTANTE: Creamos NUEVOS objetos en lugar de usar los pasados como parámetro
@@ -409,6 +445,7 @@ class GolfCourse:
         tees: list[Tee],
         holes: list[Hole],
         is_admin: bool,
+        location: CourseLocation | None = None,
     ) -> "GolfCourse | None":
         """
         Aplica una actualización al campo de golf según las reglas de negocio.
@@ -426,6 +463,7 @@ class GolfCourse:
             tees: Nueva lista de tees
             holes: Nueva lista de hoyos
             is_admin: Si el usuario es Admin
+            location: Nueva ubicación. None conserva la actual (ver update())
 
         Returns:
             None si se actualizó in-place, GolfCourse clone si se creó propuesta
@@ -446,10 +484,13 @@ class GolfCourse:
                 course_type=course_type,
                 tees=tees,
                 holes=holes,
+                location=location,
             )
             return None
 
-        # Creator + APPROVED → crear clone como update proposal
+        # Creator + APPROVED → crear clone como update proposal. El clone hereda
+        # la ubicación del original si la edición no trae una nueva, para que
+        # aprobarlo no borre las coordenadas del campo.
         clone = GolfCourse.create(
             name=name,
             country_code=country_code,
@@ -457,6 +498,7 @@ class GolfCourse:
             creator_id=self._creator_id,
             tees=tees,
             holes=holes,
+            location=location if location is not None else self.location,
         )
 
         # Reconstruir clone con campos especiales (link al original, status PENDING)
@@ -474,6 +516,7 @@ class GolfCourse:
             updated_at=clone.updated_at,
             original_golf_course_id=self._id,
             is_pending_update=False,
+            location=clone.location,
         )
 
         # Marcar original como "tiene cambios pendientes"
@@ -519,6 +562,7 @@ class GolfCourse:
         self._name = clone._name
         self._country_code = clone._country_code
         self._course_type = clone._course_type
+        self._set_location(clone.location)
 
         # Actualizar colecciones rastreadas por SQLAlchemy
         # IMPORTANTE: Creamos NUEVOS objetos en lugar de copiar referencias
@@ -757,9 +801,29 @@ class GolfCourse:
         """Retorna TRUE si este campo tiene un clone pendiente de aprobación."""
         return self._is_pending_update
 
+    @property
+    def location(self) -> CourseLocation:
+        """
+        Ubicación del campo, recompuesta desde las columnas que se persisten.
+
+        Devuelve siempre un Value Object, vacío si el campo no tiene ubicación,
+        para que quien lo consulte no tenga que comprobar None antes de leer.
+        Se usa getattr porque SQLAlchemy hidrata sin pasar por __init__ y los
+        campos previos a esta funcionalidad no tienen los atributos.
+        """
+        return CourseLocation(
+            latitude=getattr(self, "_latitude", None),
+            longitude=getattr(self, "_longitude", None),
+            address=getattr(self, "_address", None),
+            city=getattr(self, "_city", None),
+            province=getattr(self, "_province", None),
+        )
+
     # Metodos de consulta
 
-    def has_tee(self, color: TeeColor, gender: Gender | None, identifier: str | None = None) -> bool:
+    def has_tee(
+        self, color: TeeColor, gender: Gender | None, identifier: str | None = None
+    ) -> bool:
         """
         Retorna True si el campo tiene esa salida.
 

--- a/src/modules/golf_course/domain/value_objects/course_location.py
+++ b/src/modules/golf_course/domain/value_objects/course_location.py
@@ -81,5 +81,14 @@ class CourseLocation:
 
     @property
     def is_empty(self) -> bool:
-        """True si no aporta ningún dato de ubicación."""
-        return not any((self.latitude, self.longitude, self.address, self.city, self.province))
+        """
+        True si no aporta ningún dato de ubicación.
+
+        Se compara contra None y no por veracidad: la latitud y la longitud
+        cero son coordenadas válidas, y darlas por ausentes haría que la API
+        devolviera `location: null` para un campo perfectamente situado.
+        """
+        return all(
+            value is None
+            for value in (self.latitude, self.longitude, self.address, self.city, self.province)
+        )

--- a/src/modules/golf_course/domain/value_objects/course_location.py
+++ b/src/modules/golf_course/domain/value_objects/course_location.py
@@ -1,0 +1,85 @@
+"""
+CourseLocation Value Object - Dónde está físicamente un campo de golf.
+
+Existe para poder proponer campos cercanos a la ubicación del dispositivo. Todo
+es opcional: los campos dados de alta a mano pueden no tener coordenadas, y las
+federaciones no siempre las publican (11 de los 442 clubes españoles no las
+traen).
+"""
+
+from dataclasses import dataclass
+
+MIN_LATITUDE = -90.0
+MAX_LATITUDE = 90.0
+MIN_LONGITUDE = -180.0
+MAX_LONGITUDE = 180.0
+
+MAX_ADDRESS_LENGTH = 300
+MAX_CITY_LENGTH = 100
+MAX_PROVINCE_LENGTH = 100
+
+
+@dataclass(frozen=True)
+class CourseLocation:
+    """
+    Ubicación de un campo de golf.
+
+    Business Rules:
+    - Latitud y longitud van juntas: media coordenada no sitúa nada en un mapa,
+      y una búsqueda por cercanía que aceptara solo una devolvería resultados
+      arbitrarios.
+    - Los rangos son los geográficos absolutos; no se acotan a España porque el
+      modelo admite campos de cualquier país.
+    - Las cadenas vacías se normalizan a None: un texto en blanco no es un dato,
+      y guardarlo obligaría a todos los consumidores a distinguir '' de None.
+    """
+
+    latitude: float | None = None
+    longitude: float | None = None
+    address: str | None = None
+    city: str | None = None
+    province: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name, max_length in (
+            ("address", MAX_ADDRESS_LENGTH),
+            ("city", MAX_CITY_LENGTH),
+            ("province", MAX_PROVINCE_LENGTH),
+        ):
+            value = getattr(self, field_name)
+            if value is None:
+                continue
+            cleaned = value.strip()
+            object.__setattr__(self, field_name, cleaned or None)
+            if cleaned and len(cleaned) > max_length:
+                raise ValueError(
+                    f"Course location {field_name} must be at most {max_length} characters, "
+                    f"got {len(cleaned)}"
+                )
+
+        if (self.latitude is None) != (self.longitude is None):
+            raise ValueError(
+                "Course location needs both latitude and longitude, or neither. "
+                f"Got latitude={self.latitude}, longitude={self.longitude}"
+            )
+
+        if self.latitude is not None and not (MIN_LATITUDE <= self.latitude <= MAX_LATITUDE):
+            raise ValueError(
+                f"Latitude must be between {MIN_LATITUDE} and {MAX_LATITUDE}, got {self.latitude}"
+            )
+
+        if self.longitude is not None and not (MIN_LONGITUDE <= self.longitude <= MAX_LONGITUDE):
+            raise ValueError(
+                f"Longitude must be between {MIN_LONGITUDE} and {MAX_LONGITUDE}, "
+                f"got {self.longitude}"
+            )
+
+    @property
+    def has_coordinates(self) -> bool:
+        """True si el campo se puede situar en un mapa."""
+        return self.latitude is not None and self.longitude is not None
+
+    @property
+    def is_empty(self) -> bool:
+        """True si no aporta ningún dato de ubicación."""
+        return not any((self.latitude, self.longitude, self.address, self.city, self.province))

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -169,7 +169,28 @@ golf_courses_table = Table(
         default=False,
         comment="TRUE if this golf course has a pending update clone",
     ),
+    # Ubicación: columnas sueltas y no un Value Object compuesto, porque es
+    # opcional y `composite()` no admite NULL. El VO se recompone en la entidad.
+    # El índice parcial para la búsqueda por cercanía se crea en la migración.
+    Column("latitude", Float, nullable=True, comment="Latitud en grados decimales"),
+    Column("longitude", Float, nullable=True, comment="Longitud en grados decimales"),
+    Column("address", String(300), nullable=True, comment="Dirección postal completa"),
+    Column("city", String(100), nullable=True, comment="Localidad"),
+    Column("province", String(100), nullable=True, comment="Provincia o región"),
     CheckConstraint("LENGTH(name) >= 3", name="ck_golf_courses_name_min_length"),
+    CheckConstraint(
+        "latitude IS NULL OR (latitude >= -90 AND latitude <= 90)",
+        name="ck_golf_courses_latitude_range",
+    ),
+    CheckConstraint(
+        "longitude IS NULL OR (longitude >= -180 AND longitude <= 180)",
+        name="ck_golf_courses_longitude_range",
+    ),
+    # Media coordenada no sitúa nada en un mapa: o van las dos o ninguna.
+    CheckConstraint(
+        "(latitude IS NULL) = (longitude IS NULL)",
+        name="ck_golf_courses_coordinates_together",
+    ),
     CheckConstraint(
         "(approval_status != 'REJECTED') OR (rejection_reason IS NOT NULL)",
         name="ck_golf_courses_rejection_reason_required",
@@ -332,6 +353,12 @@ def start_golf_course_mappers():
                 "_created_at": column_property(golf_courses_table.c.created_at),
                 "_updated_at": column_property(golf_courses_table.c.updated_at),
                 "_is_pending_update": column_property(golf_courses_table.c.is_pending_update),
+                # Ubicación desglosada (ver comentario en la tabla)
+                "_latitude": column_property(golf_courses_table.c.latitude),
+                "_longitude": column_property(golf_courses_table.c.longitude),
+                "_address": column_property(golf_courses_table.c.address),
+                "_city": column_property(golf_courses_table.c.city),
+                "_province": column_property(golf_courses_table.c.province),
                 # One-to-many relationships with tees and holes
                 "_tees": relationship(
                     Tee,

--- a/tests/integration/api/v1/test_golf_course_location_endpoints.py
+++ b/tests/integration/api/v1/test_golf_course_location_endpoints.py
@@ -1,0 +1,144 @@
+"""
+Tests E2E de la ubicación de los campos de golf.
+
+Verifican el criterio de la issue #105: que la ubicación se pueda enviar al dar
+de alta un campo y salga en la API al consultarlo, tanto en el detalle como en
+el listado, que es de donde tirará la búsqueda por cercanía.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import (
+    approve_golf_course,
+    create_admin_user,
+    create_authenticated_user,
+)
+
+DERIO_LOCATION = {
+    "latitude": 43.29519,
+    "longitude": -2.87352,
+    "address": "CALLE EREAGA BIDEA S/N, 48160, DERIO, VIZCAYA",
+    "city": "DERIO",
+    "province": "VIZCAYA",
+}
+
+
+def build_course_payload(location: dict | None = None) -> dict:
+    """Construye el cuerpo de un alta de campo, con o sin ubicación."""
+    payload = {
+        "name": "Campo con ubicación",
+        "country_code": "ES",
+        "course_type": "STANDARD_18",
+        "tees": [
+            {
+                "color": "YELLOW",
+                "tee_gender": "MALE",
+                "course_rating": 70.2,
+                "slope_rating": 128,
+            }
+        ],
+        "holes": [{"hole_number": i, "par": 4, "stroke_index": i} for i in range(1, 19)],
+    }
+    if location is not None:
+        payload["location"] = location
+    return payload
+
+
+class TestGolfCourseLocation:
+    """Ubicación en el alta y la consulta de campos."""
+
+    @pytest.mark.asyncio
+    async def test_request_course_with_location_returns_it(self, client: AsyncClient):
+        """Un campo dado de alta con ubicación la devuelve en la respuesta."""
+        user = await create_authenticated_user(
+            client, "location-creator@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+
+        response = await client.post(
+            "/api/v1/golf-courses/request",
+            json=build_course_payload(DERIO_LOCATION),
+            cookies=user["cookies"],
+        )
+
+        assert response.status_code == 201
+        location = response.json()["location"]
+        assert location["latitude"] == 43.29519
+        assert location["longitude"] == -2.87352
+        assert location["city"] == "DERIO"
+        assert location["province"] == "VIZCAYA"
+
+    @pytest.mark.asyncio
+    async def test_request_course_without_location_returns_null(self, client: AsyncClient):
+        """Un campo sin ubicación la devuelve como null, no como objeto vacío."""
+        user = await create_authenticated_user(
+            client, "no-location@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+
+        response = await client.post(
+            "/api/v1/golf-courses/request",
+            json=build_course_payload(),
+            cookies=user["cookies"],
+        )
+
+        assert response.status_code == 201
+        assert response.json()["location"] is None
+
+    @pytest.mark.asyncio
+    async def test_half_coordinates_are_rejected(self, client: AsyncClient):
+        """Enviar solo la latitud es un error de validación, no un campo a medias."""
+        user = await create_authenticated_user(
+            client, "half-coords@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+
+        response = await client.post(
+            "/api/v1/golf-courses/request",
+            json=build_course_payload({"latitude": 43.29519}),
+            cookies=user["cookies"],
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_impossible_latitude_is_rejected(self, client: AsyncClient):
+        """Una latitud fuera del rango geográfico es un error de validación."""
+        user = await create_authenticated_user(
+            client, "bad-coords@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+
+        response = await client.post(
+            "/api/v1/golf-courses/request",
+            json=build_course_payload({"latitude": 120.0, "longitude": 0.0}),
+            cookies=user["cookies"],
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_location_survives_in_detail_and_list(self, client: AsyncClient):
+        """La ubicación sale al consultar el campo y también al listarlo."""
+        creator = await create_authenticated_user(
+            client, "location-detail@test.com", "P@ssw0rd123!", "Creator", "Test"
+        )
+        created = await client.post(
+            "/api/v1/golf-courses/request",
+            json=build_course_payload(DERIO_LOCATION),
+            cookies=creator["cookies"],
+        )
+        course_id = created.json()["id"]
+        admin = await create_admin_user(
+            client, "location-admin@test.com", "P@ssw0rd123!", "Admin", "Test"
+        )
+        await approve_golf_course(client, admin["cookies"], course_id)
+
+        detail = await client.get(f"/api/v1/golf-courses/{course_id}", cookies=creator["cookies"])
+        listing = await client.get("/api/v1/golf-courses", cookies=creator["cookies"])
+
+        assert detail.status_code == 200
+        assert detail.json()["location"]["city"] == "DERIO"
+
+        assert listing.status_code == 200
+        listed = next(
+            course for course in listing.json()["golf_courses"] if course["id"] == course_id
+        )
+        assert listed["location"]["latitude"] == 43.29519

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_location_persistence.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_location_persistence.py
@@ -1,0 +1,231 @@
+"""
+Integration tests for golf course location persistence.
+
+Comprueban que la ubicación sobrevive al viaje completo hasta PostgreSQL y de
+vuelta, y que las restricciones que protegen las coordenadas están en la base de
+datos y no solo en el dominio: la importación masiva escribe muchas filas de
+golpe y un dato a medias pasaría inadvertido.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_location import CourseLocation
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.golf_course.infrastructure.persistence.repositories.golf_course_repository import (
+    GolfCourseRepository,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+pytestmark = [pytest.mark.integration]
+
+DERIO = CourseLocation(
+    latitude=43.29519,
+    longitude=-2.87352,
+    address="CALLE EREAGA BIDEA S/N, 48160, DERIO, VIZCAYA",
+    city="DERIO",
+    province="VIZCAYA",
+)
+
+
+async def _insert_test_user(db_session, user_id: UserId) -> None:
+    """Insert a minimal user row so golf_courses.creator_id FK is satisfied."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    await db_session.execute(
+        text(
+            "INSERT INTO users (id, first_name, last_name, email, password, "
+            "created_at, updated_at, email_verified, failed_login_attempts, is_admin) "
+            "VALUES (:id, :fn, :ln, :email, :pw, :ca, :ua, :ev, :fla, :ia)"
+        ),
+        {
+            "id": str(user_id.value),
+            "fn": "Test",
+            "ln": "User",
+            "email": f"test-{user_id.value}@example.com",
+            "pw": "$2b$04$placeholder",
+            "ca": now,
+            "ua": now,
+            "ev": False,
+            "fla": 0,
+            "ia": False,
+        },
+    )
+
+
+@pytest_asyncio.fixture
+async def creator_id(db_session) -> UserId:
+    """Provide a UserId backed by an actual user row in the test DB."""
+    uid = UserId.generate()
+    await _insert_test_user(db_session, uid)
+    return uid
+
+
+@pytest.fixture
+def valid_tees():
+    """Una salida amarilla masculina."""
+    return [
+        Tee(
+            color=TeeColor.YELLOW,
+            gender=Gender.MALE,
+            identifier=None,
+            course_rating=71.2,
+            slope_rating=128,
+        )
+    ]
+
+
+@pytest.fixture
+def valid_holes():
+    """Tarjeta de 18 hoyos, par 72."""
+    pars = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+    return [Hole(number=i + 1, par=pars[i], stroke_index=i + 1, meters=350) for i in range(18)]
+
+
+def _build_course(creator_id, tees, holes, location=None) -> GolfCourse:
+    """Crea un campo con la ubicación dada."""
+    return GolfCourse.create(
+        name="Campo de prueba de ubicación",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=creator_id,
+        tees=tees,
+        holes=holes,
+        location=location,
+    )
+
+
+# ============================================================================
+# Tests: ida y vuelta a la base de datos
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_save_and_find_course_with_location(db_session, creator_id, valid_tees, valid_holes):
+    """
+    GIVEN: Un campo con ubicación completa
+    WHEN: Se persiste y se vuelve a leer
+    THEN: Conserva coordenadas, dirección, localidad y provincia
+    """
+    repository = GolfCourseRepository(db_session)
+    course = _build_course(creator_id, valid_tees, valid_holes, location=DERIO)
+
+    await repository.save(course)
+    await db_session.flush()
+    db_session.expunge_all()
+
+    found = await repository.find_by_id(course.id)
+
+    assert found is not None
+    assert found.location == DERIO
+    assert found.location.has_coordinates is True
+
+
+@pytest.mark.asyncio
+async def test_save_and_find_course_without_location(
+    db_session, creator_id, valid_tees, valid_holes
+):
+    """
+    GIVEN: Un campo sin ubicación
+    WHEN: Se persiste y se vuelve a leer
+    THEN: Devuelve una ubicación vacía, no un error
+    """
+    repository = GolfCourseRepository(db_session)
+    course = _build_course(creator_id, valid_tees, valid_holes)
+
+    await repository.save(course)
+    await db_session.flush()
+    db_session.expunge_all()
+
+    found = await repository.find_by_id(course.id)
+
+    assert found is not None
+    assert found.location.is_empty is True
+
+
+@pytest.mark.asyncio
+async def test_updating_location_persists(db_session, creator_id, valid_tees, valid_holes):
+    """
+    GIVEN: Un campo ya guardado con ubicación
+    WHEN: Se le cambia la ubicación y se vuelve a guardar
+    THEN: La base de datos refleja la nueva
+    """
+    repository = GolfCourseRepository(db_session)
+    course = _build_course(creator_id, valid_tees, valid_holes, location=DERIO)
+    await repository.save(course)
+    await db_session.flush()
+
+    marbella = CourseLocation(latitude=36.50, longitude=-4.88, city="MARBELLA", province="MÁLAGA")
+    course.update(
+        name=course.name,
+        country_code=course.country_code,
+        course_type=course.course_type,
+        tees=valid_tees,
+        holes=valid_holes,
+        location=marbella,
+    )
+    await repository.save(course)
+    await db_session.flush()
+    db_session.expunge_all()
+
+    found = await repository.find_by_id(course.id)
+
+    assert found is not None
+    assert found.location.city == "MARBELLA"
+    assert found.location.latitude == 36.50
+
+
+# ============================================================================
+# Tests: restricciones en la base de datos
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_database_rejects_half_coordinates(db_session, creator_id, valid_tees, valid_holes):
+    """
+    GIVEN: Un campo ya guardado
+    WHEN: Se intenta dejar solo la latitud por SQL directo
+    THEN: La base de datos lo rechaza, aunque el dominio no intervenga
+    """
+    repository = GolfCourseRepository(db_session)
+    course = _build_course(creator_id, valid_tees, valid_holes, location=DERIO)
+    await repository.save(course)
+    await db_session.flush()
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text("UPDATE golf_courses SET longitude = NULL WHERE id = :id"),
+            {"id": str(course.id.value)},
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_database_rejects_impossible_latitude(
+    db_session, creator_id, valid_tees, valid_holes
+):
+    """
+    GIVEN: Un campo ya guardado
+    WHEN: Se intenta escribir una latitud fuera de rango por SQL directo
+    THEN: La base de datos lo rechaza
+    """
+    repository = GolfCourseRepository(db_session)
+    course = _build_course(creator_id, valid_tees, valid_holes, location=DERIO)
+    await repository.save(course)
+    await db_session.flush()
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text("UPDATE golf_courses SET latitude = 120.0 WHERE id = :id"),
+            {"id": str(course.id.value)},
+        )
+        await db_session.flush()

--- a/tests/unit/modules/golf_course/application/use_cases/test_golf_course_location_flow.py
+++ b/tests/unit/modules/golf_course/application/use_cases/test_golf_course_location_flow.py
@@ -1,0 +1,182 @@
+"""
+Tests de la ubicación a través de la capa de aplicación.
+
+Comprueban que la ubicación viaja entera desde el DTO de entrada hasta el de
+salida, y que un campo sin ubicación la devuelve como null y no como un objeto
+con cinco nulos dentro.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.modules.golf_course.application.dtos.golf_course_dtos import (
+    HoleDTO,
+    LocationDTO,
+    RequestGolfCourseRequestDTO,
+    TeeDTO,
+)
+from src.modules.golf_course.application.mappers.golf_course_mapper import GolfCourseMapper
+from src.modules.golf_course.application.use_cases.create_direct_golf_course_use_case import (
+    CreateDirectGolfCourseUseCase,
+)
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.entities.country import Country
+from src.shared.domain.value_objects.country_code import CountryCode
+
+DERIO_LOCATION = LocationDTO(
+    latitude=43.29519,
+    longitude=-2.87352,
+    address="CALLE EREAGA BIDEA S/N, 48160, DERIO, VIZCAYA",
+    city="DERIO",
+    province="VIZCAYA",
+)
+
+
+def build_request(location: LocationDTO | None) -> RequestGolfCourseRequestDTO:
+    """Construye un alta de campo válida con la ubicación dada."""
+    return RequestGolfCourseRequestDTO(
+        name="Real Club de Golf",
+        country_code="ES",
+        course_type=CourseType.STANDARD_18,
+        tees=[
+            TeeDTO(
+                color="WHITE",
+                tee_gender="MALE",
+                course_rating=72.5,
+                slope_rating=130,
+            )
+        ],
+        holes=[
+            HoleDTO(hole_number=i, par=4 if i <= 12 else 3, stroke_index=i) for i in range(1, 19)
+        ],
+        location=location,
+    )
+
+
+@pytest.fixture
+def mock_uow():
+    """Mock del Unit of Work con un país válido."""
+    uow = AsyncMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.commit = AsyncMock()
+
+    async def aexit_side_effect(exc_type, exc, tb):
+        if exc_type is None:
+            await uow.commit()
+
+    uow.__aexit__ = AsyncMock(side_effect=aexit_side_effect)
+    uow.golf_courses = AsyncMock()
+    uow.countries = AsyncMock()
+    uow.countries.find_by_code.return_value = Country(
+        code=CountryCode("ES"), name_en="Spain", name_es="España"
+    )
+    return uow
+
+
+# ============================================================================
+# Tests: alta con ubicación
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_course_with_location_returns_it(mock_uow):
+    """
+    GIVEN: Un alta de campo con ubicación completa
+    WHEN: Se ejecuta el caso de uso
+    THEN: La respuesta devuelve la misma ubicación
+    """
+    use_case = CreateDirectGolfCourseUseCase(mock_uow)
+
+    response = await use_case.execute(build_request(DERIO_LOCATION), UserId(str(uuid4())))
+
+    assert response.golf_course.location is not None
+    assert response.golf_course.location.latitude == 43.29519
+    assert response.golf_course.location.longitude == -2.87352
+    assert response.golf_course.location.city == "DERIO"
+    assert response.golf_course.location.province == "VIZCAYA"
+
+
+@pytest.mark.asyncio
+async def test_create_course_without_location_returns_null(mock_uow):
+    """
+    GIVEN: Un alta de campo sin ubicación
+    WHEN: Se ejecuta el caso de uso
+    THEN: La respuesta trae location a null, no un objeto vacío
+    """
+    use_case = CreateDirectGolfCourseUseCase(mock_uow)
+
+    response = await use_case.execute(build_request(None), UserId(str(uuid4())))
+
+    assert response.golf_course.location is None
+
+
+@pytest.mark.asyncio
+async def test_create_course_with_only_city_returns_it(mock_uow):
+    """
+    GIVEN: Un alta de campo con localidad pero sin coordenadas
+    WHEN: Se ejecuta el caso de uso
+    THEN: La respuesta trae la localidad y las coordenadas a null
+    """
+    use_case = CreateDirectGolfCourseUseCase(mock_uow)
+
+    response = await use_case.execute(
+        build_request(LocationDTO(city="MARBELLA", province="MÁLAGA")), UserId(str(uuid4()))
+    )
+
+    assert response.golf_course.location is not None
+    assert response.golf_course.location.city == "MARBELLA"
+    assert response.golf_course.location.latitude is None
+
+
+# ============================================================================
+# Tests: validación en el DTO
+# ============================================================================
+
+
+def test_location_dto_rejects_half_coordinates():
+    """
+    GIVEN: Una ubicación con latitud pero sin longitud
+    WHEN: Se valida el DTO
+    THEN: Falla antes de llegar al dominio
+    """
+    with pytest.raises(ValueError, match="must be provided together"):
+        LocationDTO(latitude=43.29519)
+
+
+def test_location_dto_rejects_out_of_range_latitude():
+    """
+    GIVEN: Una latitud imposible
+    WHEN: Se valida el DTO
+    THEN: Falla
+    """
+    with pytest.raises(ValueError):
+        LocationDTO(latitude=91.0, longitude=0.0)
+
+
+# ============================================================================
+# Tests: mapeo a dominio
+# ============================================================================
+
+
+def test_mapper_returns_none_when_no_location_is_sent():
+    """
+    GIVEN: Una petición sin ubicación
+    WHEN: Se mapea a dominio
+    THEN: Devuelve None, que en una edición significa 'no la toques'
+    """
+    assert GolfCourseMapper.to_domain_location(None) is None
+
+
+def test_mapper_returns_empty_value_object_for_an_empty_location():
+    """
+    GIVEN: Una ubicación enviada con todos sus valores a null
+    WHEN: Se mapea a dominio
+    THEN: Devuelve un Value Object vacío, que es la forma de borrar la ubicación
+    """
+    location = GolfCourseMapper.to_domain_location(LocationDTO())
+
+    assert location is not None
+    assert location.is_empty is True

--- a/tests/unit/modules/golf_course/application/use_cases/test_golf_course_location_flow.py
+++ b/tests/unit/modules/golf_course/application/use_cases/test_golf_course_location_flow.py
@@ -114,6 +114,24 @@ async def test_create_course_without_location_returns_null(mock_uow):
 
 
 @pytest.mark.asyncio
+async def test_zero_coordinates_are_not_treated_as_missing(mock_uow):
+    """
+    GIVEN: Un campo situado en latitud y longitud cero
+    WHEN: Se ejecuta el caso de uso
+    THEN: La respuesta trae las coordenadas, no location a null
+    """
+    use_case = CreateDirectGolfCourseUseCase(mock_uow)
+
+    response = await use_case.execute(
+        build_request(LocationDTO(latitude=0.0, longitude=0.0)), UserId(str(uuid4()))
+    )
+
+    assert response.golf_course.location is not None
+    assert response.golf_course.location.latitude == 0.0
+    assert response.golf_course.location.longitude == 0.0
+
+
+@pytest.mark.asyncio
 async def test_create_course_with_only_city_returns_it(mock_uow):
     """
     GIVEN: Un alta de campo con localidad pero sin coordenadas

--- a/tests/unit/modules/golf_course/domain/entities/test_golf_course_location.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_golf_course_location.py
@@ -1,0 +1,256 @@
+"""
+Tests de la ubicación dentro del agregado GolfCourse.
+
+Lo que más se protege aquí es que editar un campo sin enviar ubicación no la
+borre: el formulario de edición es anterior a esta funcionalidad y no la manda,
+así que la omisión tiene que significar "no la toques".
+"""
+
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_location import CourseLocation
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+PAR_72 = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+
+DERIO = CourseLocation(
+    latitude=43.29519,
+    longitude=-2.87352,
+    address="CALLE EREAGA BIDEA S/N, 48160, DERIO, VIZCAYA",
+    city="DERIO",
+    province="VIZCAYA",
+)
+
+
+def build_holes() -> list[Hole]:
+    """Construye una tarjeta de 18 hoyos con índices 1-18."""
+    return [Hole(number=i + 1, par=PAR_72[i], stroke_index=i + 1, meters=350) for i in range(18)]
+
+
+def build_tees() -> list[Tee]:
+    """Construye una salida amarilla masculina."""
+    return [
+        Tee(
+            gender=Gender.MALE,
+            color=TeeColor.YELLOW,
+            identifier=None,
+            course_rating=71.2,
+            slope_rating=125,
+            holes=build_holes(),
+        )
+    ]
+
+
+def build_course(location: CourseLocation | None = None) -> GolfCourse:
+    """Crea un campo con la ubicación dada."""
+    return GolfCourse.create(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=UserId.generate(),
+        tees=build_tees(),
+        holes=build_holes(),
+        location=location,
+    )
+
+
+# ============================================================================
+# Tests: creación
+# ============================================================================
+
+
+def test_course_created_with_location_keeps_it():
+    """
+    GIVEN: Un campo creado con ubicación
+    WHEN: Se consulta su ubicación
+    THEN: Devuelve los mismos datos
+    """
+    course = build_course(location=DERIO)
+
+    assert course.location == DERIO
+    assert course.location.has_coordinates is True
+
+
+def test_course_created_without_location_has_empty_one():
+    """
+    GIVEN: Un campo creado sin ubicación
+    WHEN: Se consulta su ubicación
+    THEN: Devuelve un Value Object vacío, nunca None
+    """
+    course = build_course()
+
+    assert course.location.is_empty is True
+
+
+def test_reconstruct_restores_location():
+    """
+    GIVEN: Un campo reconstruido desde persistencia con ubicación
+    WHEN: Se consulta su ubicación
+    THEN: La conserva
+    """
+    original = build_course(location=DERIO)
+
+    restored = GolfCourse.reconstruct(
+        id=original.id,
+        name=original.name,
+        country_code=original.country_code,
+        course_type=original.course_type,
+        creator_id=original.creator_id,
+        tees=build_tees(),
+        holes=build_holes(),
+        approval_status=original.approval_status,
+        rejection_reason=None,
+        created_at=original.created_at,
+        updated_at=original.updated_at,
+        location=DERIO,
+    )
+
+    assert restored.location == DERIO
+
+
+# ============================================================================
+# Tests: la edición no borra la ubicación
+# ============================================================================
+
+
+def test_update_without_location_keeps_the_existing_one():
+    """
+    GIVEN: Un campo con ubicación
+    WHEN: Se edita sin enviar ubicación (lo que hace el formulario actual)
+    THEN: La ubicación se conserva
+    """
+    course = build_course(location=DERIO)
+
+    course.update(
+        name="Nombre nuevo",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+    )
+
+    assert course.location == DERIO
+    assert course.name == "Nombre nuevo"
+
+
+def test_update_with_empty_location_clears_it():
+    """
+    GIVEN: Un campo con ubicación
+    WHEN: Se edita enviando una ubicación explícitamente vacía
+    THEN: La ubicación se borra
+    """
+    course = build_course(location=DERIO)
+
+    course.update(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        location=CourseLocation(),
+    )
+
+    assert course.location.is_empty is True
+
+
+def test_update_with_new_location_replaces_it():
+    """
+    GIVEN: Un campo con ubicación
+    WHEN: Se edita con una ubicación distinta
+    THEN: Queda la nueva
+    """
+    course = build_course(location=DERIO)
+    marbella = CourseLocation(latitude=36.5, longitude=-4.9, city="MARBELLA")
+
+    course.update(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        location=marbella,
+    )
+
+    assert course.location == marbella
+
+
+# ============================================================================
+# Tests: propuestas de cambio (clones)
+# ============================================================================
+
+
+def test_clone_inherits_location_when_the_edit_omits_it():
+    """
+    GIVEN: Un campo APPROVED con ubicación, editado por su creator
+    WHEN: Se genera el clone de propuesta sin enviar ubicación
+    THEN: El clone hereda la ubicación, para que aprobarlo no la borre
+    """
+    course = build_course(location=DERIO)
+    course.approve()
+
+    clone = course.apply_update(
+        name="Nombre nuevo",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        is_admin=False,
+    )
+
+    assert clone is not None
+    assert clone.location == DERIO
+
+
+def test_approving_a_clone_copies_its_location_to_the_original():
+    """
+    GIVEN: Un clone con una ubicación nueva
+    WHEN: Se aplican sus cambios al campo original
+    THEN: El original queda con la ubicación del clone
+    """
+    course = build_course()
+    course.approve()
+    marbella = CourseLocation(latitude=36.5, longitude=-4.9, city="MARBELLA")
+
+    clone = course.apply_update(
+        name="Nombre nuevo",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        is_admin=False,
+        location=marbella,
+    )
+    assert clone is not None
+
+    course.apply_changes_from_clone(clone)
+
+    assert course.location == marbella
+
+
+def test_admin_edit_applies_location_in_place():
+    """
+    GIVEN: Un campo APPROVED editado por un admin
+    WHEN: La edición trae ubicación nueva
+    THEN: Se aplica directamente, sin crear clone
+    """
+    course = build_course()
+    course.approve()
+    marbella = CourseLocation(latitude=36.5, longitude=-4.9, city="MARBELLA")
+
+    clone = course.apply_update(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        is_admin=True,
+        location=marbella,
+    )
+
+    assert clone is None
+    assert course.location == marbella

--- a/tests/unit/modules/golf_course/domain/entities/test_golf_course_location.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_golf_course_location.py
@@ -158,6 +158,31 @@ def test_update_with_empty_location_clears_it():
     assert course.location.is_empty is True
 
 
+def test_update_with_a_partial_location_replaces_the_whole_object():
+    """
+    GIVEN: Un campo con coordenadas, dirección, localidad y provincia
+    WHEN: Se edita enviando una ubicación con solo la localidad
+    THEN: La ubicación se reemplaza entera y el resto queda vacío
+
+    La ubicación no se parchea campo a campo: se comporta igual que `tees` y
+    `holes` en la misma petición, que también se reemplazan enteros.
+    """
+    course = build_course(location=DERIO)
+
+    course.update(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        tees=build_tees(),
+        holes=build_holes(),
+        location=CourseLocation(city="MARBELLA"),
+    )
+
+    assert course.location.city == "MARBELLA"
+    assert course.location.has_coordinates is False
+    assert course.location.address is None
+
+
 def test_update_with_new_location_replaces_it():
     """
     GIVEN: Un campo con ubicación

--- a/tests/unit/modules/golf_course/domain/value_objects/test_course_location.py
+++ b/tests/unit/modules/golf_course/domain/value_objects/test_course_location.py
@@ -1,0 +1,207 @@
+"""
+Tests del Value Object CourseLocation.
+
+La ubicación es lo que permitirá proponer campos cercanos a la posición del
+dispositivo, así que la regla que más se protege aquí es que las coordenadas
+vayan completas: media coordenada no sitúa nada en un mapa.
+"""
+
+import pytest
+
+from src.modules.golf_course.domain.value_objects.course_location import CourseLocation
+
+# ============================================================================
+# Tests: construcción básica
+# ============================================================================
+
+
+def test_location_can_be_empty():
+    """
+    GIVEN: Ningún dato de ubicación
+    WHEN: Se construye el Value Object
+    THEN: Es válido y se reconoce como vacío
+    """
+    location = CourseLocation()
+
+    assert location.is_empty is True
+    assert location.has_coordinates is False
+
+
+def test_location_with_full_data():
+    """
+    GIVEN: Coordenadas, dirección, localidad y provincia
+    WHEN: Se construye el Value Object
+    THEN: Conserva todos los datos y se puede situar en un mapa
+    """
+    location = CourseLocation(
+        latitude=43.29519,
+        longitude=-2.87352,
+        address="CALLE EREAGA BIDEA S/N, 48160, DERIO, VIZCAYA",
+        city="DERIO",
+        province="VIZCAYA",
+    )
+
+    assert location.latitude == 43.29519
+    assert location.longitude == -2.87352
+    assert location.city == "DERIO"
+    assert location.province == "VIZCAYA"
+    assert location.has_coordinates is True
+    assert location.is_empty is False
+
+
+def test_location_accepts_address_without_coordinates():
+    """
+    GIVEN: Una dirección pero ninguna coordenada
+    WHEN: Se construye el Value Object
+    THEN: Es válido, aunque el campo no salga en búsquedas por cercanía
+    """
+    location = CourseLocation(city="MARBELLA", province="MÁLAGA")
+
+    assert location.has_coordinates is False
+    assert location.is_empty is False
+
+
+# ============================================================================
+# Tests: coordenadas completas
+# ============================================================================
+
+
+def test_latitude_without_longitude_is_rejected():
+    """
+    GIVEN: Solo latitud
+    WHEN: Se construye el Value Object
+    THEN: Falla, porque media coordenada no sitúa nada
+    """
+    with pytest.raises(ValueError, match="both latitude and longitude"):
+        CourseLocation(latitude=43.29519)
+
+
+def test_longitude_without_latitude_is_rejected():
+    """
+    GIVEN: Solo longitud
+    WHEN: Se construye el Value Object
+    THEN: Falla, porque media coordenada no sitúa nada
+    """
+    with pytest.raises(ValueError, match="both latitude and longitude"):
+        CourseLocation(longitude=-2.87352)
+
+
+def test_zero_coordinates_are_valid():
+    """
+    GIVEN: Latitud y longitud a cero (el punto del golfo de Guinea)
+    WHEN: Se construye el Value Object
+    THEN: Es válido: cero es una coordenada, no un dato ausente
+    """
+    location = CourseLocation(latitude=0.0, longitude=0.0)
+
+    assert location.has_coordinates is True
+
+
+# ============================================================================
+# Tests: rangos geográficos
+# ============================================================================
+
+
+@pytest.mark.parametrize("latitude", [-90.1, 90.1, 180.0])
+def test_latitude_out_of_range_is_rejected(latitude):
+    """
+    GIVEN: Una latitud fuera de -90..90
+    WHEN: Se construye el Value Object
+    THEN: Falla
+    """
+    with pytest.raises(ValueError, match="Latitude must be between"):
+        CourseLocation(latitude=latitude, longitude=0.0)
+
+
+@pytest.mark.parametrize("longitude", [-180.1, 180.1, 360.0])
+def test_longitude_out_of_range_is_rejected(longitude):
+    """
+    GIVEN: Una longitud fuera de -180..180
+    WHEN: Se construye el Value Object
+    THEN: Falla
+    """
+    with pytest.raises(ValueError, match="Longitude must be between"):
+        CourseLocation(latitude=0.0, longitude=longitude)
+
+
+@pytest.mark.parametrize(
+    "latitude,longitude",
+    [(-90.0, -180.0), (90.0, 180.0)],
+)
+def test_range_limits_are_accepted(latitude, longitude):
+    """
+    GIVEN: Coordenadas justo en los límites geográficos
+    WHEN: Se construye el Value Object
+    THEN: Son válidas
+    """
+    location = CourseLocation(latitude=latitude, longitude=longitude)
+
+    assert location.has_coordinates is True
+
+
+# ============================================================================
+# Tests: normalización de texto
+# ============================================================================
+
+
+def test_blank_strings_become_none():
+    """
+    GIVEN: Textos en blanco
+    WHEN: Se construye el Value Object
+    THEN: Se normalizan a None, para que nadie tenga que distinguir '' de None
+    """
+    location = CourseLocation(address="   ", city="", province="\t")
+
+    assert location.address is None
+    assert location.city is None
+    assert location.province is None
+    assert location.is_empty is True
+
+
+def test_text_is_trimmed():
+    """
+    GIVEN: Textos con espacios alrededor
+    WHEN: Se construye el Value Object
+    THEN: Se recortan
+    """
+    location = CourseLocation(city="  MARBELLA  ")
+
+    assert location.city == "MARBELLA"
+
+
+def test_address_longer_than_limit_is_rejected():
+    """
+    GIVEN: Una dirección de más de 300 caracteres
+    WHEN: Se construye el Value Object
+    THEN: Falla, porque no cabría en la columna
+    """
+    with pytest.raises(ValueError, match="address must be at most 300"):
+        CourseLocation(address="A" * 301)
+
+
+@pytest.mark.parametrize("field_name", ["city", "province"])
+def test_city_and_province_longer_than_limit_are_rejected(field_name):
+    """
+    GIVEN: Una localidad o provincia de más de 100 caracteres
+    WHEN: Se construye el Value Object
+    THEN: Falla
+    """
+    with pytest.raises(ValueError, match=f"{field_name} must be at most 100"):
+        CourseLocation(**{field_name: "A" * 101})
+
+
+# ============================================================================
+# Tests: igualdad
+# ============================================================================
+
+
+def test_two_locations_with_same_data_are_equal():
+    """
+    GIVEN: Dos ubicaciones con los mismos datos
+    WHEN: Se comparan
+    THEN: Son iguales, como corresponde a un Value Object
+    """
+    first = CourseLocation(latitude=36.5, longitude=-4.9, city="MARBELLA")
+    second = CourseLocation(latitude=36.5, longitude=-4.9, city="MARBELLA")
+
+    assert first == second

--- a/tests/unit/modules/golf_course/domain/value_objects/test_course_location.py
+++ b/tests/unit/modules/golf_course/domain/value_objects/test_course_location.py
@@ -90,11 +90,13 @@ def test_zero_coordinates_are_valid():
     """
     GIVEN: Latitud y longitud a cero (el punto del golfo de Guinea)
     WHEN: Se construye el Value Object
-    THEN: Es válido: cero es una coordenada, no un dato ausente
+    THEN: Es válido y NO se considera vacío: cero es una coordenada, no un dato
+          ausente, y darla por ausente devolvería `location: null` en la API
     """
     location = CourseLocation(latitude=0.0, longitude=0.0)
 
     assert location.has_coordinates is True
+    assert location.is_empty is False
 
 
 # ============================================================================


### PR DESCRIPTION
## What

Golf courses can now store where they are: coordinates, postal address, city and province — all optional — across the domain aggregate, the API and migration `c4d8e1a72b93`.

This is the groundwork for suggesting nearby courses from the device location in quick matches. The proximity search itself is deliberately out of scope, as the issue states.

Closes #105

## Decisions worth reviewing

**Latitude and longitude go together or not at all.** Half a coordinate places nothing on a map, and a proximity search that accepted it would return arbitrary results. Enforced in three places — the value object, the DTO and a database CHECK — because the upcoming federated course import writes thousands of rows at once and a half-written coordinate would go unnoticed.

**Plain columns, not a composite value object.** `CourseLocation` is recomposed when read. Location is optional and `composite()` does not handle NULL, which is the rule already documented in `CLAUDE.md`.

**Updating without a location keeps the existing one.** Clearing it requires sending the object with every value null. The current edit form predates this feature and omits the field entirely, so treating the omission as a delete would wipe a course's coordinates on a rename. Same reasoning applies to update proposals: a clone inherits the original's location so that approving it never drops the coordinates.

**A course without location returns `null`, not an object with five nulls**, so a client can tell at a glance whether the course can be placed on a map.

## Testing

- 36 new tests: value object, aggregate, application flow, persistence and API
- Full unit suite: 2673 passing
- Migration applied, rolled back and reapplied against a scratch database; partial index and all three CHECKs verified in PostgreSQL
- `ruff check` and `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5LcqohCvkjLhxazL78mZK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional location details for golf courses, including coordinates, address, city, and province.
  * Locations are available when creating, viewing, and updating courses.
  * Updates preserve existing locations when omitted and remove them when explicitly cleared.
  * Added validation for coordinate ranges and paired latitude/longitude values.
* **Documentation**
  * Documented the new golf-course location support in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->