### PR TITLE
fix: List approved courses alphabetically

### DIFF
--- a/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
+++ b/src/modules/golf_course/infrastructure/persistence/repositories/golf_course_repository.py
@@ -198,17 +198,22 @@ class GolfCourseRepository(IGolfCourseRepository):
         )
 
         # El id desempata siempre: sin un orden total, dos campos con la misma
-        # distancia o la misma fecha pueden salir en distinto orden en cada
+        # distancia o el mismo nombre pueden salir en distinto orden en cada
         # consulta, y paginando eso significa ver uno repetido y perder otro.
         # Los 802 campos importados se dieron de alta en el mismo lote, así que
-        # los empates de created_at no son hipotéticos
+        # los empates no son hipotéticos
+        #
+        # Alfabético y no por fecha de alta: quien abre el desplegable busca un
+        # campo que ya tiene en la cabeza, y lo recorre por su nombre. Ordenar
+        # por `created_at` descendente hacía además que el lote de la RFEG,
+        # importado de la A a la Z, saliera justo del revés
         stmt = select(GolfCourse).where(*filters)
         if distance is not None:
             stmt = stmt.add_columns(distance.label("distance_km")).order_by(
                 distance.asc(), columns.id.asc()
             )
         else:
-            stmt = stmt.order_by(columns.created_at.desc(), columns.id.asc())
+            stmt = stmt.order_by(columns.name.asc(), columns.id.asc())
 
         # selectinload y no joinedload: el join a las salidas multiplica las
         # filas, así que un LIMIT cortaría por la mitad las salidas de un campo

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
@@ -511,21 +511,52 @@ async def test_search_approved_orders_alphabetically(
     db_session, creator_id, valid_tees, valid_holes
 ):
     """
-    GIVEN: Campos dados de alta en orden alfabético, como el lote de la RFEG
+    GIVEN: Campos dados de alta en un orden que no es el alfabético
     WHEN: Se listan sin posición desde la que medir distancias
     THEN: Salen de la A a la Z, y no por fecha de alta
 
-    Ordenar por `created_at` descendente devolvía ese lote justo del revés, así
-    que el desplegable empezaba por la Z.
+    Ordenar por `created_at` descendente devolvía el lote de la RFEG justo del
+    revés, así que el desplegable empezaba por la Z.
+
+    Se dan de alta desordenados a propósito: insertándolos ya ordenados, una
+    consulta que perdiera el ORDER BY pasaría igual, devolviéndolos en el orden
+    en que se escribieron.
     """
     repository = GolfCourseRepository(db_session)
-    for name in ("Alcaidesa", "Mediterráneo", "Zaudín"):
+    for name in ("Mediterráneo", "Zaudín", "Alcaidesa"):
         await _approved_course(repository, creator_id, valid_tees, valid_holes, name)
     await db_session.commit()
 
     page = await repository.search_approved(ApprovedCourseSearch())
 
     assert [course.name for course in page.courses] == ["Alcaidesa", "Mediterráneo", "Zaudín"]
+
+
+async def test_search_approved_breaks_name_ties_by_id(
+    db_session, creator_id, valid_tees, valid_holes
+):
+    """
+    GIVEN: Dos campos aprobados con el mismo nombre
+    WHEN: Se piden de uno en uno, como haría el cliente al paginar
+    THEN: Salen los dos, en orden de id y sin repetirse
+
+    El desempate no es cosmético: sin un orden total, dos campos homónimos
+    pueden salir en distinto orden en cada consulta, y paginando eso significa
+    ver uno repetido y perder el otro. La federación publica recorridos casi
+    homónimos del mismo club, así que los empates no son hipotéticos.
+    """
+    repository = GolfCourseRepository(db_session)
+    for _ in range(2):
+        await _approved_course(repository, creator_id, valid_tees, valid_holes, "La Envía")
+    await db_session.commit()
+
+    first = await repository.search_approved(ApprovedCourseSearch(limit=1))
+    second = await repository.search_approved(ApprovedCourseSearch(limit=1, offset=1))
+
+    assert first.total == 2
+    assert [course.name for course in first.courses] == ["La Envía"]
+    assert [course.name for course in second.courses] == ["La Envía"]
+    assert str(first.courses[0].id) < str(second.courses[0].id)
 
 
 async def test_search_approved_treats_wildcards_as_text(

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
@@ -507,6 +507,27 @@ async def test_search_approved_filters_by_partial_name(
     }
 
 
+async def test_search_approved_orders_alphabetically(
+    db_session, creator_id, valid_tees, valid_holes
+):
+    """
+    GIVEN: Campos dados de alta en orden alfabético, como el lote de la RFEG
+    WHEN: Se listan sin posición desde la que medir distancias
+    THEN: Salen de la A a la Z, y no por fecha de alta
+
+    Ordenar por `created_at` descendente devolvía ese lote justo del revés, así
+    que el desplegable empezaba por la Z.
+    """
+    repository = GolfCourseRepository(db_session)
+    for name in ("Alcaidesa", "Mediterráneo", "Zaudín"):
+        await _approved_course(repository, creator_id, valid_tees, valid_holes, name)
+    await db_session.commit()
+
+    page = await repository.search_approved(ApprovedCourseSearch())
+
+    assert [course.name for course in page.courses] == ["Alcaidesa", "Mediterráneo", "Zaudín"]
+
+
 async def test_search_approved_treats_wildcards_as_text(
     db_session, creator_id, valid_tees, valid_holes
 ):


### PR DESCRIPTION
## Problem

The course picker opened at the end of the alphabet: Zuia, Vistabella, Villa Padierna…

`search_approved` ordered by `created_at` descending. The 802 RFEG courses were imported from A to Z in a single batch, so "newest first" handed them back exactly reversed.

## Fix

Order by `name` ascending. Whoever opens the picker is looking for a course they already have in mind and scans it by name, so that is the useful order.

- The id still breaks ties: without a total order, paginating two courses with the same name could show one twice and drop the other.
- **Ordering by distance is untouched** — when a position is supplied, nearest still wins.
- `search_approved` is only used by the listing use case behind the picker; the admin panel goes through a different path and is unaffected.

## Verification

- New integration test fixing the order. Verified it catches the bug: with the old ordering it fails with `['Zaudín', …, 'Alcaidesa']`.
- Golf course integration tests: 33 passing.
- Unit tests: 2821 passing.
- `ruff` and `mypy` clean.
- Deployed to the local Kind cluster and checked end to end: the API now returns Abama, Abama H6, Aguilón Golf, Alborán… across all 803 courses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approved golf course searches without location coordinates now display results alphabetically by course name, with consistent ordering for matching names.
  * Location-based searches continue to prioritize nearest courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->