### PR TITLE
Fix match play stroke allocation in quick matches and competitions, and add a scratch mode

### DIFF
--- a/alembic/versions/b4d7e1a9c25f_add_play_mode_to_quick_matches.py
+++ b/alembic/versions/b4d7e1a9c25f_add_play_mode_to_quick_matches.py
@@ -1,0 +1,66 @@
+"""add play_mode to quick_matches
+
+Anade el modo de juego (SCRATCH / HANDICAP) a las partidas rapidas, el mismo
+Value Object que ya usan las competiciones.
+
+Las filas existentes NO se rellenan todas igual, y es deliberado: se les asigna
+el modo que reproduce lo que la aplicacion venia mostrando, para no reescribir
+el resultado de partidas ya jugadas.
+
+- Partidas de match play (match_format IS NOT NULL): el resultado se venia
+  calculando con los golpes brutos, sin aplicar handicap. Eso es exactamente
+  SCRATCH, asi que se quedan en SCRATCH y su resultado no se mueve.
+- Partido libre (scoring_format IS NOT NULL): la clasificacion ya se calculaba
+  neta, aplicando el Playing Handicap de cada uno. Eso es HANDICAP.
+
+Las partidas nuevas nacen en HANDICAP salvo que el creador elija scratch.
+
+Revision ID: b4d7e1a9c25f
+Revises: e7f2b3c9d418
+Create Date: 2026-08-15
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b4d7e1a9c25f"
+down_revision = "e7f2b3c9d418"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Se crea nullable para poder rellenar las filas existentes antes de exigir
+    # el NOT NULL: una tabla con datos no admite una columna NOT NULL sin default.
+    op.add_column("quick_matches", sa.Column("play_mode", sa.String(20), nullable=True))
+
+    op.execute(
+        """
+        UPDATE quick_matches
+        SET play_mode = CASE
+            WHEN match_format IS NOT NULL THEN 'SCRATCH'
+            ELSE 'HANDICAP'
+        END
+        WHERE play_mode IS NULL
+        """
+    )
+
+    op.alter_column(
+        "quick_matches",
+        "play_mode",
+        nullable=False,
+        server_default="HANDICAP",
+    )
+
+    op.create_check_constraint(
+        "ck_quick_matches_play_mode",
+        "quick_matches",
+        "play_mode IN ('SCRATCH', 'HANDICAP')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_quick_matches_play_mode", "quick_matches", type_="check")
+    op.drop_column("quick_matches", "play_mode")

--- a/alembic/versions/b4d7e1a9c25f_add_play_mode_to_quick_matches.py
+++ b/alembic/versions/b4d7e1a9c25f_add_play_mode_to_quick_matches.py
@@ -7,11 +7,16 @@ Las filas existentes NO se rellenan todas igual, y es deliberado: se les asigna
 el modo que reproduce lo que la aplicacion venia mostrando, para no reescribir
 el resultado de partidas ya jugadas.
 
-- Partidas de match play (match_format IS NOT NULL): el resultado se venia
-  calculando con los golpes brutos, sin aplicar handicap. Eso es exactamente
-  SCRATCH, asi que se quedan en SCRATCH y su resultado no se mueve.
-- Partido libre (scoring_format IS NOT NULL): la clasificacion ya se calculaba
-  neta, aplicando el Playing Handicap de cada uno. Eso es HANDICAP.
+- Match play YA TERMINADO o cancelado (match_format IS NOT NULL y status en
+  COMPLETED/CANCELLED): el resultado se venia calculando con los golpes brutos,
+  sin aplicar handicap. Eso es exactamente SCRATCH, asi que se quedan en SCRATCH
+  y su resultado guardado no se mueve.
+- Todo lo demas, HANDICAP. Esto incluye el partido libre (su clasificacion ya se
+  calculaba neta) y, sobre todo, las partidas de match play que en el momento del
+  despliegue esten PENDING o IN_PROGRESS: esas todavia se van a jugar, no hay
+  resultado que preservar, y sus jugadores las montaron dando por hecho que
+  habria handicap. Dejarlas en SCRATCH seria un cambio silencioso e irreversible,
+  porque no existe ningun endpoint que cambie `play_mode` despues de crear.
 
 Las partidas nuevas nacen en HANDICAP salvo que el creador elija scratch.
 
@@ -40,7 +45,8 @@ def upgrade() -> None:
         """
         UPDATE quick_matches
         SET play_mode = CASE
-            WHEN match_format IS NOT NULL THEN 'SCRATCH'
+            WHEN match_format IS NOT NULL
+                 AND status IN ('COMPLETED', 'CANCELLED') THEN 'SCRATCH'
             ELSE 'HANDICAP'
         END
         WHERE play_mode IS NULL

--- a/scripts/generate_parity_fixtures.py
+++ b/scripts/generate_parity_fixtures.py
@@ -1,0 +1,242 @@
+"""
+Genera los casos de paridad que consume el test del frontend.
+
+El frontend duplica el reparto de golpes a proposito (sin el no hay anotacion
+sin conexion), y el riesgo real de esa duplicacion es que las dos
+implementaciones se separen sin que nadie se entere. Los tests escritos a mano
+en cada lado fijan lo que uno CREE que hacen los dos; esto fija lo que hace el
+backend de verdad.
+
+Uso (desde la raiz del repositorio):
+    source .venv/bin/activate
+    python scripts/generate_parity_fixtures.py
+
+Escribe el JSON en el repositorio del frontend, donde lo lee
+`MatchPlayStrokeAllocator.parity.test.js`. Si ese test falla despues de tocar el
+reparto del backend: se regenera este fichero y se arregla el cliente hasta que
+vuelva a cuadrar. No al reves.
+"""
+
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.quick_match.domain.services.stroke_allocation_service import (
+    StrokeAllocationService,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.shared.domain.value_objects.gender import Gender
+
+OUTPUT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "RyderCupWeb"
+    / "src"
+    / "domain"
+    / "services"
+    / "__fixtures__"
+    / "backendParity.json"
+)
+
+# Golf de Meis (RFEG 487), recorrido Par 72: el campo donde se detecto el fallo
+MEIS_STROKE_INDEX = [7, 1, 13, 5, 15, 9, 3, 11, 17, 16, 2, 14, 12, 8, 18, 6, 4, 10]
+MEIS_PAR = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+
+TEES = {
+    ("YELLOW", "MALE"): TeeRating(course_rating=Decimal("73.1"), slope_rating=140, par=72),
+    ("YELLOW", "FEMALE"): TeeRating(course_rating=Decimal("79.4"), slope_rating=147, par=72),
+    ("WHITE", None): TeeRating(course_rating=Decimal("74.0"), slope_rating=142, par=72),
+}
+
+service = StrokeAllocationService()
+_ids: dict[str, ParticipantId] = {}
+scenarios: list[dict] = []
+
+
+def _pid(name: str) -> ParticipantId:
+    """Id estable por nombre, para que el JSON no cambie en cada ejecucion."""
+    if name not in _ids:
+        _ids[name] = ParticipantId.generate()
+    return _ids[name]
+
+
+def guest(name, handicap, color, gender, team=None) -> QuickMatchParticipant:
+    return QuickMatchParticipant(
+        participant_id=_pid(name),
+        user_id=None,
+        first_name=name,
+        last_name="T",
+        handicap=handicap,
+        team=team,
+        tee_color=color,
+        tee_gender=gender,
+    )
+
+
+def _order(stroke_index_by_hole: list[int]) -> list[int]:
+    return sorted(range(1, 19), key=lambda hole: stroke_index_by_hole[hole - 1])
+
+
+def run(name, players, match_format, allowance, play_mode, tees=None, by_tee=None) -> None:
+    tees = TEES if tees is None else tees
+    result = service.allocate(
+        participants=players,
+        handicaps={
+            p.participant_id: (None if p.handicap is None else Decimal(str(p.handicap)))
+            for p in players
+        },
+        tee_ratings=tees,
+        holes_by_stroke_index=_order(MEIS_STROKE_INDEX),
+        match_format=match_format,
+        allowance_percentage=allowance,
+        play_mode=play_mode,
+        holes_by_stroke_index_by_tee=by_tee,
+    )
+    scenarios.append(
+        {
+            "name": name,
+            "matchFormat": match_format.value if match_format else None,
+            "allowancePercentage": allowance,
+            "playMode": play_mode.value,
+            "holes": [
+                {"holeNumber": i + 1, "par": MEIS_PAR[i], "strokeIndex": MEIS_STROKE_INDEX[i]}
+                for i in range(18)
+            ],
+            "tees": [
+                {
+                    "color": color,
+                    "gender": gender,
+                    "courseRating": float(rating.course_rating),
+                    "slopeRating": rating.slope_rating,
+                }
+                for (color, gender), rating in tees.items()
+            ],
+            "teeCards": {
+                f"{color}|{gender or ''}": order for (color, gender), order in (by_tee or {}).items()
+            },
+            "participants": [
+                {
+                    "participantId": str(p.participant_id.value),
+                    "handicap": p.handicap,
+                    "color": p.tee_color.value if p.tee_color else None,
+                    "teeGender": p.tee_gender.value if p.tee_gender else None,
+                    "team": p.team,
+                }
+                for p in players
+            ],
+            "expected": {
+                str(pid.value): {
+                    "playingHandicap": strokes.playing_handicap,
+                    "strokesByHole": {
+                        str(hole): count
+                        for hole, count in sorted(strokes.strokes_by_hole.items())
+                    },
+                }
+                for pid, strokes in result.items()
+            },
+        }
+    )
+
+
+def main() -> None:
+    yellow, white = TeeColor.YELLOW, TeeColor.WHITE
+    male, female = Gender.MALE, Gender.FEMALE
+    handicap, scratch = PlayMode.HANDICAP, PlayMode.SCRATCH
+
+    run(
+        "singles Meis 18 vs 20.7",
+        [guest("a", 18.0, yellow, male), guest("b", 20.7, yellow, male)],
+        MatchFormat.SINGLES,
+        100,
+        handicap,
+    )
+    run(
+        "singles barras distinto genero",
+        [guest("c", 18.0, yellow, female), guest("d", 20.7, yellow, male)],
+        MatchFormat.SINGLES,
+        100,
+        handicap,
+    )
+    run(
+        "libre 95%",
+        [guest("e", 18.0, yellow, male), guest("f", 20.7, yellow, male)],
+        None,
+        95,
+        handicap,
+    )
+    run("libre handicap plus", [guest("g", -2.0, yellow, male)], None, 100, handicap)
+    run(
+        "scratch",
+        [guest("h", 5.0, yellow, male), guest("i", 30.0, yellow, male)],
+        MatchFormat.SINGLES,
+        100,
+        scratch,
+    )
+    run("sin barra valorable 95%", [guest("j", 20.0, yellow, male)], None, 95, handicap, tees={})
+    run("handicap .5 sin barra", [guest("k", 20.5, yellow, male)], None, 100, handicap, tees={})
+    run("barra sin genero", [guest("l", 18.0, white, male)], None, 100, handicap)
+    run(
+        "fourball 90%",
+        [
+            guest("m", 5.0, yellow, male, "A"),
+            guest("n", 15.0, yellow, male, "A"),
+            guest("o", 20.0, yellow, male, "B"),
+            guest("p", 25.0, yellow, male, "B"),
+        ],
+        MatchFormat.FOURBALL,
+        90,
+        handicap,
+    )
+    run(
+        "foursomes 50%",
+        [
+            guest("q", 10.0, yellow, male, "A"),
+            guest("r", 12.0, yellow, male, "A"),
+            guest("s", 20.0, yellow, male, "B"),
+            guest("t", 24.0, yellow, male, "B"),
+        ],
+        MatchFormat.FOURSOMES,
+        50,
+        handicap,
+    )
+    run(
+        "tarjeta propia de la barra",
+        [guest("u", 20.0, yellow, female)],
+        None,
+        100,
+        handicap,
+        by_tee={("YELLOW", "FEMALE"): list(range(18, 0, -1))},
+    )
+    run(
+        "sin handicap",
+        [guest("v", 18.0, yellow, male), guest("w", None, yellow, male)],
+        MatchFormat.SINGLES,
+        100,
+        handicap,
+    )
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT.open("w", encoding="utf-8") as handle:
+        json.dump(
+            {"generatedBy": "RyderCupAm StrokeAllocationService", "scenarios": scenarios},
+            handle,
+            indent=2,
+            ensure_ascii=False,
+        )
+        handle.write("\n")
+
+    print(f"{len(scenarios)} escenarios escritos en {OUTPUT}")
+
+
+if __name__ == "__main__":
+    # Se ejecuta como script suelto, no como modulo: sin esto `src` no se
+    # encuentra salvo que se exporte PYTHONPATH a mano
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    main()

--- a/scripts/generate_parity_fixtures.py
+++ b/scripts/generate_parity_fixtures.py
@@ -9,7 +9,7 @@ backend de verdad.
 
 Uso (desde la raiz del repositorio):
     source .venv/bin/activate
-    python scripts/generate_parity_fixtures.py
+    PYTHONPATH=. python scripts/generate_parity_fixtures.py
 
 Escribe el JSON en el repositorio del frontend, donde lo lee
 `MatchPlayStrokeAllocator.parity.test.js`. Si ese test falla despues de tocar el
@@ -18,7 +18,6 @@ vuelva a cuadrar. No al reves.
 """
 
 import json
-import sys
 from decimal import Decimal
 from pathlib import Path
 
@@ -236,7 +235,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    # Se ejecuta como script suelto, no como modulo: sin esto `src` no se
-    # encuentra salvo que se exporte PYTHONPATH a mano
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     main()

--- a/scripts/regenerate_scheduled_round_strokes.py
+++ b/scripts/regenerate_scheduled_round_strokes.py
@@ -1,0 +1,161 @@
+"""
+Recalcula el reparto de golpes de las rondas que aun no se han empezado.
+
+POR QUE HACE FALTA
+------------------
+Los partidos de competicion se generan una vez y se PERSISTEN: el
+`strokes_received` de cada jugador queda escrito en la fila del partido. Un
+reparto mal calculado no se arregla solo al desplegar el codigo corregido, se
+queda congelado en la base de datos.
+
+Las dos correcciones que obligan a pasar esto:
+
+1. Cada barra se valora contra SU par, no contra el del campo. Cambia cuantos
+   golpes se reparten.
+2. Los golpes se reparten con el stroke index de la barra que juega cada uno, no
+   con el de la tarjeta de referencia. Cambia en que hoyos caen.
+
+De los 800 campos federados importados con mas de una barra con tarjeta, 25
+tienen par distinto entre barras y 56 stroke index distinto: un 10% esta expuesto
+a al menos uno de los dos.
+
+COMO LO HACE
+------------
+No duplica el calculo: lee los emparejamientos que ya hay, devuelve la ronda a
+PENDING_MATCHES (`Round.reopen_for_regeneration`) y vuelve a llamar a
+`GenerateMatchesUseCase` con esos mismos emparejamientos como `manual_pairings`.
+Asi el reparto sale del codigo corregido y nadie cambia de rival ni de partido.
+
+QUE TOCA Y QUE NO
+-----------------
+- Solo rondas en SCHEDULED (partidos generados, ninguno empezado). IN_PROGRESS y
+  COMPLETED no se tocan: ahi ya hay resultados.
+- Solo competiciones en modo HANDICAP. En SCRATCH no hay golpes que repartir.
+- Conserva emparejamientos y numero de partido.
+
+USO
+---
+    source .venv/bin/activate
+    PYTHONPATH=. python scripts/regenerate_scheduled_round_strokes.py --dry-run
+    PYTHONPATH=. python scripts/regenerate_scheduled_round_strokes.py
+
+`--dry-run` no escribe nada: lista las rondas que se regenerarian. Conviene
+mirarlo antes de ejecutarlo en serio, y tener copia de seguridad de la base de
+datos: esto borra y recrea filas de `matches`.
+"""
+
+import argparse
+import asyncio
+
+from src.config.database import async_session_maker
+from src.modules.competition.application.dto.round_match_dto import (
+    GenerateMatchesRequestDTO,
+    ManualPairingDTO,
+)
+from src.modules.competition.application.use_cases.generate_matches_use_case import (
+    GenerateMatchesUseCase,
+)
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.competition.domain.value_objects.round_status import RoundStatus
+from src.modules.competition.infrastructure.persistence.sqlalchemy.competition_unit_of_work import (
+    SQLAlchemyCompetitionUnitOfWork,
+)
+from src.modules.golf_course.infrastructure.persistence.sqlalchemy.golf_course_unit_of_work import (
+    SQLAlchemyGolfCourseUnitOfWork,
+)
+from src.modules.user.infrastructure.persistence.sqlalchemy.unit_of_work import (
+    SQLAlchemyUnitOfWork,
+)
+
+COMPETITIONS_PAGE = 200
+
+
+async def main(dry_run: bool) -> int:
+    regenerated_rounds = 0
+    regenerated_matches = 0
+    skipped = 0
+
+    async with async_session_maker() as session:
+        uow = SQLAlchemyCompetitionUnitOfWork(session)
+        # `handicap_service=None` a proposito: en un lote no se sale a pedir
+        # handicaps a la RFEG, se recalcula con los que ya hay guardados.
+        use_case = GenerateMatchesUseCase(
+            uow=uow,
+            golf_course_repository=SQLAlchemyGolfCourseUnitOfWork(session).golf_courses,
+            user_repository=SQLAlchemyUnitOfWork(session).users,
+        )
+
+        async with uow:
+            competitions = await uow.competitions.find_all(limit=COMPETITIONS_PAGE, offset=0)
+
+        for competition in competitions:
+            if competition.play_mode != PlayMode.HANDICAP:
+                continue
+
+            async with uow:
+                rounds = await uow.rounds.find_by_competition(competition.id)
+
+            for round_entity in rounds:
+                if round_entity.status != RoundStatus.SCHEDULED:
+                    continue
+
+                async with uow:
+                    matches = await uow.matches.find_by_round(round_entity.id)
+
+                if not matches:
+                    continue
+
+                pairings = [
+                    ManualPairingDTO(
+                        team_a_player_ids=[p.user_id.value for p in match.team_a_players],
+                        team_b_player_ids=[p.user_id.value for p in match.team_b_players],
+                    )
+                    for match in sorted(matches, key=lambda m: m.match_number)
+                ]
+
+                print(
+                    f"  {competition.name} / ronda {round_entity.id.value}: "
+                    f"{len(pairings)} partidos"
+                )
+
+                if dry_run:
+                    regenerated_rounds += 1
+                    regenerated_matches += len(pairings)
+                    continue
+
+                try:
+                    async with uow:
+                        round_entity.reopen_for_regeneration()
+                        await uow.rounds.update(round_entity)
+
+                    await use_case.execute(
+                        GenerateMatchesRequestDTO(
+                            round_id=round_entity.id.value,
+                            manual_pairings=pairings,
+                        ),
+                        user_id=competition.creator_id,
+                        is_admin=True,
+                    )
+                    regenerated_rounds += 1
+                    regenerated_matches += len(pairings)
+                except Exception as exc:  # se informa y se sigue con las demas
+                    skipped += 1
+                    print(f"    ERROR, ronda sin tocar: {exc}")
+
+    print(
+        f"\n{'(dry-run) ' if dry_run else ''}"
+        f"Rondas regeneradas: {regenerated_rounds} | partidos: {regenerated_matches}"
+        + (f" | rondas con error: {skipped}" if skipped else "")
+    )
+    return 1 if skipped else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Recalcula el reparto de golpes de las rondas SCHEDULED"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Lista lo que haria sin escribir nada"
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(main(args.dry_run)))

--- a/scripts/regenerate_scheduled_round_strokes.py
+++ b/scripts/regenerate_scheduled_round_strokes.py
@@ -85,8 +85,17 @@ async def main(dry_run: bool) -> int:
             user_repository=SQLAlchemyUnitOfWork(session).users,
         )
 
-        async with uow:
-            competitions = await uow.competitions.find_all(limit=COMPETITIONS_PAGE, offset=0)
+        competitions = []
+        offset = 0
+        while True:
+            async with uow:
+                page = await uow.competitions.find_all(limit=COMPETITIONS_PAGE, offset=offset)
+            if not page:
+                break
+            competitions.extend(page)
+            offset += COMPETITIONS_PAGE
+
+        print(f"Competiciones: {len(competitions)}")
 
         for competition in competitions:
             if competition.play_mode != PlayMode.HANDICAP:
@@ -124,10 +133,11 @@ async def main(dry_run: bool) -> int:
                     continue
 
                 try:
-                    async with uow:
-                        round_entity.reopen_for_regeneration()
-                        await uow.rounds.update(round_entity)
-
+                    # `allow_regeneration` reabre la ronda DENTRO de la misma
+                    # transaccion que borra y recrea los partidos. Hacerlo aqui
+                    # fuera la dejaria en PENDING_MATCHES con los partidos
+                    # viejos si la generacion fallara, y las pasadas siguientes
+                    # la saltarian por no estar ya en SCHEDULED.
                     await use_case.execute(
                         GenerateMatchesRequestDTO(
                             round_id=round_entity.id.value,
@@ -135,12 +145,13 @@ async def main(dry_run: bool) -> int:
                         ),
                         user_id=competition.creator_id,
                         is_admin=True,
+                        allow_regeneration=True,
                     )
                     regenerated_rounds += 1
                     regenerated_matches += len(pairings)
                 except Exception as exc:  # se informa y se sigue con las demas
                     skipped += 1
-                    print(f"    ERROR, ronda sin tocar: {exc}")
+                    print(f"    ERROR, la ronda se queda como estaba: {exc}")
 
     print(
         f"\n{'(dry-run) ' if dry_run else ''}"

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -1547,9 +1547,12 @@ def get_get_quick_match_use_case(
     user_uow: UserUnitOfWorkInterface = Depends(get_uow),
     scoring_service: ScoringService = Depends(get_scoring_service),
     coverage_service: ScoringCoverageService = Depends(get_scoring_coverage_service),
+    golf_course_uow: GolfCourseUnitOfWorkInterface = Depends(get_golf_course_uow),
 ) -> GetQuickMatchUseCase:
     """Proveedor del caso de uso GetQuickMatchUseCase."""
-    return GetQuickMatchUseCase(uow, user_uow, scoring_service, coverage_service)
+    return GetQuickMatchUseCase(
+        uow, user_uow, scoring_service, coverage_service, golf_course_uow
+    )
 
 
 def get_list_my_quick_matches_use_case(

--- a/src/modules/competition/application/services/__init__.py
+++ b/src/modules/competition/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Servicios de aplicacion del modulo Competition."""

--- a/src/modules/competition/application/services/tee_context_builder.py
+++ b/src/modules/competition/application/services/tee_context_builder.py
@@ -1,0 +1,122 @@
+"""
+TeeContextBuilder - Traduce un GolfCourse a lo que necesita el reparto de golpes.
+
+`GenerateMatchesUseCase` y `ReassignMatchPlayersUseCase` tenian cada uno su
+propia copia de esta traduccion, y las dos arrastraban los mismos dos fallos:
+valoraban todas las barras contra el par del campo y repartian los golpes con el
+stroke index de la tarjeta de referencia. Una sola fuente evita que el proximo
+arreglo se aplique solo en una de las dos.
+
+Equivalente al `StrokeContextBuilder` de `quick_match`, que hace lo mismo para
+las partidas rapidas.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TeeContext:
+    """Ratings y orden de dificultad de un campo, listos para repartir golpes."""
+
+    tee_ratings: dict[tuple[str, str | None], TeeRating]
+    holes_by_stroke_index: list[int]
+    # Orden propio de cada barra. `golf_course.holes` es solo la tarjeta de la
+    # PRIMERA barra (ver `GolfCourse._sync_holes_and_tees`), y el importador de
+    # la RFEG guarda una por barra: de los 800 campos federados con mas de una
+    # barra con tarjeta, 56 tienen stroke index distinto entre ellas y 25 par
+    # distinto. Repartir con el orden de otra barra pone los golpes en los hoyos
+    # equivocados.
+    holes_by_tee: dict[tuple[str, str | None], list[int]] = field(default_factory=dict)
+
+    def holes_for(self, tee_color, tee_gender) -> list[int]:
+        """
+        Orden de dificultad de una barra concreta.
+
+        Cae al del campo cuando la barra no trae tarjeta propia. Misma reserva de
+        genero que la busqueda de ratings, para que las dos resuelvan la misma
+        barra.
+        """
+        if tee_color is None:
+            return self.holes_by_stroke_index
+        color = tee_color.value
+        gender = tee_gender.value if tee_gender else None
+        return (
+            self.holes_by_tee.get((color, gender))
+            or self.holes_by_tee.get((color, None))
+            or self.holes_by_stroke_index
+        )
+
+
+class TeeContextBuilder:
+    """Construye el TeeContext de un campo."""
+
+    @staticmethod
+    def build(golf_course: GolfCourse) -> TeeContext:
+        course_par = sum(h.par for h in golf_course.holes)
+        holes_by_stroke_index = [
+            h.number for h in sorted(golf_course.holes, key=lambda h: h.stroke_index)
+        ]
+
+        tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
+        holes_by_tee: dict[tuple[str, str | None], list[int]] = {}
+
+        for tee in golf_course.tees:
+            gender = tee.gender.value if tee.gender else None
+            tee_key = (tee.color.value, gender)
+            tee_ratings[tee_key] = TeeContextBuilder._rating_for(tee, course_par, golf_course)
+
+            card = TeeContextBuilder._card_for(tee)
+            if card:
+                holes_by_tee[tee_key] = card
+
+        return TeeContext(
+            tee_ratings=tee_ratings,
+            holes_by_stroke_index=holes_by_stroke_index,
+            holes_by_tee=holes_by_tee,
+        )
+
+    @staticmethod
+    def _rating_for(tee, course_par: int, golf_course: GolfCourse) -> TeeRating:
+        """
+        Valoracion de una barra, contra SU par cuando trae tarjeta propia.
+
+        Si ese par no sirve —se sale del rango WHS, o la tarjeta viene
+        malformada— se cae al del campo, que es lo que se venia usando, en vez de
+        dejar la ronda sin poder generar partidos.
+        """
+        course_rating = Decimal(str(tee.course_rating))
+        try:
+            return TeeRating(
+                course_rating=course_rating,
+                slope_rating=tee.slope_rating,
+                par=tee.par_total if tee.holes else course_par,
+            )
+        except (ValueError, TypeError):
+            logger.debug(
+                "Tee %s of golf course %s has an unusable par; rating it against the course par",
+                tee.color.value,
+                golf_course.id,
+            )
+            return TeeRating(
+                course_rating=course_rating,
+                slope_rating=tee.slope_rating,
+                par=course_par,
+            )
+
+    @staticmethod
+    def _card_for(tee) -> list[int]:
+        """Hoyos de la barra ordenados por su stroke index; vacio si no tiene tarjeta."""
+        if not tee.holes:
+            return []
+        try:
+            return [h.number for h in sorted(tee.holes, key=lambda h: h.stroke_index)]
+        except TypeError:
+            # Tarjeta malformada: se reparte con el orden del campo
+            return []

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -16,6 +16,9 @@ from src.modules.competition.application.exceptions import (
     NotCompetitionCreatorError,
     RoundNotFoundError,
 )
+from src.modules.competition.application.services.tee_context_builder import (
+    TeeContextBuilder,
+)
 from src.modules.competition.domain.entities.match import Match
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
@@ -154,6 +157,7 @@ class GenerateMatchesUseCase:
                 holes_by_stroke_index,
                 user_handicap_map,
                 user_gender_map,
+                holes_by_tee,
             ) = await self._build_handicap_data(
                 golf_course,
                 is_scratch,
@@ -189,6 +193,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
             else:
                 matches_created = await self._generate_auto(
@@ -205,6 +210,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
 
             # 13. Transicionar ronda
@@ -221,6 +227,7 @@ class GenerateMatchesUseCase:
         """Pre-fetch tee ratings, hole stroke order, user handicaps, and user genders."""
         tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
         holes_by_stroke_index: list[int] = []
+        holes_by_tee: dict[tuple[str, str | None], list[int]] = {}
         user_handicap_map: dict[str, Decimal] = {}
         user_gender_map: dict[str, Gender | None] = {}
 
@@ -231,17 +238,10 @@ class GenerateMatchesUseCase:
             )
 
         if golf_course and not is_scratch:
-            for tee in golf_course.tees:
-                total_par = sum(h.par for h in golf_course.holes)
-                gender_key = tee.gender.value if tee.gender else None
-                tee_ratings[(tee.color.value, gender_key)] = TeeRating(
-                    course_rating=Decimal(str(tee.course_rating)),
-                    slope_rating=tee.slope_rating,
-                    par=total_par,
-                )
-            holes_by_stroke_index = [
-                h.number for h in sorted(golf_course.holes, key=lambda h: h.stroke_index)
-            ]
+            context = TeeContextBuilder.build(golf_course)
+            tee_ratings = context.tee_ratings
+            holes_by_stroke_index = context.holes_by_stroke_index
+            holes_by_tee = context.holes_by_tee
 
         if not is_scratch:
             all_player_ids = list(team_assignment.team_a_player_ids) + list(
@@ -262,7 +262,13 @@ class GenerateMatchesUseCase:
                         user_handicap_map[str(pid.value)] = Decimal(str(user.handicap.value))
                     user_gender_map[str(pid.value)] = user.gender
 
-        return tee_ratings, holes_by_stroke_index, user_handicap_map, user_gender_map
+        return (
+            tee_ratings,
+            holes_by_stroke_index,
+            user_handicap_map,
+            user_gender_map,
+            holes_by_tee,
+        )
 
     async def _maybe_refresh_rfeg_handicap(self, user) -> None:
         """
@@ -322,6 +328,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ):
         """Genera partidos automáticamente emparejando por ranking."""
         # Para SINGLES: 1v1, para FOURBALL/FOURSOMES: 2v2
@@ -356,6 +363,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
                 team_a_match_players = [a_player]
                 team_b_match_players = [b_player]
@@ -372,6 +380,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
             elif match_format == MatchFormat.FOURSOMES:
                 team_a_match_players, team_b_match_players = self._build_foursomes_match_players(
@@ -386,6 +395,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
             else:
                 raise ValueError(f"Formato de partido no soportado: {match_format.value}")
@@ -418,6 +428,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ):
         """Genera partidos según emparejamientos manuales."""
         # Validar que todos los jugadores estén inscritos (APPROVED)
@@ -448,6 +459,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
             elif match_format == MatchFormat.FOURSOMES:
                 team_a_match_players, team_b_match_players = self._build_foursomes_match_players(
@@ -462,6 +474,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
             elif match_format == MatchFormat.SINGLES:
                 # SINGLES: método diferencial WHS (solo el jugador con mayor PH recibe golpes)
@@ -477,6 +490,7 @@ class GenerateMatchesUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     max_playing_handicap,
+                    holes_by_tee,
                 )
                 team_a_match_players = [a_player]
                 team_b_match_players = [b_player]
@@ -540,6 +554,21 @@ class GenerateMatchesUseCase:
 
         return tee_color, tee_gender, tee_rating, handicap_index
 
+    @staticmethod
+    def _holes_for_tee(tee_color, tee_gender, holes_by_tee, default):
+        """
+        Orden de dificultad de la barra que juega el jugador.
+
+        Cae al del campo cuando la barra no trae tarjeta propia. Misma reserva de
+        genero que `_resolve_player_data`, para que las dos resuelvan la misma
+        barra.
+        """
+        if not holes_by_tee or tee_color is None:
+            return default
+        color = tee_color.value
+        gender = tee_gender.value if tee_gender else None
+        return holes_by_tee.get((color, gender)) or holes_by_tee.get((color, None)) or default
+
     def _build_match_player(
         self,
         user_id,
@@ -552,6 +581,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ) -> MatchPlayer:
         """Construye un MatchPlayer con handicap calculado y tee auto-resuelto."""
         tee_color, tee_gender, tee_rating, handicap_index = self._resolve_player_data(
@@ -578,7 +608,8 @@ class GenerateMatchesUseCase:
             handicap_index, tee_rating, allowance, max_playing_handicap
         )
         strokes_received = calculator.compute_strokes_received(
-            playing_handicap, holes_by_stroke_index
+            playing_handicap,
+            self._holes_for_tee(tee_color, tee_gender, holes_by_tee, holes_by_stroke_index),
         )
 
         return MatchPlayer.create(
@@ -603,6 +634,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ) -> tuple[list[MatchPlayer], list[MatchPlayer]]:
         """
         Construye MatchPlayers para FOURBALL usando el método diferencial WHS.
@@ -677,7 +709,9 @@ class GenerateMatchesUseCase:
             uid_str = str(uid.value)
             tee_color, tee_gen, _, hi = player_data[uid_str]
             ph = differential_phs[uid_str]
-            strokes = calculator.compute_strokes_received(ph, holes_by_stroke_index)
+            strokes = calculator.compute_strokes_received(
+                ph, self._holes_for_tee(tee_color, tee_gen, holes_by_tee, holes_by_stroke_index)
+            )
             return MatchPlayer.create(
                 user_id=uid,
                 playing_handicap=ph,
@@ -704,6 +738,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ) -> tuple["MatchPlayer", "MatchPlayer"]:
         """
         Construye MatchPlayers para SINGLES usando el método diferencial WHS.
@@ -757,9 +792,12 @@ class GenerateMatchesUseCase:
         ph_a = calculator.calculate(hi_a, tee_rating_a, allowance, max_playing_handicap)
         ph_b = calculator.calculate(hi_b, tee_rating_b, allowance, max_playing_handicap)
 
-        strokes_a, strokes_b = calculator.calculate_singles_differential(
-            ph_a, ph_b, holes_by_stroke_index
-        )
+        # Cada uno recibe en los hoyos de SU barra: solo uno de los dos recibe,
+        # asi que no hay conflicto entre dos ordenes distintos.
+        holes_a = self._holes_for_tee(tee_color_a, tee_gen_a, holes_by_tee, holes_by_stroke_index)
+        holes_b = self._holes_for_tee(tee_color_b, tee_gen_b, holes_by_tee, holes_by_stroke_index)
+        strokes_a, _ = calculator.calculate_singles_differential(ph_a, ph_b, holes_a)
+        _, strokes_b = calculator.calculate_singles_differential(ph_a, ph_b, holes_b)
 
         return (
             MatchPlayer.create(
@@ -793,6 +831,7 @@ class GenerateMatchesUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ) -> tuple[list[MatchPlayer], list[MatchPlayer]]:
         """
         Construye MatchPlayers para FOURSOMES usando el método diferencial WHS.

--- a/src/modules/competition/application/use_cases/generate_matches_use_case.py
+++ b/src/modules/competition/application/use_cases/generate_matches_use_case.py
@@ -34,6 +34,7 @@ from src.modules.competition.domain.value_objects.match_format import MatchForma
 from src.modules.competition.domain.value_objects.match_player import MatchPlayer
 from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.competition.domain.value_objects.round_id import RoundId
+from src.modules.competition.domain.value_objects.round_status import RoundStatus
 from src.modules.golf_course.domain.repositories.golf_course_repository import IGolfCourseRepository
 from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 from src.modules.user.domain.repositories.user_repository_interface import UserRepositoryInterface
@@ -95,8 +96,22 @@ class GenerateMatchesUseCase:
         self._handicap_service = handicap_service
 
     async def execute(
-        self, request: GenerateMatchesRequestDTO, user_id: UserId, is_admin: bool = False
+        self,
+        request: GenerateMatchesRequestDTO,
+        user_id: UserId,
+        is_admin: bool = False,
+        allow_regeneration: bool = False,
     ) -> GenerateMatchesResponseDTO:
+        """
+        Args:
+            allow_regeneration: Admite una ronda ya en SCHEDULED y la reabre
+                DENTRO de esta misma transaccion. Lo usa
+                `scripts/regenerate_scheduled_round_strokes.py` para recalcular
+                el reparto de golpes de rondas ya montadas. Reabrirla fuera
+                dejaria la ronda en PENDING_MATCHES con los partidos viejos si
+                la generacion fallara, y las pasadas siguientes la saltarian por
+                no estar ya en SCHEDULED.
+        """
         async with self._uow:
             # 1. Buscar la ronda
             round_id = RoundId(request.round_id)
@@ -121,6 +136,11 @@ class GenerateMatchesUseCase:
                 )
 
             # 5. Verificar ronda PENDING_MATCHES
+            if allow_regeneration and round_entity.status == RoundStatus.SCHEDULED:
+                # La misma transaccion que borra y recrea los partidos: si algo
+                # falla despues, la ronda vuelve sola a SCHEDULED al deshacerse.
+                round_entity.reopen_for_regeneration()
+
             if not round_entity.can_generate_matches():
                 raise RoundNotPendingMatchesError(
                     f"La ronda debe estar en PENDING_MATCHES. Estado: {round_entity.status.value}"
@@ -554,6 +574,25 @@ class GenerateMatchesUseCase:
 
         return tee_color, tee_gender, tee_rating, handicap_index
 
+    @classmethod
+    def _team_holes(cls, team_ids, player_data, holes_by_tee, default):
+        """
+        Orden de dificultad de un equipo de FOURSOMES.
+
+        Comparten bola, asi que el golpe es del equipo y no puede caer en dos
+        hoyos segun quien golpee: hace falta UNA tarjeta. Si los dos juegan la
+        misma barra, la suya; si no, la del campo, que es lo unico neutral.
+        """
+        tees = {
+            (player_data[str(uid.value)][0], player_data[str(uid.value)][1])
+            for uid in team_ids
+            if str(uid.value) in player_data
+        }
+        if len(tees) != 1:
+            return default
+        tee_color, tee_gender = next(iter(tees))
+        return cls._holes_for_tee(tee_color, tee_gender, holes_by_tee, default)
+
     @staticmethod
     def _holes_for_tee(tee_color, tee_gender, holes_by_tee, default):
         """
@@ -908,9 +947,16 @@ class GenerateMatchesUseCase:
             team_a_chs, team_b_chs, allowance, max_playing_handicap
         )
 
-        # 3. Ambos jugadores del equipo comparten los mismos strokes (una bola)
-        team_a_strokes = calculator.compute_strokes_received(team_a_ph, holes_by_stroke_index)
-        team_b_strokes = calculator.compute_strokes_received(team_b_ph, holes_by_stroke_index)
+        # 3. Ambos jugadores del equipo comparten los mismos strokes (una bola),
+        #    y por tanto un solo orden de dificultad. Se usa el de la barra del
+        #    equipo cuando los dos juegan la misma; si juegan barras distintas no
+        #    hay una tarjeta que sea "la del equipo" y se cae a la del campo.
+        team_a_strokes = calculator.compute_strokes_received(
+            team_a_ph, self._team_holes(team_a_ids, player_data, holes_by_tee, holes_by_stroke_index)
+        )
+        team_b_strokes = calculator.compute_strokes_received(
+            team_b_ph, self._team_holes(team_b_ids, player_data, holes_by_tee, holes_by_stroke_index)
+        )
 
         team_a_players = []
         for uid in team_a_ids:

--- a/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
+++ b/src/modules/competition/application/use_cases/reassign_match_players_use_case.py
@@ -11,6 +11,9 @@ from src.modules.competition.application.exceptions import (
     MatchNotFoundError,
     NotCompetitionCreatorError,
 )
+from src.modules.competition.application.services.tee_context_builder import (
+    TeeContextBuilder,
+)
 from src.modules.competition.domain.entities.match import Match
 from src.modules.competition.domain.repositories.competition_unit_of_work_interface import (
     CompetitionUnitOfWorkInterface,
@@ -108,6 +111,7 @@ class ReassignMatchPlayersUseCase:
                 holes_by_stroke_index,
                 user_handicap_map,
                 user_gender_map,
+                holes_by_tee,
             ) = await self._build_handicap_data(round_entity, is_scratch, all_player_ids)
 
             # 7. Construir nuevos MatchPlayers
@@ -122,6 +126,7 @@ class ReassignMatchPlayersUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     competition.max_playing_handicap,
+                    holes_by_tee,
                 )
                 for uid in request.team_a_player_ids
             ]
@@ -136,6 +141,7 @@ class ReassignMatchPlayersUseCase:
                     holes_by_stroke_index,
                     user_gender_map,
                     competition.max_playing_handicap,
+                    holes_by_tee,
                 )
                 for uid in request.team_b_player_ids
             ]
@@ -164,6 +170,7 @@ class ReassignMatchPlayersUseCase:
         """Pre-fetch tee ratings, hole stroke order, user handicaps, and user genders."""
         tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
         holes_by_stroke_index: list[int] = []
+        holes_by_tee: dict[tuple[str, str | None], list[int]] = {}
         user_handicap_map: dict[str, Decimal] = {}
         user_gender_map: dict[str, Gender | None] = {}
 
@@ -174,17 +181,10 @@ class ReassignMatchPlayersUseCase:
                     "Se requiere un campo de golf para el modo HANDICAP. "
                     "Asocie un campo de golf aprobado a la competición."
                 )
-            total_par = sum(h.par for h in golf_course.holes)
-            for tee in golf_course.tees:
-                gender_key = tee.gender.value if tee.gender else None
-                tee_ratings[(tee.color.value, gender_key)] = TeeRating(
-                    course_rating=Decimal(str(tee.course_rating)),
-                    slope_rating=tee.slope_rating,
-                    par=total_par,
-                )
-            holes_by_stroke_index = [
-                h.number for h in sorted(golf_course.holes, key=lambda h: h.stroke_index)
-            ]
+            context = TeeContextBuilder.build(golf_course)
+            tee_ratings = context.tee_ratings
+            holes_by_stroke_index = context.holes_by_stroke_index
+            holes_by_tee = context.holes_by_tee
 
             users = await asyncio.gather(
                 *(self._user_repo.find_by_id(pid) for pid in all_player_ids)
@@ -195,7 +195,22 @@ class ReassignMatchPlayersUseCase:
                         user_handicap_map[str(pid.value)] = Decimal(str(user.handicap.value))
                     user_gender_map[str(pid.value)] = user.gender
 
-        return tee_ratings, holes_by_stroke_index, user_handicap_map, user_gender_map
+        return (
+            tee_ratings,
+            holes_by_stroke_index,
+            user_handicap_map,
+            user_gender_map,
+            holes_by_tee,
+        )
+
+    @staticmethod
+    def _holes_for_tee(tee_color, tee_gender, holes_by_tee, default):
+        """Orden de dificultad de la barra que juega el jugador (ver TeeContext)."""
+        if not holes_by_tee or tee_color is None:
+            return default
+        color = tee_color.value
+        gender = tee_gender.value if tee_gender else None
+        return holes_by_tee.get((color, gender)) or holes_by_tee.get((color, None)) or default
 
     def _build_match_player(
         self,
@@ -208,6 +223,7 @@ class ReassignMatchPlayersUseCase:
         holes_by_stroke_index,
         user_gender_map,
         max_playing_handicap=None,
+        holes_by_tee=None,
     ) -> MatchPlayer:
         """Construye un MatchPlayer con handicap calculado y tee auto-resuelto."""
         uid = UserId(uid_value)
@@ -253,7 +269,8 @@ class ReassignMatchPlayersUseCase:
             handicap_index, tee_rating, allowance, max_playing_handicap
         )
         strokes_received = self._calculator.compute_strokes_received(
-            playing_handicap, holes_by_stroke_index
+            playing_handicap,
+            self._holes_for_tee(tee_color, tee_gender, holes_by_tee, holes_by_stroke_index),
         )
         return MatchPlayer.create(
             user_id=uid,

--- a/src/modules/competition/domain/entities/match.py
+++ b/src/modules/competition/domain/entities/match.py
@@ -108,11 +108,27 @@ class Match:
         if match_number < 1:
             raise ValueError(f"match_number must be >= 1, got {match_number}")
 
-        # Calcular handicap combinado de cada equipo
-        team_a_handicap = sum(p.playing_handicap for p in team_a_players)
-        team_b_handicap = sum(p.playing_handicap for p in team_b_players)
+        # Golpes de ventaja: se cuentan los que de verdad se reparten en la
+        # vuelta, no se suman los playing_handicap.
+        #
+        # Sumarlos daba el DOBLE en foursomes: los dos jugadores del equipo
+        # llevan el mismo handicap de equipo (comparten bola, ver
+        # `_build_foursomes_match_players`), asi que la suma lo contaba dos
+        # veces y la tarjeta pintaba 14 donde el equipo recibia 7. En fourball
+        # la suma de diferenciales individuales tampoco significaba nada.
+        #
+        # `strokes_received` ya lleva un hoyo por golpe recibido, asi que el
+        # maximo del equipo es la ventaja real en SINGLES (solo recibe uno) y en
+        # FOURSOMES (los dos reciben lo mismo).
+        #
+        # En FOURBALL sigue siendo una aproximacion, y no por este calculo: ahi
+        # cada jugador recibe lo suyo y no existe un "golpes de ventaja del
+        # equipo". Este numero es el del jugador que mas recibe de cada bando, y
+        # se queda como resumen; el reparto de verdad esta en el
+        # `strokes_received` de cada uno, que es lo que decide los hoyos.
+        team_a_handicap = max((len(p.strokes_received) for p in team_a_players), default=0)
+        team_b_handicap = max((len(p.strokes_received) for p in team_b_players), default=0)
 
-        # Determinar golpes de ventaja
         handicap_diff = abs(team_a_handicap - team_b_handicap)
         if team_a_handicap > team_b_handicap:
             strokes_given_to_team = "A"

--- a/src/modules/competition/domain/entities/round.py
+++ b/src/modules/competition/domain/entities/round.py
@@ -186,6 +186,27 @@ class Round:
         self._status = RoundStatus.SCHEDULED
         self._updated_at = datetime.now(UTC).replace(tzinfo=None)
 
+    def reopen_for_regeneration(self) -> None:
+        """
+        Devuelve la ronda a PENDING_MATCHES para poder regenerar sus partidos.
+        Transición: SCHEDULED → PENDING_MATCHES
+
+        Existe para una sola cosa: recalcular el reparto de golpes de rondas que
+        ya tenían partidos generados pero que aún no se han empezado, cuando el
+        cálculo del hándicap se corrige. El reparto se persiste al generar, así
+        que un fallo de cálculo se queda congelado en la base de datos y no se
+        arregla solo al desplegar.
+
+        Solo desde SCHEDULED: en cuanto una ronda arranca hay resultados, y
+        cambiarle los golpes reescribiría hoyos ya jugados.
+        """
+        if self._status != RoundStatus.SCHEDULED:
+            raise ValueError(
+                f"Cannot reopen a round in status {self._status}. Expected SCHEDULED"
+            )
+        self._status = RoundStatus.PENDING_MATCHES
+        self._updated_at = datetime.now(UTC).replace(tzinfo=None)
+
     def start(self) -> None:
         """
         Inicia la sesión (al menos un partido comenzó).

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -235,8 +235,9 @@ class ParticipantStrokesDTO(BaseModel):
 
     participant_id: UUID
     playing_handicap: int
-    # Numeros de hoyo, con repeticion si recibe mas de un golpe en el mismo
-    strokes_received: list[int] = Field(default_factory=list)
+    # Numero de hoyo -> golpes en ese hoyo, CON SIGNO (negativo si los cede, que
+    # es lo que hace un handicap plus). Solo los hoyos con golpe.
+    strokes_by_hole: dict[int, int] = Field(default_factory=dict)
 
 
 class QuickMatchDetailResponseDTO(QuickMatchResponseDTO):

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -43,6 +43,14 @@ class CreateQuickMatchRequestDTO(BaseModel):
     allowance_percentage: int | None = Field(
         None, ge=50, le=100, description="Allowance WHS personalizado (50-100, incrementos de 5)."
     )
+    play_mode: str = Field(
+        "HANDICAP",
+        pattern="^(SCRATCH|HANDICAP)$",
+        description=(
+            "SCRATCH juega a golpes brutos y nadie recibe golpes; HANDICAP aplica "
+            "el reparto WHS. Se omite para el comportamiento habitual (HANDICAP)."
+        ),
+    )
     creator_tee_color: str | None = Field(None, pattern=TEE_COLOR_PATTERN)
     creator_tee_gender: str | None = Field(None, pattern=TEE_GENDER_PATTERN)
 
@@ -173,6 +181,7 @@ class QuickMatchResponseDTO(BaseModel):
     name: str | None = None
     allowance_percentage: int | None = None
     effective_allowance: int
+    play_mode: str = "HANDICAP"
     participants: list[QuickMatchParticipantDTO]
     scorer_ids: list[UUID]
     created_at: datetime
@@ -215,9 +224,25 @@ class ScoringAssignmentDTO(BaseModel):
     covered_participant_ids: list[UUID]
 
 
+class ParticipantStrokesDTO(BaseModel):
+    """
+    Golpes que recibe un participante, ya resueltos por el backend.
+
+    Se expone para que la tarjeta pinte exactamente los mismos golpes que se han
+    usado para decidir cada hoyo. El frontend conserva su propio calculo para
+    poder anotar sin conexion, pero mientras haya red este es el dato bueno.
+    """
+
+    participant_id: UUID
+    playing_handicap: int
+    # Numeros de hoyo, con repeticion si recibe mas de un golpe en el mismo
+    strokes_received: list[int] = Field(default_factory=list)
+
+
 class QuickMatchDetailResponseDTO(QuickMatchResponseDTO):
     """DTO de detalle: partida + scores + standing + reparto de anotacion."""
 
     hole_scores: list[HoleScoreResponseDTO]
     standing: QuickMatchStandingResponseDTO | None = None
     scoring_assignments: list[ScoringAssignmentDTO] = Field(default_factory=list)
+    participant_strokes: list[ParticipantStrokesDTO] = Field(default_factory=list)

--- a/src/modules/quick_match/application/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/application/mappers/quick_match_mapper.py
@@ -73,6 +73,7 @@ class QuickMatchDTOMapper:
             name=quick_match.name,
             allowance_percentage=quick_match.allowance_percentage,
             effective_allowance=quick_match.get_effective_allowance(),
+            play_mode=quick_match.play_mode.value,
             participants=participants_dto,
             scorer_ids=[sid.value for sid in quick_match.scorer_ids],
             created_at=quick_match.created_at,

--- a/src/modules/quick_match/application/services/__init__.py
+++ b/src/modules/quick_match/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Servicios de aplicacion del modulo QuickMatch."""

--- a/src/modules/quick_match/application/services/stroke_context_builder.py
+++ b/src/modules/quick_match/application/services/stroke_context_builder.py
@@ -1,0 +1,73 @@
+"""
+StrokeContextBuilder - Traduce un GolfCourse a lo que necesita el reparto de golpes.
+
+Vive en la capa de aplicacion a proposito: `StrokeAllocationService` es dominio
+puro de `quick_match` y no debe conocer las entidades de `golf_course`. Aqui se
+hace la traduccion, una sola vez, para los dos consumidores que la necesitan
+(el detalle de la partida y el historial de partidas recientes).
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+
+
+@dataclass(frozen=True)
+class StrokeContext:
+    """Datos del campo ya resueltos para repartir golpes."""
+
+    tee_ratings: dict[tuple[str, str | None], TeeRating]
+    holes_by_stroke_index: list[int]
+    par_by_hole: dict[int, int]
+
+    @property
+    def course_par(self) -> int:
+        return sum(self.par_by_hole.values())
+
+
+class StrokeContextBuilder:
+    """Construye el StrokeContext de un campo."""
+
+    @staticmethod
+    def build(golf_course: GolfCourse) -> StrokeContext:
+        """
+        Args:
+            golf_course: Campo donde se juega la partida
+
+        Returns:
+            StrokeContext con los ratings por (color, genero), el orden de hoyos
+            por stroke index y el par de cada hoyo.
+        """
+        holes = sorted(golf_course.holes, key=lambda h: h.number)
+        par_by_hole = {hole.number: hole.par for hole in holes}
+        course_par = sum(par_by_hole.values())
+
+        holes_by_stroke_index = [
+            hole.number for hole in sorted(holes, key=lambda h: h.stroke_index)
+        ]
+
+        tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
+        for tee in golf_course.tees:
+            gender = tee.gender.value if tee.gender else None
+            # El par del tee cuando trae tarjeta propia; si no, el del campo.
+            par = tee.par_total if tee.holes else course_par
+            try:
+                rating = TeeRating(
+                    course_rating=Decimal(str(tee.course_rating)),
+                    slope_rating=tee.slope_rating,
+                    par=par,
+                )
+            except ValueError:
+                # Un tee con ratings fuera del rango WHS (dato importado suelto)
+                # no debe tumbar la partida entera: se omite y quien juegue desde
+                # el cae en el fallback del Handicap Index.
+                continue
+            tee_ratings[(tee.color.value, gender)] = rating
+
+        return StrokeContext(
+            tee_ratings=tee_ratings,
+            holes_by_stroke_index=holes_by_stroke_index,
+            par_by_hole=par_by_hole,
+        )

--- a/src/modules/quick_match/application/services/stroke_context_builder.py
+++ b/src/modules/quick_match/application/services/stroke_context_builder.py
@@ -8,13 +8,27 @@ hace la traduccion, una sola vez, para los dos consumidores que la necesitan
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 
 from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
 
 logger = logging.getLogger(__name__)
+
+# Campos por los que ya se ha avisado en este proceso. El detalle de la partida
+# se pide cada 10 segundos mientras se juega, asi que avisar en cada llamada
+# llenaria el log con la misma linea durante toda la vuelta. Interesa enterarse
+# del campo mal valorado, no contarlo 24 veces por minuto.
+_reported_courses: set[str] = set()
+
+
+def _report_once(course_id, message: str, *args) -> None:
+    key = str(course_id)
+    if key in _reported_courses:
+        return
+    _reported_courses.add(key)
+    logger.warning(message, *args)
 
 
 @dataclass(frozen=True)
@@ -24,6 +38,14 @@ class StrokeContext:
     tee_ratings: dict[tuple[str, str | None], TeeRating]
     holes_by_stroke_index: list[int]
     par_by_hole: dict[int, int]
+    # Orden de dificultad propio de cada barra. `golf_course.holes` es solo la
+    # tarjeta de la PRIMERA barra (ver `GolfCourse._sync_holes_and_tees`), y el
+    # importador de la RFEG guarda una tarjeta por barra: en 56 de los 800
+    # campos federados el stroke index cambia de una a otra. Repartir con el
+    # orden de otra barra pone los golpes en los hoyos equivocados.
+    holes_by_stroke_index_by_tee: dict[tuple[str, str | None], list[int]] = field(
+        default_factory=dict
+    )
 
     @property
     def course_par(self) -> int:
@@ -52,7 +74,8 @@ class StrokeContextBuilder:
             # partida acaba jugandose a bruto — que es justo el fallo que este
             # reparto arregla. Degradar en silencio aqui seria indistinguible del
             # exito, y con 800 campos importados conviene poder contarlo.
-            logger.warning(
+            _report_once(
+                golf_course.id,
                 "Golf course %s has no holes: quick match strokes cannot be allocated",
                 golf_course.id,
             )
@@ -62,8 +85,13 @@ class StrokeContextBuilder:
         ]
 
         tee_ratings: dict[tuple[str, str | None], TeeRating] = {}
+        holes_by_tee: dict[tuple[str, str | None], list[int]] = {}
         for tee in golf_course.tees:
             gender = tee.gender.value if tee.gender else None
+            if tee.holes:
+                holes_by_tee[(tee.color.value, gender)] = [
+                    hole.number for hole in sorted(tee.holes, key=lambda h: h.stroke_index)
+                ]
             # El par del tee cuando trae tarjeta propia; si no, el del campo.
             par = tee.par_total if tee.holes else course_par
             try:
@@ -76,8 +104,10 @@ class StrokeContextBuilder:
                 # Un tee con ratings fuera del rango WHS (dato importado suelto)
                 # no debe tumbar la partida entera: se omite y quien juegue desde
                 # el cae en el fallback del Handicap Index.
-                logger.warning(
-                    "Skipping tee %s (%s) of golf course %s: %s",
+                _report_once(
+                    golf_course.id,
+                    "Skipping tee %s (%s) of golf course %s: %s. "
+                    "Players on it fall back to their Handicap Index.",
                     tee.color.value,
                     gender,
                     golf_course.id,
@@ -90,4 +120,5 @@ class StrokeContextBuilder:
             tee_ratings=tee_ratings,
             holes_by_stroke_index=holes_by_stroke_index,
             par_by_hole=par_by_hole,
+            holes_by_stroke_index_by_tee=holes_by_tee,
         )

--- a/src/modules/quick_match/application/services/stroke_context_builder.py
+++ b/src/modules/quick_match/application/services/stroke_context_builder.py
@@ -7,11 +7,14 @@ hace la traduccion, una sola vez, para los dos consumidores que la necesitan
 (el detalle de la partida y el historial de partidas recientes).
 """
 
+import logging
 from dataclasses import dataclass
 from decimal import Decimal
 
 from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -44,6 +47,16 @@ class StrokeContextBuilder:
         par_by_hole = {hole.number: hole.par for hole in holes}
         course_par = sum(par_by_hole.values())
 
+        if not holes:
+            # Sin tarjeta no hay stroke index con el que repartir, asi que la
+            # partida acaba jugandose a bruto — que es justo el fallo que este
+            # reparto arregla. Degradar en silencio aqui seria indistinguible del
+            # exito, y con 800 campos importados conviene poder contarlo.
+            logger.warning(
+                "Golf course %s has no holes: quick match strokes cannot be allocated",
+                golf_course.id,
+            )
+
         holes_by_stroke_index = [
             hole.number for hole in sorted(holes, key=lambda h: h.stroke_index)
         ]
@@ -59,10 +72,17 @@ class StrokeContextBuilder:
                     slope_rating=tee.slope_rating,
                     par=par,
                 )
-            except ValueError:
+            except ValueError as exc:
                 # Un tee con ratings fuera del rango WHS (dato importado suelto)
                 # no debe tumbar la partida entera: se omite y quien juegue desde
                 # el cae en el fallback del Handicap Index.
+                logger.warning(
+                    "Skipping tee %s (%s) of golf course %s: %s",
+                    tee.color.value,
+                    gender,
+                    golf_course.id,
+                    exc,
+                )
                 continue
             tee_ratings[(tee.color.value, gender)] = rating
 

--- a/src/modules/quick_match/application/use_cases/create_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/create_quick_match_use_case.py
@@ -1,6 +1,7 @@
 """Caso de Uso: Crear una Partida Rapida."""
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
@@ -75,6 +76,7 @@ class CreateQuickMatchUseCase:
             ),
             name=request.name,
             allowance_percentage=request.allowance_percentage,
+            play_mode=PlayMode(request.play_mode),
             creator_tee_color=creator_tee_color,
             creator_tee_gender=creator_tee_gender,
         )

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -155,6 +155,7 @@ class GetQuickMatchUseCase:
             handicaps=self._resolve_handicaps(quick_match, users_by_id),
             tee_ratings=context.tee_ratings,
             holes_by_stroke_index=context.holes_by_stroke_index,
+            holes_by_stroke_index_by_tee=context.holes_by_stroke_index_by_tee,
             match_format=quick_match.match_format,
             allowance_percentage=quick_match.get_effective_allowance(),
             play_mode=quick_match.play_mode,

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -112,7 +112,7 @@ class GetQuickMatchUseCase:
                 ParticipantStrokesDTO(
                     participant_id=ps.participant_id.value,
                     playing_handicap=ps.playing_handicap,
-                    strokes_received=list(ps.strokes_received),
+                    strokes_by_hole=dict(ps.strokes_by_hole),
                 )
                 for ps in strokes_by_participant.values()
             ],
@@ -124,10 +124,20 @@ class GetQuickMatchUseCase:
         """
         Reparte los golpes de handicap de la partida.
 
+        En una partida scratch se sale sin tocar la base de datos: nadie recibe
+        golpes, asi que cargar el campo seria trabajo tirado. Importa porque el
+        detalle se pide cada 10 segundos mientras se juega.
+
         Si el campo no se puede cargar se devuelve un reparto vacio en vez de
         fallar: perder los puntitos de la tarjeta es mucho menos grave que dejar
         la partida inaccesible mientras se esta jugando.
         """
+        if not quick_match.uses_handicap():
+            return {
+                p.participant_id: ParticipantStrokes(p.participant_id, 0, {})
+                for p in quick_match.participants
+            }
+
         async with self._golf_course_uow:
             golf_course = await self._golf_course_uow.golf_courses.find_by_id(
                 quick_match.golf_course_id
@@ -135,7 +145,7 @@ class GetQuickMatchUseCase:
 
         if golf_course is None:
             return {
-                p.participant_id: ParticipantStrokes(p.participant_id, 0, ())
+                p.participant_id: ParticipantStrokes(p.participant_id, 0, {})
                 for p in quick_match.participants
             }
 

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -1,8 +1,14 @@
 """Caso de Uso: Obtener el detalle de una Partida Rapida (con scores y standing)."""
 
+from decimal import Decimal
+
 from src.modules.competition.domain.services.scoring_service import ScoringService
+from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
+    GolfCourseUnitOfWorkInterface,
+)
 from src.modules.quick_match.application.dto.quick_match_dto import (
     HoleScoreResponseDTO,
+    ParticipantStrokesDTO,
     QuickMatchDetailResponseDTO,
     QuickMatchStandingResponseDTO,
     ScoringAssignmentDTO,
@@ -12,11 +18,18 @@ from src.modules.quick_match.application.exceptions import (
     QuickMatchNotFoundError,
 )
 from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
+from src.modules.quick_match.application.services.stroke_context_builder import (
+    StrokeContextBuilder,
+)
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
 )
 from src.modules.quick_match.domain.services.scoring_coverage_service import (
     ScoringCoverageService,
+)
+from src.modules.quick_match.domain.services.stroke_allocation_service import (
+    ParticipantStrokes,
+    StrokeAllocationService,
 )
 from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
@@ -37,11 +50,15 @@ class GetQuickMatchUseCase:
         user_uow: UserUnitOfWorkInterface,
         scoring_service: ScoringService,
         coverage_service: ScoringCoverageService,
+        golf_course_uow: GolfCourseUnitOfWorkInterface,
+        stroke_allocation_service: StrokeAllocationService | None = None,
     ):
         self._uow = uow
         self._user_uow = user_uow
         self._scoring_service = scoring_service
         self._coverage_service = coverage_service
+        self._golf_course_uow = golf_course_uow
+        self._stroke_allocation_service = stroke_allocation_service or StrokeAllocationService()
 
     async def execute(
         self, quick_match_id_raw: str, current_user_id_raw: str
@@ -82,7 +99,8 @@ class GetQuickMatchUseCase:
             for hs in sorted(hole_scores, key=lambda h: h.hole_number)
         ]
 
-        standing_dto = self._compute_standing(quick_match, hole_scores)
+        strokes_by_participant = await self._allocate_strokes(quick_match, users_by_id)
+        standing_dto = self._compute_standing(quick_match, hole_scores, strokes_by_participant)
         assignments_dto = self._build_assignments(quick_match, users_by_id)
 
         return QuickMatchDetailResponseDTO(
@@ -90,7 +108,67 @@ class GetQuickMatchUseCase:
             hole_scores=hole_scores_dto,
             standing=standing_dto,
             scoring_assignments=assignments_dto,
+            participant_strokes=[
+                ParticipantStrokesDTO(
+                    participant_id=ps.participant_id.value,
+                    playing_handicap=ps.playing_handicap,
+                    strokes_received=list(ps.strokes_received),
+                )
+                for ps in strokes_by_participant.values()
+            ],
         )
+
+    async def _allocate_strokes(
+        self, quick_match, users_by_id
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """
+        Reparte los golpes de handicap de la partida.
+
+        Si el campo no se puede cargar se devuelve un reparto vacio en vez de
+        fallar: perder los puntitos de la tarjeta es mucho menos grave que dejar
+        la partida inaccesible mientras se esta jugando.
+        """
+        async with self._golf_course_uow:
+            golf_course = await self._golf_course_uow.golf_courses.find_by_id(
+                quick_match.golf_course_id
+            )
+
+        if golf_course is None:
+            return {
+                p.participant_id: ParticipantStrokes(p.participant_id, 0, ())
+                for p in quick_match.participants
+            }
+
+        context = StrokeContextBuilder.build(golf_course)
+        return self._stroke_allocation_service.allocate(
+            participants=quick_match.participants,
+            handicaps=self._resolve_handicaps(quick_match, users_by_id),
+            tee_ratings=context.tee_ratings,
+            holes_by_stroke_index=context.holes_by_stroke_index,
+            match_format=quick_match.match_format,
+            allowance_percentage=quick_match.get_effective_allowance(),
+            play_mode=quick_match.play_mode,
+        )
+
+    @staticmethod
+    def _resolve_handicaps(quick_match, users_by_id) -> dict[ParticipantId, Decimal | None]:
+        """
+        Handicap Index efectivo de cada participante.
+
+        Misma precedencia que el mapper de presentacion: el override manual del
+        creador gana al del perfil, y un invitado solo tiene el manual.
+        """
+        handicaps: dict[ParticipantId, Decimal | None] = {}
+        for p in quick_match.participants:
+            if p.is_guest:
+                raw = p.handicap
+            elif p.custom_handicap is not None:
+                raw = p.custom_handicap
+            else:
+                user = users_by_id.get(p.user_id)
+                raw = user.handicap.value if user and user.handicap else None
+            handicaps[p.participant_id] = None if raw is None else Decimal(str(raw))
+        return handicaps
 
     def _build_assignments(self, quick_match, users_by_id) -> list[ScoringAssignmentDTO]:
         if not quick_match.scorer_ids:
@@ -116,7 +194,12 @@ class GetQuickMatchUseCase:
             )
         return result
 
-    def _compute_standing(self, quick_match, hole_scores) -> QuickMatchStandingResponseDTO | None:
+    def _compute_standing(
+        self,
+        quick_match,
+        hole_scores,
+        strokes_by_participant: dict[ParticipantId, ParticipantStrokes],
+    ) -> QuickMatchStandingResponseDTO | None:
         if quick_match.match_format is None:
             # Partido libre (MEDAL/STABLEFORD): sin equipos, no hay standing A-vs-B.
             # La clasificacion individual se calcula en el frontend a partir de hole_scores.
@@ -139,8 +222,17 @@ class GetQuickMatchUseCase:
             if not all(pid in scores for pid in team_a_ids | team_b_ids):
                 continue
 
-            team_a_scores = [scores[pid] for pid in team_a_ids]
-            team_b_scores = [scores[pid] for pid in team_b_ids]
+            # `calculate_hole_winner` compara scores NETOS. Pasarle el bruto hacia
+            # que un match play se resolviese siempre a scratch, por mucho
+            # handicap que tuviesen los jugadores.
+            team_a_scores = [
+                self._net(scores[pid], pid, hole_number, strokes_by_participant)
+                for pid in team_a_ids
+            ]
+            team_b_scores = [
+                self._net(scores[pid], pid, hole_number, strokes_by_participant)
+                for pid in team_b_ids
+            ]
             hole_results.append(
                 self._scoring_service.calculate_hole_winner(
                     team_a_scores, team_b_scores, quick_match.match_format
@@ -158,3 +250,15 @@ class GetQuickMatchUseCase:
             holes_remaining=standing["holes_remaining"],
             is_decided=self._scoring_service.is_match_decided(standing),
         )
+
+    @staticmethod
+    def _net(
+        gross_score: int,
+        participant_id: ParticipantId,
+        hole_number: int,
+        strokes_by_participant: dict[ParticipantId, ParticipantStrokes],
+    ) -> int:
+        strokes = strokes_by_participant.get(participant_id)
+        if strokes is None:
+            return gross_score
+        return strokes.net_score(hole_number, gross_score)

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -9,6 +9,7 @@ competition por composicion, no por herencia ni acoplamiento de persistencia.
 from datetime import datetime
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 from src.modules.user.domain.value_objects.user_id import UserId
@@ -84,6 +85,7 @@ class QuickMatch:
         name: str | None = None,
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
+        play_mode: PlayMode = PlayMode.HANDICAP,
         scorer_ids: list[ParticipantId] | None = None,
         hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
@@ -98,6 +100,7 @@ class QuickMatch:
         self._match_format = match_format
         self._scoring_format = scoring_format
         self._allowance_percentage = allowance_percentage
+        self._play_mode = play_mode
         self._status = status
         self._participants = list(participants)
         self._name = self._validate_name(name)
@@ -157,6 +160,7 @@ class QuickMatch:
         scoring_format: ScoringFormat | None = None,
         name: str | None = None,
         allowance_percentage: int | None = None,
+        play_mode: PlayMode = PlayMode.HANDICAP,
         creator_tee_color: TeeColor | None = None,
         creator_tee_gender: Gender | None = None,
     ) -> "QuickMatch":
@@ -167,6 +171,10 @@ class QuickMatch:
         (partido libre, todos contra todos) debe indicarse. allowance_percentage
         personalizado debe ser 50-100 en incrementos de 5; si se omite, se usa el
         default WHS del formato (ver get_effective_allowance()).
+
+        play_mode decide si se aplican handicaps: SCRATCH juega a golpes brutos
+        (nadie recibe golpes, en cualquier formato) y HANDICAP —el default— aplica
+        el reparto WHS. Es el mismo Value Object que usa `Competition.play_mode`.
         """
         now = datetime.now()
         uses_teams = match_format is not None and match_format != MatchFormat.SINGLES
@@ -185,6 +193,7 @@ class QuickMatch:
             match_format=match_format,
             scoring_format=scoring_format,
             allowance_percentage=allowance_percentage,
+            play_mode=play_mode,
             status=QuickMatchStatus.PENDING,
             participants=[creator_participant],
             name=name,
@@ -223,6 +232,7 @@ class QuickMatch:
         name: str | None = None,
         scoring_format: ScoringFormat | None = None,
         allowance_percentage: int | None = None,
+        play_mode: PlayMode = PlayMode.HANDICAP,
         scorer_ids: list[ParticipantId] | None = None,
         hidden_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
@@ -236,6 +246,7 @@ class QuickMatch:
             match_format=match_format,
             scoring_format=scoring_format,
             allowance_percentage=allowance_percentage,
+            play_mode=play_mode,
             status=status,
             participants=participants,
             name=name,
@@ -278,6 +289,21 @@ class QuickMatch:
     def allowance_percentage(self) -> int | None:
         """Allowance personalizado (50-100); None si se usa el default WHS del formato."""
         return self._allowance_percentage
+
+    @property
+    def play_mode(self) -> PlayMode:
+        """SCRATCH (golpes brutos) o HANDICAP (reparto WHS). Default HANDICAP."""
+        return self._play_mode
+
+    def uses_handicap(self) -> bool:
+        """
+        Si esta partida reparte golpes de handicap.
+
+        Se consulta desde el reparto de golpes y desde el calculo del resultado,
+        que son dos sitios distintos: una partida SCRATCH no debe pintar puntos en
+        la tarjeta *ni* restar nada al bruto.
+        """
+        return self._play_mode.allows_handicap()
 
     def get_effective_allowance(self) -> int:
         """

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -296,13 +296,7 @@ class QuickMatch:
         return self._play_mode
 
     def uses_handicap(self) -> bool:
-        """
-        Si esta partida reparte golpes de handicap.
-
-        Se consulta desde el reparto de golpes y desde el calculo del resultado,
-        que son dos sitios distintos: una partida SCRATCH no debe pintar puntos en
-        la tarjeta *ni* restar nada al bruto.
-        """
+        """Si esta partida reparte golpes de handicap (SCRATCH no reparte nada)."""
         return self._play_mode.allows_handicap()
 
     def get_effective_allowance(self) -> int:

--- a/src/modules/quick_match/domain/services/stroke_allocation_service.py
+++ b/src/modules/quick_match/domain/services/stroke_allocation_service.py
@@ -1,0 +1,284 @@
+"""
+StrokeAllocationService - Reparto de golpes de handicap en una partida rapida.
+
+Responde a una sola pregunta: cuantos golpes recibe cada participante en cada
+hoyo. De ahi salen tanto los puntos que pinta la tarjeta como el score neto con
+el que se decide cada hoyo en match play, que hasta ahora eran dos calculos
+distintos (y discrepantes).
+
+El reparto depende del formato, siguiendo el WHS igual que `competition`:
+
+- SCRATCH: nadie recibe golpes, sea cual sea el formato.
+- SINGLES: metodo diferencial. Solo el de mayor Playing Handicap recibe, y
+  recibe la diferencia, en los hoyos de menor stroke index. El otro juega off
+  scratch. Repartir el PH completo a cada uno (lo que hacia el frontend) da un
+  total parecido pero en hoyos distintos, que es justo lo que decide los hoyos
+  ajustados.
+- FOURBALL: diferencias respecto al menor Course Handicap de los cuatro, con el
+  allowance aplicado a la diferencia.
+- FOURSOMES: a nivel de equipo, sobre el promedio de Course Handicaps; los dos
+  jugadores del equipo comparten el mismo reparto porque comparten bola.
+- Partido libre (MEDAL/STABLEFORD): cada uno contra el campo, con su Playing
+  Handicap individual. Aqui el reparto individual SI es el correcto.
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.modules.competition.domain.services.playing_handicap_calculator import (
+    PlayingHandicapCalculator,
+    TeeRating,
+)
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+
+from ..value_objects.participant_id import ParticipantId
+from ..value_objects.quick_match_participant import QuickMatchParticipant
+
+# Un SINGLES es exactamente 1 vs 1: con cualquier otro numero de participantes
+# la partida esta a medio montar y no hay diferencia que repartir.
+SINGLES_PARTICIPANTS = 2
+
+
+@dataclass(frozen=True)
+class ParticipantStrokes:
+    """
+    Golpes que recibe un participante, resueltos para un campo concreto.
+
+    `strokes_received` lleva un numero de hoyo repetido tantas veces como golpes
+    reciba en el (wrap-around cuando el reparto pasa de 18), igual que
+    `MatchPlayer.strokes_received` en `competition`.
+    """
+
+    participant_id: ParticipantId
+    playing_handicap: int
+    strokes_received: tuple[int, ...]
+
+    def strokes_on_hole(self, hole_number: int) -> int:
+        """Golpes en un hoyo concreto (0, 1, 2...)."""
+        return self.strokes_received.count(hole_number)
+
+    def net_score(self, hole_number: int, gross_score: int) -> int:
+        """Score neto en un hoyo, con el mismo suelo de 0 que `HoleScore` en competition."""
+        return max(0, gross_score - self.strokes_on_hole(hole_number))
+
+
+class StrokeAllocationService:
+    """Servicio de dominio puro: sin IO, se le entregan los datos del campo ya resueltos."""
+
+    def __init__(self, calculator: PlayingHandicapCalculator | None = None):
+        self._calculator = calculator or PlayingHandicapCalculator()
+
+    def allocate(
+        self,
+        *,
+        participants: list[QuickMatchParticipant],
+        handicaps: dict[ParticipantId, Decimal | None],
+        tee_ratings: dict[tuple[str, str | None], TeeRating],
+        holes_by_stroke_index: list[int],
+        match_format: MatchFormat | None,
+        allowance_percentage: int,
+        play_mode: PlayMode,
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """
+        Calcula el reparto de golpes de todos los participantes.
+
+        Args:
+            participants: Participantes de la partida (llevan tee_color/tee_gender)
+            handicaps: Handicap Index ya resuelto por participante (custom_handicap,
+                handicap manual del invitado o el del perfil). None si no se conoce.
+            tee_ratings: Ratings por (color, genero); el genero va como str o None
+            holes_by_stroke_index: Numeros de hoyo ordenados por stroke index
+            match_format: SINGLES/FOURBALL/FOURSOMES, o None en partido libre
+            allowance_percentage: Allowance efectivo de la partida (50-100)
+            play_mode: SCRATCH no reparte nada; HANDICAP aplica el reparto WHS
+
+        Returns:
+            dict participant_id -> ParticipantStrokes (una entrada por participante,
+            siempre; los que no reciben golpes salen con la tupla vacia)
+        """
+        if play_mode == PlayMode.SCRATCH:
+            return {p.participant_id: self._no_strokes(p.participant_id) for p in participants}
+
+        if match_format is None:
+            return self._allocate_free_play(
+                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+            )
+
+        if match_format == MatchFormat.SINGLES:
+            return self._allocate_singles(
+                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+            )
+
+        if match_format == MatchFormat.FOURBALL:
+            return self._allocate_fourball(
+                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+            )
+
+        return self._allocate_foursomes(
+            participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+        )
+
+    # ===========================================
+    # Reparto por formato
+    # ===========================================
+
+    def _allocate_free_play(
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """Cada uno contra el campo: su Playing Handicap individual, entero."""
+        result = {}
+        for p in participants:
+            ph = self._playing_handicap(p, handicaps, tee_ratings, allowance)
+            result[p.participant_id] = self._build(p.participant_id, ph, holes_by_stroke_index)
+        return result
+
+    def _allocate_singles(
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """
+        Metodo diferencial WHS: solo el de mayor PH recibe, y recibe la diferencia.
+
+        Con menos de dos participantes (partida a medio montar) no hay contra quien
+        medir la diferencia, asi que nadie recibe.
+        """
+        if len(participants) != SINGLES_PARTICIPANTS:
+            return {p.participant_id: self._no_strokes(p.participant_id) for p in participants}
+
+        a, b = participants
+        ph_a = self._playing_handicap(a, handicaps, tee_ratings, allowance)
+        ph_b = self._playing_handicap(b, handicaps, tee_ratings, allowance)
+
+        strokes_a, strokes_b = self._calculator.calculate_singles_differential(
+            ph_a, ph_b, holes_by_stroke_index
+        )
+        return {
+            a.participant_id: ParticipantStrokes(a.participant_id, ph_a, tuple(strokes_a)),
+            b.participant_id: ParticipantStrokes(b.participant_id, ph_b, tuple(strokes_b)),
+        }
+
+    def _allocate_fourball(
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """Diferencias respecto al menor Course Handicap de los cuatro, con allowance."""
+        course_handicaps = [
+            (str(p.participant_id.value), self._course_handicap(p, handicaps, tee_ratings))
+            for p in participants
+        ]
+        differential_phs = self._calculator.calculate_fourball_differential(
+            course_handicaps, allowance
+        )
+
+        result = {}
+        for p in participants:
+            ph = differential_phs[str(p.participant_id.value)]
+            result[p.participant_id] = self._build(p.participant_id, ph, holes_by_stroke_index)
+        return result
+
+    def _allocate_foursomes(
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+    ) -> dict[ParticipantId, ParticipantStrokes]:
+        """
+        A nivel de equipo: allowance sobre la diferencia de promedios de Course Handicap.
+
+        Los dos jugadores de un equipo reciben exactamente el mismo reparto: juegan
+        una sola bola a golpe alterno, de modo que el golpe es del equipo, no de
+        quien la golpee en ese hoyo.
+        """
+        team_a = [p for p in participants if p.team == "A"]
+        team_b = [p for p in participants if p.team == "B"]
+        if not team_a or not team_b:
+            return {p.participant_id: self._no_strokes(p.participant_id) for p in participants}
+
+        team_a_chs = [self._course_handicap(p, handicaps, tee_ratings) for p in team_a]
+        team_b_chs = [self._course_handicap(p, handicaps, tee_ratings) for p in team_b]
+
+        team_a_ph, team_b_ph = self._calculator.calculate_foursomes_differential(
+            team_a_chs, team_b_chs, allowance
+        )
+
+        result = {}
+        for p in team_a:
+            result[p.participant_id] = self._build(
+                p.participant_id, team_a_ph, holes_by_stroke_index
+            )
+        for p in team_b:
+            result[p.participant_id] = self._build(
+                p.participant_id, team_b_ph, holes_by_stroke_index
+            )
+        return result
+
+    # ===========================================
+    # Helpers
+    # ===========================================
+
+    def _playing_handicap(
+        self,
+        participant: QuickMatchParticipant,
+        handicaps: dict[ParticipantId, Decimal | None],
+        tee_ratings: dict[tuple[str, str | None], TeeRating],
+        allowance: int,
+    ) -> int:
+        """
+        Playing Handicap del participante, con allowance aplicado.
+
+        Sin handicap conocido juega a scratch. Sin un tee que se pueda valorar
+        (no eligio barra, o la barra elegida no esta en el campo) se usa el propio
+        Handicap Index como Playing Handicap: es una aproximacion, pero deja la
+        partida utilizable en vez de tratar al jugador como scratch.
+        """
+        hi = handicaps.get(participant.participant_id)
+        if hi is None:
+            return 0
+
+        tee_rating = self._tee_rating_for(participant, tee_ratings)
+        if tee_rating is None:
+            return max(0, int(hi.to_integral_value()))
+
+        return self._calculator.calculate(hi, tee_rating, allowance)
+
+    def _course_handicap(
+        self,
+        participant: QuickMatchParticipant,
+        handicaps: dict[ParticipantId, Decimal | None],
+        tee_ratings: dict[tuple[str, str | None], TeeRating],
+    ) -> int:
+        """Course Handicap (sin allowance), base de los repartos por equipos."""
+        hi = handicaps.get(participant.participant_id)
+        if hi is None:
+            return 0
+
+        tee_rating = self._tee_rating_for(participant, tee_ratings)
+        if tee_rating is None:
+            return max(0, int(hi.to_integral_value()))
+
+        return self._calculator.calculate_course_handicap(hi, tee_rating)
+
+    @staticmethod
+    def _tee_rating_for(
+        participant: QuickMatchParticipant,
+        tee_ratings: dict[tuple[str, str | None], TeeRating],
+    ) -> TeeRating | None:
+        """
+        Busca la valoracion del tee elegido por (color, genero).
+
+        El genero forma parte de la clave, no es un detalle decorativo: un campo
+        federado valora la misma barra por separado para cada genero y la
+        diferencia de CR/SR entre ambas vale varios golpes.
+        """
+        if participant.tee_color is None:
+            return None
+        gender = participant.tee_gender.value if participant.tee_gender else None
+        return tee_ratings.get((participant.tee_color.value, gender))
+
+    def _build(
+        self, participant_id: ParticipantId, playing_handicap: int, holes_by_stroke_index: list[int]
+    ) -> ParticipantStrokes:
+        strokes = self._calculator.compute_strokes_received(
+            playing_handicap, holes_by_stroke_index
+        )
+        return ParticipantStrokes(participant_id, playing_handicap, tuple(strokes))
+
+    @staticmethod
+    def _no_strokes(participant_id: ParticipantId) -> ParticipantStrokes:
+        return ParticipantStrokes(participant_id, 0, ())

--- a/src/modules/quick_match/domain/services/stroke_allocation_service.py
+++ b/src/modules/quick_match/domain/services/stroke_allocation_service.py
@@ -23,7 +23,7 @@ El reparto depende del formato, siguiendo el WHS igual que `competition`:
 """
 
 from dataclasses import dataclass, field
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
 from src.modules.competition.domain.services.playing_handicap_calculator import (
     PlayingHandicapCalculator,
@@ -86,6 +86,7 @@ class StrokeAllocationService:
         match_format: MatchFormat | None,
         allowance_percentage: int,
         play_mode: PlayMode,
+        holes_by_stroke_index_by_tee: dict[tuple[str, str | None], list[int]] | None = None,
     ) -> dict[ParticipantId, ParticipantStrokes]:
         """
         Calcula el reparto de golpes de todos los participantes.
@@ -95,7 +96,10 @@ class StrokeAllocationService:
             handicaps: Handicap Index ya resuelto por participante (custom_handicap,
                 handicap manual del invitado o el del perfil). None si no se conoce.
             tee_ratings: Ratings por (color, genero); el genero va como str o None
-            holes_by_stroke_index: Numeros de hoyo ordenados por stroke index
+            holes_by_stroke_index: Numeros de hoyo ordenados por stroke index (por defecto)
+            holes_by_stroke_index_by_tee: Orden propio de cada barra, cuando el campo
+                lo trae. En un campo federado el stroke index puede cambiar de una
+                barra a otra, y los golpes van en los hoyos de la barra que se juega
             match_format: SINGLES/FOURBALL/FOURSOMES, o None en partido libre
             allowance_percentage: Allowance efectivo de la partida (50-100)
             play_mode: SCRATCH no reparte nada; HANDICAP aplica el reparto WHS
@@ -107,31 +111,60 @@ class StrokeAllocationService:
         if play_mode == PlayMode.SCRATCH:
             return {p.participant_id: self._no_strokes(p.participant_id) for p in participants}
 
+        # Se pasa como argumento en lugar de guardarlo en el objeto: el servicio
+        # se inyecta como singleton y tiene que seguir siendo puro.
+        by_tee = holes_by_stroke_index_by_tee or {}
+
         if match_format is None:
             return self._allocate_free_play(
-                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+                participants,
+                handicaps,
+                tee_ratings,
+                holes_by_stroke_index,
+                allowance_percentage,
+                by_tee,
             )
 
         if match_format == MatchFormat.SINGLES:
             return self._allocate_singles(
-                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+                participants,
+                handicaps,
+                tee_ratings,
+                holes_by_stroke_index,
+                allowance_percentage,
+                by_tee,
             )
 
         if match_format == MatchFormat.FOURBALL:
             return self._allocate_fourball(
-                participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
+                participants,
+                handicaps,
+                tee_ratings,
+                holes_by_stroke_index,
+                allowance_percentage,
+                by_tee,
             )
 
-        return self._allocate_foursomes(
-            participants, handicaps, tee_ratings, holes_by_stroke_index, allowance_percentage
-        )
+        if match_format == MatchFormat.FOURSOMES:
+            return self._allocate_foursomes(
+                participants,
+                handicaps,
+                tee_ratings,
+                holes_by_stroke_index,
+                allowance_percentage,
+                by_tee,
+            )
+
+        # Un formato nuevo tiene que traer su reparto: caer aqui por descarte le
+        # daria en silencio el de golpe alterno, que casi seguro no es el suyo.
+        raise ValueError(f"No stroke allocation defined for match format {match_format}")
 
     # ===========================================
     # Reparto por formato
     # ===========================================
 
     def _allocate_free_play(
-        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance, by_tee
     ) -> dict[ParticipantId, ParticipantStrokes]:
         """
         Cada uno contra el campo: su Playing Handicap individual, entero.
@@ -145,11 +178,13 @@ class StrokeAllocationService:
             ph = self._playing_handicap(
                 p, handicaps, tee_ratings, allowance, allow_negative=True
             )
-            result[p.participant_id] = self._build(p.participant_id, ph, holes_by_stroke_index)
+            result[p.participant_id] = self._build(
+                p.participant_id, ph, self._holes_for(p, holes_by_stroke_index, by_tee)
+            )
         return result
 
     def _allocate_singles(
-        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance, by_tee
     ) -> dict[ParticipantId, ParticipantStrokes]:
         """
         Metodo diferencial WHS: solo el de mayor PH recibe, y recibe la diferencia.
@@ -168,20 +203,22 @@ class StrokeAllocationService:
         # El PH que se guarda es el individual, para poder mostrarlo; el reparto
         # es la diferencia, y solo la recibe uno de los dos.
         return {
-            a.participant_id: ParticipantStrokes(
+            a.participant_id: self._build(
                 a.participant_id,
-                ph_a,
-                self.allocate_by_hole(max(0, difference), holes_by_stroke_index),
+                max(0, difference),
+                self._holes_for(a, holes_by_stroke_index, by_tee),
+                display_handicap=ph_a,
             ),
-            b.participant_id: ParticipantStrokes(
+            b.participant_id: self._build(
                 b.participant_id,
-                ph_b,
-                self.allocate_by_hole(max(0, -difference), holes_by_stroke_index),
+                max(0, -difference),
+                self._holes_for(b, holes_by_stroke_index, by_tee),
+                display_handicap=ph_b,
             ),
         }
 
     def _allocate_fourball(
-        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance, by_tee
     ) -> dict[ParticipantId, ParticipantStrokes]:
         """Diferencias respecto al menor Course Handicap de los cuatro, con allowance."""
         course_handicaps = [
@@ -194,12 +231,20 @@ class StrokeAllocationService:
 
         result = {}
         for p in participants:
-            ph = differential_phs[str(p.participant_id.value)]
-            result[p.participant_id] = self._build(p.participant_id, ph, holes_by_stroke_index)
+            allocated = differential_phs[str(p.participant_id.value)]
+            # Se guarda el Playing Handicap del jugador, no la diferencia. Si no,
+            # la tarjeta enseña "Hcp de juego 14 - recibe 14 golpes": el mismo
+            # numero dos veces, y ninguno es su handicap de juego.
+            result[p.participant_id] = self._build(
+                p.participant_id,
+                allocated,
+                self._holes_for(p, holes_by_stroke_index, by_tee),
+                display_handicap=self._playing_handicap(p, handicaps, tee_ratings, allowance),
+            )
         return result
 
     def _allocate_foursomes(
-        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
+        self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance, by_tee
     ) -> dict[ParticipantId, ParticipantStrokes]:
         """
         A nivel de equipo: allowance sobre la diferencia de promedios de Course Handicap.
@@ -221,14 +266,20 @@ class StrokeAllocationService:
         )
 
         result = {}
-        for p in team_a:
-            result[p.participant_id] = self._build(
-                p.participant_id, team_a_ph, holes_by_stroke_index
-            )
-        for p in team_b:
-            result[p.participant_id] = self._build(
-                p.participant_id, team_b_ph, holes_by_stroke_index
-            )
+        for team, allocated in ((team_a, team_a_ph), (team_b, team_b_ph)):
+            # Golpe alterno: una sola bola, asi que un solo orden de dificultad
+            # para los dos. Se usa el del campo aunque cada uno juegue una barra
+            # distinta, porque el golpe es del equipo y no puede caer en dos
+            # hoyos segun quien golpee.
+            for p in team:
+                result[p.participant_id] = self._build(
+                    p.participant_id,
+                    allocated,
+                    holes_by_stroke_index,
+                    display_handicap=self._playing_handicap(
+                        p, handicaps, tee_ratings, allowance
+                    ),
+                )
         return result
 
     # ===========================================
@@ -261,7 +312,10 @@ class StrokeAllocationService:
 
         tee_rating = self._tee_rating_for(participant, tee_ratings)
         if tee_rating is None:
-            rounded = int(hi.to_integral_value())
+            # El allowance se aplica igual: sin el, quien no tiene barra
+            # valorable jugaria al 100% de su handicap mientras el resto de la
+            # partida juega al 95%, y saldria ganando por no tener datos.
+            rounded = self._round_half_up(hi * Decimal(allowance) / Decimal(100))
             return rounded if allow_negative else max(0, rounded)
 
         if allow_negative:
@@ -281,7 +335,7 @@ class StrokeAllocationService:
 
         tee_rating = self._tee_rating_for(participant, tee_ratings)
         if tee_rating is None:
-            return max(0, int(hi.to_integral_value()))
+            return max(0, self._round_half_up(hi))
 
         return self._calculator.calculate_course_handicap(hi, tee_rating)
 
@@ -296,20 +350,69 @@ class StrokeAllocationService:
         El genero forma parte de la clave, no es un detalle decorativo: un campo
         federado valora la misma barra por separado para cada genero y la
         diferencia de CR/SR entre ambas vale varios golpes.
+
+        Pero un campo dado de alta a mano puede tener la salida sin genero, y el
+        participante siempre manda color y genero juntos (lo exige el DTO). Sin
+        la reserva a `(color, None)` esa busqueda no acertaria nunca y el jugador
+        caeria al Handicap Index: cinco golpes de diferencia, en silencio. Es la
+        misma reserva que hace `generate_matches_use_case` en competition.
         """
         if participant.tee_color is None:
             return None
+
+        color = participant.tee_color.value
         gender = participant.tee_gender.value if participant.tee_gender else None
-        return tee_ratings.get((participant.tee_color.value, gender))
+        return tee_ratings.get((color, gender)) or tee_ratings.get((color, None))
+
+    @staticmethod
+    def _holes_for(
+        participant: QuickMatchParticipant,
+        default: list[int],
+        by_tee: dict[tuple[str, str | None], list[int]],
+    ) -> list[int]:
+        """
+        Orden de dificultad de la barra que juega el participante.
+
+        Cae al del campo cuando la barra no trae tarjeta propia. Misma reserva de
+        genero que `_tee_rating_for`, para que las dos resuelvan la misma barra.
+        """
+        if participant.tee_color is None:
+            return default
+        color = participant.tee_color.value
+        gender = participant.tee_gender.value if participant.tee_gender else None
+        return by_tee.get((color, gender)) or by_tee.get((color, None)) or default
 
     def _build(
-        self, participant_id: ParticipantId, playing_handicap: int, holes_by_stroke_index: list[int]
+        self,
+        participant_id: ParticipantId,
+        allocated: int,
+        holes_by_stroke_index: list[int],
+        display_handicap: int | None = None,
     ) -> ParticipantStrokes:
+        """
+        Args:
+            allocated: Golpes a repartir (la diferencia, en los formatos por equipos)
+            display_handicap: Playing Handicap del jugador, para mostrar. En match
+                play NO coincide con `allocated`: uno es con lo que juega y el otro
+                lo que recibe.
+        """
         return ParticipantStrokes(
             participant_id,
-            playing_handicap,
-            self.allocate_by_hole(playing_handicap, holes_by_stroke_index),
+            allocated if display_handicap is None else display_handicap,
+            self.allocate_by_hole(allocated, holes_by_stroke_index),
         )
+
+    @staticmethod
+    def _round_half_up(value: Decimal) -> int:
+        """
+        Redondea alejandose del cero, como `PlayingHandicapCalculator`.
+
+        `Decimal.to_integral_value()` usa ROUND_HALF_EVEN por defecto: 20.5 -> 20
+        y 21.5 -> 22. Todo el resto del calculo de handicap usa ROUND_HALF_UP, y
+        el frontend tambien, asi que dejarlo al default partia el empate para el
+        lado contrario en los handicaps acabados en .5, que son de lo mas comun.
+        """
+        return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
     @staticmethod
     def allocate_by_hole(playing_handicap: int, holes_by_stroke_index: list[int]) -> dict[int, int]:

--- a/src/modules/quick_match/domain/services/stroke_allocation_service.py
+++ b/src/modules/quick_match/domain/services/stroke_allocation_service.py
@@ -22,7 +22,7 @@ El reparto depende del formato, siguiendo el WHS igual que `competition`:
   Handicap individual. Aqui el reparto individual SI es el correcto.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 
 from src.modules.competition.domain.services.playing_handicap_calculator import (
@@ -45,22 +45,29 @@ class ParticipantStrokes:
     """
     Golpes que recibe un participante, resueltos para un campo concreto.
 
-    `strokes_received` lleva un numero de hoyo repetido tantas veces como golpes
-    reciba en el (wrap-around cuando el reparto pasa de 18), igual que
-    `MatchPlayer.strokes_received` en `competition`.
+    `strokes_by_hole` va CON SIGNO y solo lleva los hoyos con golpe: positivo si
+    lo recibe, negativo si lo cede. Un jugador de handicap plus cede golpes al
+    campo empezando por el hoyo mas facil (Regla WHS 8.2), y por eso no vale la
+    lista de hoyos repetidos que usa `MatchPlayer` en `competition`: esa no sabe
+    representar un golpe negativo.
     """
 
     participant_id: ParticipantId
     playing_handicap: int
-    strokes_received: tuple[int, ...]
+    strokes_by_hole: dict[int, int] = field(default_factory=dict)
 
     def strokes_on_hole(self, hole_number: int) -> int:
-        """Golpes en un hoyo concreto (0, 1, 2...)."""
-        return self.strokes_received.count(hole_number)
+        """Golpes en un hoyo concreto: 0, 1, 2... o negativo si los cede."""
+        return self.strokes_by_hole.get(hole_number, 0)
 
     def net_score(self, hole_number: int, gross_score: int) -> int:
         """Score neto en un hoyo, con el mismo suelo de 0 que `HoleScore` en competition."""
         return max(0, gross_score - self.strokes_on_hole(hole_number))
+
+    @property
+    def total_strokes(self) -> int:
+        """Suma con signo de los golpes repartidos en la vuelta."""
+        return sum(self.strokes_by_hole.values())
 
 
 class StrokeAllocationService:
@@ -95,7 +102,7 @@ class StrokeAllocationService:
 
         Returns:
             dict participant_id -> ParticipantStrokes (una entrada por participante,
-            siempre; los que no reciben golpes salen con la tupla vacia)
+            siempre; los que no reciben golpes salen con el reparto vacio)
         """
         if play_mode == PlayMode.SCRATCH:
             return {p.participant_id: self._no_strokes(p.participant_id) for p in participants}
@@ -126,10 +133,18 @@ class StrokeAllocationService:
     def _allocate_free_play(
         self, participants, handicaps, tee_ratings, holes_by_stroke_index, allowance
     ) -> dict[ParticipantId, ParticipantStrokes]:
-        """Cada uno contra el campo: su Playing Handicap individual, entero."""
+        """
+        Cada uno contra el campo: su Playing Handicap individual, entero.
+
+        Aqui el Playing Handicap NO se acota a cero. Un jugador de handicap plus
+        cede golpes al campo (Regla WHS 8.2), y acotarlo dejaria la tarjeta
+        contando una cosa y la clasificacion otra.
+        """
         result = {}
         for p in participants:
-            ph = self._playing_handicap(p, handicaps, tee_ratings, allowance)
+            ph = self._playing_handicap(
+                p, handicaps, tee_ratings, allowance, allow_negative=True
+            )
             result[p.participant_id] = self._build(p.participant_id, ph, holes_by_stroke_index)
         return result
 
@@ -148,13 +163,21 @@ class StrokeAllocationService:
         a, b = participants
         ph_a = self._playing_handicap(a, handicaps, tee_ratings, allowance)
         ph_b = self._playing_handicap(b, handicaps, tee_ratings, allowance)
+        difference = ph_a - ph_b
 
-        strokes_a, strokes_b = self._calculator.calculate_singles_differential(
-            ph_a, ph_b, holes_by_stroke_index
-        )
+        # El PH que se guarda es el individual, para poder mostrarlo; el reparto
+        # es la diferencia, y solo la recibe uno de los dos.
         return {
-            a.participant_id: ParticipantStrokes(a.participant_id, ph_a, tuple(strokes_a)),
-            b.participant_id: ParticipantStrokes(b.participant_id, ph_b, tuple(strokes_b)),
+            a.participant_id: ParticipantStrokes(
+                a.participant_id,
+                ph_a,
+                self.allocate_by_hole(max(0, difference), holes_by_stroke_index),
+            ),
+            b.participant_id: ParticipantStrokes(
+                b.participant_id,
+                ph_b,
+                self.allocate_by_hole(max(0, -difference), holes_by_stroke_index),
+            ),
         }
 
     def _allocate_fourball(
@@ -218,6 +241,7 @@ class StrokeAllocationService:
         handicaps: dict[ParticipantId, Decimal | None],
         tee_ratings: dict[tuple[str, str | None], TeeRating],
         allowance: int,
+        allow_negative: bool = False,
     ) -> int:
         """
         Playing Handicap del participante, con allowance aplicado.
@@ -226,6 +250,10 @@ class StrokeAllocationService:
         (no eligio barra, o la barra elegida no esta en el campo) se usa el propio
         Handicap Index como Playing Handicap: es una aproximacion, pero deja la
         partida utilizable en vez de tratar al jugador como scratch.
+
+        `allow_negative` deja pasar el handicap plus. En match play no se usa: la
+        diferencia entre dos Playing Handicaps ya recoge la ventaja, y el WHS
+        acota cada uno a cero antes de restarlos.
         """
         hi = handicaps.get(participant.participant_id)
         if hi is None:
@@ -233,8 +261,11 @@ class StrokeAllocationService:
 
         tee_rating = self._tee_rating_for(participant, tee_ratings)
         if tee_rating is None:
-            return max(0, int(hi.to_integral_value()))
+            rounded = int(hi.to_integral_value())
+            return rounded if allow_negative else max(0, rounded)
 
+        if allow_negative:
+            return self._calculator.calculate_unbounded(hi, tee_rating, allowance)
         return self._calculator.calculate(hi, tee_rating, allowance)
 
     def _course_handicap(
@@ -274,11 +305,44 @@ class StrokeAllocationService:
     def _build(
         self, participant_id: ParticipantId, playing_handicap: int, holes_by_stroke_index: list[int]
     ) -> ParticipantStrokes:
-        strokes = self._calculator.compute_strokes_received(
-            playing_handicap, holes_by_stroke_index
+        return ParticipantStrokes(
+            participant_id,
+            playing_handicap,
+            self.allocate_by_hole(playing_handicap, holes_by_stroke_index),
         )
-        return ParticipantStrokes(participant_id, playing_handicap, tuple(strokes))
+
+    @staticmethod
+    def allocate_by_hole(playing_handicap: int, holes_by_stroke_index: list[int]) -> dict[int, int]:
+        """
+        Reparte un Playing Handicap con signo sobre los hoyos del campo.
+
+        Positivo: se reparte del hoyo mas dificil (stroke index 1) al mas facil,
+        dando la vuelta cuando pasa del numero de hoyos.
+        Negativo (handicap plus): se cede empezando por el mas facil y hacia
+        atras, que es lo que manda la Regla WHS 8.2.
+
+        Solo devuelve los hoyos con golpe, para no arrastrar 18 ceros.
+        """
+        total_holes = len(holes_by_stroke_index)
+        if total_holes == 0 or playing_handicap == 0:
+            return {}
+
+        sign = 1 if playing_handicap > 0 else -1
+        magnitude = abs(playing_handicap)
+        base, remainder = divmod(magnitude, total_holes)
+
+        allocation: dict[int, int] = {}
+        for position, hole_number in enumerate(holes_by_stroke_index):
+            stroke_index = position + 1
+            count = base
+            if sign > 0:
+                count += 1 if remainder >= stroke_index else 0
+            else:
+                count += 1 if remainder >= (total_holes + 1 - stroke_index) else 0
+            if count:
+                allocation[hole_number] = sign * count
+        return allocation
 
     @staticmethod
     def _no_strokes(participant_id: ParticipantId) -> ParticipantStrokes:
-        return ParticipantStrokes(participant_id, 0, ())
+        return ParticipantStrokes(participant_id, 0, {})

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -151,6 +151,7 @@ class CreateQuickMatchBody(BaseModel):
     scoring_format: str | None = Field(None, pattern="^(MEDAL|STABLEFORD)$")
     name: str | None = Field(None, max_length=MAX_NAME_LENGTH)
     allowance_percentage: int | None = Field(None, ge=50, le=100)
+    play_mode: str = Field("HANDICAP", pattern="^(SCRATCH|HANDICAP)$")
     creator_tee_color: str | None = Field(None, pattern=TEE_COLOR_PATTERN)
     creator_tee_gender: str | None = Field(None, pattern=TEE_GENDER_PATTERN)
 
@@ -253,6 +254,7 @@ async def create_quick_match(
             scoring_format=body.scoring_format,
             name=body.name,
             allowance_percentage=body.allowance_percentage,
+            play_mode=body.play_mode,
             creator_tee_color=body.creator_tee_color,
             creator_tee_gender=body.creator_tee_gender,
         )

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -15,6 +15,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.types import CHAR
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
 from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
@@ -171,6 +172,28 @@ class MatchFormatType(sqlalchemy.types.TypeDecorator[MatchFormat]):
         return MatchFormat(value)
 
 
+class PlayModeType(sqlalchemy.types.TypeDecorator[PlayMode]):
+    """
+    TypeDecorator local para PlayMode (VO compartido con `competition`).
+
+    Como MatchFormatType: se comparte el Value Object, no el decorator, para no
+    acoplar la persistencia de los dos modulos.
+    """
+
+    impl = String(20)
+    cache_ok = True
+
+    def process_bind_param(self, value: PlayMode | None, dialect: Any) -> str | None:
+        if value is None:
+            return None
+        return value.value
+
+    def process_result_value(self, value: str | None, dialect: Any) -> PlayMode | None:
+        if value is None:
+            return None
+        return PlayMode(value)
+
+
 class ScoringFormatType(sqlalchemy.types.TypeDecorator[ScoringFormat]):
     """TypeDecorator para ScoringFormat (VO local a quick_match, formato de partido libre)."""
 
@@ -297,6 +320,7 @@ quick_matches_table = Table(
     Column("status", QuickMatchStatusType, nullable=False),
     Column("name", String(100), nullable=True),
     Column("allowance_percentage", Integer, nullable=True),
+    Column("play_mode", PlayModeType, nullable=False, default=PlayMode.HANDICAP),
     Column("participants", QuickMatchParticipantsJsonType, nullable=False),
     Column("scorer_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("hidden_by_participant_ids", ScorerIdsJsonType, nullable=False, default=list),
@@ -352,6 +376,7 @@ def start_quick_match_mappers() -> None:
                 "_status": quick_matches_table.c.status,
                 "_name": quick_matches_table.c.name,
                 "_allowance_percentage": quick_matches_table.c.allowance_percentage,
+                "_play_mode": quick_matches_table.c.play_mode,
                 "_participants": quick_matches_table.c.participants,
                 "_scorer_ids": quick_matches_table.c.scorer_ids,
                 "_hidden_by_participant_ids": quick_matches_table.c.hidden_by_participant_ids,

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -230,18 +230,18 @@ class GetPlayerStatsUseCase:
                 holes = [
                     HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in played
                 ]
-                # Una partida scratch se jugó a bruto: la media de la casa usa
-                # el hándicap con el que se jugó, y ahí no hubo ninguno.
-                # (El diferencial WHS de más abajo no se toca: ignora el
-                # allowance por diseño y el hándicap solo le sirve para el tope
-                # de doble bogey neto.)
-                handicap = (
-                    self._effective_handicap(participant, profile_handicap)
-                    if match.uses_handicap()
-                    else None
-                )
+                # Son DOS hándicaps distintos y no se pueden compartir:
+                #
+                # - La media de la casa usa el hándicap con el que se jugó, y en
+                #   una partida scratch no hubo ninguno.
+                # - El diferencial WHS de más abajo usa siempre el efectivo,
+                #   scratch o no: ahí el hándicap solo sirve para el tope de
+                #   doble bogey neto del Adjusted Gross Score, que es parte de
+                #   la fórmula WHS y no depende de cómo se jugara la partida.
+                effective_handicap = self._effective_handicap(participant, profile_handicap)
+                scoring_handicap = effective_handicap if match.uses_handicap() else None
                 totals = self._calculator.compute_participant_totals(
-                    handicap=handicap,
+                    handicap=scoring_handicap,
                     holes=holes,
                     scores_by_hole=scores_by_hole,
                     allowance_percentage=match.get_effective_allowance(),
@@ -259,7 +259,7 @@ class GetPlayerStatsUseCase:
                             course=course,
                             holes=holes,
                             scores_by_hole=scores_by_hole,
-                            handicap=handicap,
+                            handicap=effective_handicap,
                             tee_color=participant.tee_color,
                             tee_gender=participant.tee_gender,
                         ),

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -230,7 +230,16 @@ class GetPlayerStatsUseCase:
                 holes = [
                     HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in played
                 ]
-                handicap = self._effective_handicap(participant, profile_handicap)
+                # Una partida scratch se jugó a bruto: la media de la casa usa
+                # el hándicap con el que se jugó, y ahí no hubo ninguno.
+                # (El diferencial WHS de más abajo no se toca: ignora el
+                # allowance por diseño y el hándicap solo le sirve para el tope
+                # de doble bogey neto.)
+                handicap = (
+                    self._effective_handicap(participant, profile_handicap)
+                    if match.uses_handicap()
+                    else None
+                )
                 totals = self._calculator.compute_participant_totals(
                     handicap=handicap,
                     holes=holes,

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from datetime import date as date_type
+from decimal import Decimal
 
 from src.modules.competition.domain.entities.match import Match
 from src.modules.competition.domain.entities.round import Round
@@ -14,6 +15,9 @@ from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interf
     GolfCourseUnitOfWorkInterface,
 )
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.services.stroke_context_builder import (
+    StrokeContextBuilder,
+)
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -21,6 +25,9 @@ from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interf
 from src.modules.quick_match.domain.services.stableford_calculator import (
     HoleSetup,
     StablefordCalculator,
+)
+from src.modules.quick_match.domain.services.stroke_allocation_service import (
+    StrokeAllocationService,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
@@ -94,6 +101,7 @@ class GetRecentMatchesUseCase:
         golf_course_uow: GolfCourseUnitOfWorkInterface,
         stableford_calculator: StablefordCalculator | None = None,
         scoring_service: ScoringService | None = None,
+        stroke_allocation_service: StrokeAllocationService | None = None,
     ):
         self._user_uow = user_uow
         self._competition_uow = competition_uow
@@ -101,6 +109,9 @@ class GetRecentMatchesUseCase:
         self._golf_course_uow = golf_course_uow
         self._calculator = stableford_calculator or StablefordCalculator()
         self._scoring_service = scoring_service or ScoringService()
+        self._stroke_allocation_service = (
+            stroke_allocation_service or StrokeAllocationService()
+        )
 
     async def execute(
         self, user_id: UserId, limit: int = DEFAULT_LIMIT
@@ -284,7 +295,7 @@ class GetRecentMatchesUseCase:
         totals = self._participant_totals(raw, course, profile_handicap)
 
         if match.match_format is not None:
-            result, score = self._quick_match_play_outcome(raw)
+            result, score = self._quick_match_play_outcome(raw, course, users_by_id)
         elif totals is not None:
             if match.scoring_format == ScoringFormat.STABLEFORD:
                 score = f"{totals.stableford_points} pts"
@@ -355,7 +366,50 @@ class GetRecentMatchesUseCase:
 
     # ==================== Cálculo ====================
 
-    def _quick_match_play_outcome(self, raw: _QuickMatchRaw) -> tuple[str | None, str | None]:
+    def _quick_match_strokes(
+        self,
+        raw: _QuickMatchRaw,
+        course: GolfCourse | None,
+        users_by_id: dict[UserId, User],
+    ) -> dict:
+        """
+        Reparto de golpes de una partida rápida del historial.
+
+        Sin el campo (borrado, o no cargado) se devuelve un reparto vacío: el
+        resultado sale a bruto, que es peor que nada pero mejor que no poder
+        mostrar el historial.
+        """
+        if course is None:
+            return {}
+
+        context = StrokeContextBuilder.build(course)
+        handicaps = {}
+        for participant in raw.match.participants:
+            if participant.is_guest:
+                value = participant.handicap
+            elif participant.custom_handicap is not None:
+                value = participant.custom_handicap
+            else:
+                user = users_by_id.get(participant.user_id)
+                value = user.handicap.value if user and user.handicap else None
+            handicaps[participant.participant_id] = None if value is None else Decimal(str(value))
+
+        return self._stroke_allocation_service.allocate(
+            participants=raw.match.participants,
+            handicaps=handicaps,
+            tee_ratings=context.tee_ratings,
+            holes_by_stroke_index=context.holes_by_stroke_index,
+            match_format=raw.match.match_format,
+            allowance_percentage=raw.match.get_effective_allowance(),
+            play_mode=raw.match.play_mode,
+        )
+
+    def _quick_match_play_outcome(
+        self,
+        raw: _QuickMatchRaw,
+        course: GolfCourse | None,
+        users_by_id: dict[UserId, User],
+    ) -> tuple[str | None, str | None]:
         """
         Cómo quedó una partida rápida por equipos, desde el lado del jugador.
 
@@ -363,11 +417,17 @@ class GetRecentMatchesUseCase:
         con el mismo motor que usa el detalle de la partida. Solo cuentan los
         hoyos donde anotaron los dos bandos, porque un hoyo a medias no se puede
         adjudicar.
+
+        Los golpes se reparten con el mismo servicio que el detalle: si aquí se
+        compararan los brutos, el historial contaría una película distinta de la
+        que muestra la partida abierta.
         """
         rosters = raw.match.team_rosters()
         if rosters is None:
             return None, None
         team_a_ids, team_b_ids = rosters
+
+        strokes_by_participant = self._quick_match_strokes(raw, course, users_by_id)
 
         hole_results = []
         for hole_number in range(1, TOTAL_HOLES + 1):
@@ -378,10 +438,17 @@ class GetRecentMatchesUseCase:
             }
             if not all(pid in scores for pid in team_a_ids | team_b_ids):
                 continue
+
+            def net(pid, hole=hole_number, values=scores):
+                allocation = strokes_by_participant.get(pid)
+                if allocation is None:
+                    return values[pid]
+                return allocation.net_score(hole, values[pid])
+
             hole_results.append(
                 self._scoring_service.calculate_hole_winner(
-                    [scores[pid] for pid in team_a_ids],
-                    [scores[pid] for pid in team_b_ids],
+                    [net(pid) for pid in team_a_ids],
+                    [net(pid) for pid in team_b_ids],
                     raw.match.match_format,
                 )
             )

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -399,6 +399,7 @@ class GetRecentMatchesUseCase:
             handicaps=handicaps,
             tee_ratings=context.tee_ratings,
             holes_by_stroke_index=context.holes_by_stroke_index,
+            holes_by_stroke_index_by_tee=context.holes_by_stroke_index_by_tee,
             match_format=raw.match.match_format,
             allowance_percentage=raw.match.get_effective_allowance(),
             play_mode=raw.match.play_mode,
@@ -491,8 +492,16 @@ class GetRecentMatchesUseCase:
             return None
 
         holes = [HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in course.holes]
+        # En una partida scratch nadie recibe golpes, tampoco para los puntos
+        # Stableford ni el resultado contra el par: sin esto, una vuelta jugada a
+        # bruto se apuntaba como si le hubieran dado golpes.
+        handicap = (
+            self._effective_handicap(raw.participant, profile_handicap)
+            if raw.match.uses_handicap()
+            else None
+        )
         return self._calculator.compute_participant_totals(
-            handicap=self._effective_handicap(raw.participant, profile_handicap),
+            handicap=handicap,
             holes=holes,
             scores_by_hole=scores_by_hole,
             allowance_percentage=raw.match.get_effective_allowance(),

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -109,3 +109,32 @@ class TestPerTeePar:
 
         assert context.tee_ratings[("YELLOW", "MALE")].par == 72
         assert context.tee_ratings[("RED", "FEMALE")].par == 70
+
+
+class TestFoursomesTeamCard:
+    """
+    En golpe alterno el equipo comparte bola, asi que comparte UNA tarjeta.
+
+    CodeRabbit lo señalo en la PR #208: el reparto de foursomes seguia usando la
+    tarjeta de referencia del campo aunque el equipo entero jugase otra barra.
+    """
+
+    def test_a_team_on_a_single_tee_uses_that_tees_card(self):
+        forward = _card(list(range(1, 19)))
+        backward = _card(list(range(18, 0, -1)))
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140, holes=forward),
+                Tee(color=TeeColor.RED, gender=Gender.FEMALE, course_rating=71.0,
+                    slope_rating=130, holes=backward),
+            ],
+            holes=forward,
+        )
+
+        context = TeeContextBuilder.build(course)
+
+        # Un equipo entero desde rojas reparte con el orden de rojas, no con el
+        # del campo (que es el de amarillas, la primera barra)
+        assert context.holes_for(TeeColor.RED, Gender.FEMALE)[0] == 18
+        assert context.holes_by_stroke_index[0] == 1

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -1,0 +1,111 @@
+"""
+Tests del TeeContextBuilder.
+
+Los dos fallos que motivaron este servicio venian de valorar todas las barras
+contra la tarjeta de referencia del campo: `golf_course.holes` es solo la de la
+PRIMERA barra. De los 800 campos federados importados con mas de una barra con
+tarjeta, 25 tienen par distinto entre barras y 56 stroke index distinto.
+"""
+
+from src.modules.competition.application.services.tee_context_builder import TeeContextBuilder
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+
+def _card(stroke_indices, pars=None):
+    pars = pars or [4] * 18
+    return [
+        Hole(number=i + 1, par=pars[i], stroke_index=stroke_indices[i]) for i in range(18)
+    ]
+
+
+def _course(tees, holes=None):
+    course = GolfCourse.create(
+        name="Test",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=UserId.generate(),
+        tees=tees,
+        holes=holes or _card(list(range(1, 19))),
+    )
+    course.approve()
+    return course
+
+
+class TestPerTeeCard:
+    def test_each_tee_keeps_its_own_stroke_index_order(self):
+        """
+        Given dos barras con stroke index distintos
+        When se construye el contexto
+        Then cada una conserva su propio orden de dificultad
+        """
+        forward = _card(list(range(1, 19)))
+        backward = _card(list(range(18, 0, -1)))
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140, holes=forward),
+                Tee(color=TeeColor.YELLOW, gender=Gender.FEMALE, course_rating=79.4,
+                    slope_rating=147, holes=backward),
+            ],
+            holes=forward,
+        )
+
+        context = TeeContextBuilder.build(course)
+
+        assert context.holes_for(TeeColor.YELLOW, Gender.MALE)[0] == 1
+        # La femenina tiene el orden invertido: su hoyo mas dificil es el 18
+        assert context.holes_for(TeeColor.YELLOW, Gender.FEMALE)[0] == 18
+
+    def test_falls_back_to_the_course_order_without_a_card(self):
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140),
+            ]
+        )
+
+        context = TeeContextBuilder.build(course)
+
+        assert context.holes_for(TeeColor.YELLOW, Gender.MALE) == context.holes_by_stroke_index
+
+    def test_falls_back_to_a_genderless_tee(self):
+        course = _course(
+            [Tee(color=TeeColor.WHITE, gender=None, course_rating=74.0, slope_rating=142)]
+        )
+
+        context = TeeContextBuilder.build(course)
+
+        assert (TeeColor.WHITE.value, None) in context.tee_ratings
+        assert context.holes_for(TeeColor.WHITE, Gender.MALE) == context.holes_by_stroke_index
+
+
+class TestPerTeePar:
+    def test_each_tee_is_rated_against_its_own_par(self):
+        """
+        Given una barra con par 70 en un campo cuya tarjeta de referencia es par 72
+        When se construye el contexto
+        Then esa barra se valora contra 70, no contra 72
+        """
+        par_72 = _card(list(range(1, 19)), pars=[4] * 18)
+        par_70 = _card(list(range(1, 19)), pars=[3, 3] + [4] * 16)
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140, holes=par_72),
+                Tee(color=TeeColor.RED, gender=Gender.FEMALE, course_rating=71.0,
+                    slope_rating=130, holes=par_70),
+            ],
+            holes=par_72,
+        )
+
+        context = TeeContextBuilder.build(course)
+
+        assert context.tee_ratings[("YELLOW", "MALE")].par == 72
+        assert context.tee_ratings[("RED", "FEMALE")].par == 70

--- a/tests/unit/modules/competition/domain/entities/test_round.py
+++ b/tests/unit/modules/competition/domain/entities/test_round.py
@@ -141,6 +141,50 @@ class TestRoundStatusTransitions:
 
         assert round.status == RoundStatus.SCHEDULED
 
+    def _scheduled_round(self, status=None):
+        return Round.reconstruct(
+            id=RoundId.generate(),
+            competition_id=CompetitionId.generate(),
+            golf_course_id=GolfCourseId.generate(),
+            round_date=date(2026, 3, 15),
+            session_type=SessionType.MORNING,
+            match_format=MatchFormat.SINGLES,
+            status=status or RoundStatus.SCHEDULED,
+            handicap_mode=HandicapMode.MATCH_PLAY,
+            allowance_percentage=None,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+    def test_reopen_for_regeneration_from_scheduled(self):
+        """
+        SCHEDULED → PENDING_MATCHES.
+
+        Es la puerta para recalcular el reparto de golpes de una ronda ya
+        montada: el reparto se persiste al generar, así que corregir el cálculo
+        no basta para arreglar las que ya existen.
+        """
+        round = self._scheduled_round()
+
+        round.reopen_for_regeneration()
+
+        assert round.status == RoundStatus.PENDING_MATCHES
+        assert round.can_generate_matches()
+
+    @pytest.mark.parametrize(
+        "status",
+        [RoundStatus.IN_PROGRESS, RoundStatus.COMPLETED, RoundStatus.PENDING_TEAMS],
+    )
+    def test_reopen_for_regeneration_rejects_any_other_status(self, status):
+        """
+        Una ronda empezada no se reabre: ya hay resultados y cambiarle los
+        golpes reescribiría hoyos jugados.
+        """
+        round = self._scheduled_round(status=status)
+
+        with pytest.raises(ValueError, match="Expected SCHEDULED"):
+            round.reopen_for_regeneration()
+
     def test_start_from_scheduled(self):
         """SCHEDULED → IN_PROGRESS."""
         round = Round.reconstruct(

--- a/tests/unit/modules/competition/domain/entities/test_round.py
+++ b/tests/unit/modules/competition/domain/entities/test_round.py
@@ -173,7 +173,12 @@ class TestRoundStatusTransitions:
 
     @pytest.mark.parametrize(
         "status",
-        [RoundStatus.IN_PROGRESS, RoundStatus.COMPLETED, RoundStatus.PENDING_TEAMS],
+        [
+            RoundStatus.PENDING_MATCHES,
+            RoundStatus.IN_PROGRESS,
+            RoundStatus.COMPLETED,
+            RoundStatus.PENDING_TEAMS,
+        ],
     )
     def test_reopen_for_regeneration_rejects_any_other_status(self, status):
         """

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -6,7 +6,9 @@ import pytest
 
 from src.modules.competition.domain.services.scoring_service import ScoringService
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
 from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
 from src.modules.quick_match.application.dto.quick_match_dto import (
     SubmitHoleScoreRequestDTO,
     SubmitProxyHoleScoreRequestDTO,
@@ -34,7 +36,12 @@ from src.modules.quick_match.domain.value_objects.quick_match_participant import
 )
 from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
 from src.modules.user.domain.value_objects.user_id import UserId
-from tests.unit.modules.quick_match.conftest import create_user
+from src.shared.domain.value_objects.gender import Gender
+from tests.unit.modules.quick_match.conftest import (
+    create_golf_course,
+    create_user,
+    unique_email,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -54,13 +61,13 @@ async def _create_in_progress_match(qm_uow, creator_id, other_id):
 
 
 class TestGetQuickMatchUseCase:
-    async def test_participant_can_view_detail(self, qm_uow, user_uow):
+    async def test_participant_can_view_detail(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator@test.com")
         other = await create_user(user_uow, "other@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
         use_case = GetQuickMatchUseCase(
-            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
         )
         detail = await use_case.execute(str(qm.id.value), str(creator.id.value))
 
@@ -74,25 +81,25 @@ class TestGetQuickMatchUseCase:
             other.id.value,
         }
 
-    async def test_non_participant_cannot_view(self, qm_uow, user_uow):
+    async def test_non_participant_cannot_view(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator2@test.com")
         other = await create_user(user_uow, "other2@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
         use_case = GetQuickMatchUseCase(
-            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
         )
         with pytest.raises(NotQuickMatchParticipantError):
             await use_case.execute(str(qm.id.value), str(UserId(uuid4()).value))
 
-    async def test_not_found_raises(self, qm_uow, user_uow):
+    async def test_not_found_raises(self, qm_uow, user_uow, golf_course_uow):
         use_case = GetQuickMatchUseCase(
-            qm_uow, user_uow, ScoringService(), ScoringCoverageService()
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
         )
         with pytest.raises(QuickMatchNotFoundError):
             await use_case.execute(str(uuid4()), str(uuid4()))
 
-    async def test_standing_computed_after_complete_hole(self, qm_uow, user_uow):
+    async def test_standing_computed_after_complete_hole(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator3@test.com")
         other = await create_user(user_uow, "other3@test.com")
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
@@ -119,7 +126,9 @@ class TestGetQuickMatchUseCase:
             )
         )
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         assert len(detail.hole_scores) == 2
@@ -128,12 +137,14 @@ class TestGetQuickMatchUseCase:
         assert detail.standing.leading_team == "A"
         assert detail.standing.status == "1UP"
 
-    async def test_registered_participant_handicap_comes_from_user_profile(self, qm_uow, user_uow):
+    async def test_registered_participant_handicap_comes_from_user_profile(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator-hcp@test.com", handicap=12.4)
         other = await create_user(user_uow, "other-hcp@test.com", handicap=None)
         qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         creator_dto = next(p for p in detail.participants if p.user_id == creator.id.value)
@@ -141,7 +152,7 @@ class TestGetQuickMatchUseCase:
         assert creator_dto.handicap == 12.4
         assert other_dto.handicap is None
 
-    async def test_free_play_standing_is_always_none(self, qm_uow, user_uow):
+    async def test_free_play_standing_is_always_none(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator-freeplay@test.com")
         other = await create_user(user_uow, "other-freeplay@test.com")
         qm = QuickMatch.create(
@@ -165,9 +176,138 @@ class TestGetQuickMatchUseCase:
             )
         )
 
-        get_uc = GetQuickMatchUseCase(qm_uow, user_uow, ScoringService(), ScoringCoverageService())
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
         detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
 
         assert detail.match_format is None
         assert detail.scoring_format == "STABLEFORD"
         assert detail.standing is None
+
+
+class TestStandingAppliesHandicap:
+    """
+    El standing de match play se calcula con scores NETOS.
+
+    Antes se le pasaban los brutos a `calculate_hole_winner`, cuya firma pide
+    netos, de modo que un 1 vs 1 se resolvia siempre a scratch por mucho
+    handicap que tuviesen los jugadores.
+    """
+
+    async def _match_on_real_course(self, qm_uow, golf_course_uow, creator, other, play_mode):
+        golf_course = await create_golf_course(golf_course_uow, creator.id)
+        qm = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=creator.id,
+            golf_course_id=golf_course.id,
+            match_format=MatchFormat.SINGLES,
+            play_mode=play_mode,
+            creator_tee_color=TeeColor.YELLOW,
+            creator_tee_gender=Gender.MALE,
+        )
+        qm.add_participant(
+            QuickMatchParticipant.for_user(
+                other.id, tee_color=TeeColor.YELLOW, tee_gender=Gender.MALE
+            )
+        )
+        qm.start([qm.creator_participant_id])
+        async with qm_uow:
+            await qm_uow.quick_matches.add(qm)
+        return qm
+
+    async def _score_hole(self, qm_uow, qm, creator, other, hole, creator_score, other_score):
+        submit_uc = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        await submit_uc.execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=creator.id.value,
+                hole_number=hole,
+                score=creator_score,
+            )
+        )
+        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
+        await proxy_uc.execute(
+            SubmitProxyHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=other.id.value,
+                hole_number=hole,
+                score=other_score,
+            )
+        )
+
+    async def test_higher_handicap_wins_the_hole_thanks_to_the_stroke(
+        self, qm_uow, user_uow, golf_course_uow
+    ):
+        """
+        Given un jugador de 5.0 y otro de 20.0 en el hoyo de stroke index 1
+        When empatan a golpes brutos
+        Then gana el de mas handicap, porque recibe golpe en ese hoyo
+        """
+        creator = await create_user(user_uow, unique_email("scratch-a"), handicap=5.0)
+        other = await create_user(user_uow, unique_email("scratch-b"), handicap=20.0)
+        qm = await self._match_on_real_course(
+            qm_uow, golf_course_uow, creator, other, PlayMode.HANDICAP
+        )
+
+        # Hoyo 1 = stroke index 1 en el campo de prueba. Empate a 5 golpes brutos.
+        await self._score_hole(qm_uow, qm, creator, other, hole=1, creator_score=5, other_score=5)
+
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
+        detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is not None
+        assert detail.standing.leading_team == "B"
+        assert detail.standing.status == "1UP"
+
+    async def test_scratch_mode_ignores_the_handicap(self, qm_uow, user_uow, golf_course_uow):
+        """
+        Given la misma pareja y el mismo empate bruto, pero la partida en SCRATCH
+        When se calcula el standing
+        Then el hoyo queda empatado: nadie recibe golpes
+        """
+        creator = await create_user(user_uow, unique_email("scratch-c"), handicap=5.0)
+        other = await create_user(user_uow, unique_email("scratch-d"), handicap=20.0)
+        qm = await self._match_on_real_course(
+            qm_uow, golf_course_uow, creator, other, PlayMode.SCRATCH
+        )
+
+        await self._score_hole(qm_uow, qm, creator, other, hole=1, creator_score=5, other_score=5)
+
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
+        detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is not None
+        assert detail.standing.leading_team is None
+        assert detail.play_mode == "SCRATCH"
+        assert all(ps.strokes_received == [] for ps in detail.participant_strokes)
+
+    async def test_detail_exposes_the_strokes_used_to_decide_the_holes(
+        self, qm_uow, user_uow, golf_course_uow
+    ):
+        """La tarjeta debe pintar los mismos golpes que han decidido los hoyos."""
+        creator = await create_user(user_uow, unique_email("scratch-e"), handicap=5.0)
+        other = await create_user(user_uow, unique_email("scratch-f"), handicap=20.0)
+        qm = await self._match_on_real_course(
+            qm_uow, golf_course_uow, creator, other, PlayMode.HANDICAP
+        )
+
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
+        detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
+
+        by_participant = {ps.participant_id: ps for ps in detail.participant_strokes}
+        creator_strokes = by_participant[creator.id.value]
+        other_strokes = by_participant[other.id.value]
+
+        # Reparto diferencial: solo recibe el de mas handicap
+        assert creator_strokes.strokes_received == []
+        assert len(other_strokes.strokes_received) > 0
+        # Y recibe en los hoyos mas dificiles: el campo de prueba tiene SI = numero de hoyo
+        assert min(other_strokes.strokes_received) == 1

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -285,7 +285,7 @@ class TestStandingAppliesHandicap:
         assert detail.standing is not None
         assert detail.standing.leading_team is None
         assert detail.play_mode == "SCRATCH"
-        assert all(ps.strokes_received == [] for ps in detail.participant_strokes)
+        assert all(ps.strokes_by_hole == {} for ps in detail.participant_strokes)
 
     async def test_detail_exposes_the_strokes_used_to_decide_the_holes(
         self, qm_uow, user_uow, golf_course_uow
@@ -307,7 +307,7 @@ class TestStandingAppliesHandicap:
         other_strokes = by_participant[other.id.value]
 
         # Reparto diferencial: solo recibe el de mas handicap
-        assert creator_strokes.strokes_received == []
-        assert len(other_strokes.strokes_received) > 0
+        assert creator_strokes.strokes_by_hole == {}
+        assert other_strokes.strokes_by_hole
         # Y recibe en los hoyos mas dificiles: el campo de prueba tiene SI = numero de hoyo
-        assert min(other_strokes.strokes_received) == 1
+        assert min(other_strokes.strokes_by_hole) == 1

--- a/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
@@ -467,3 +467,169 @@ class TestAllocateByHole:
 
     def test_no_holes_allocates_nothing(self, service):
         assert service.allocate_by_hole(10, []) == {}
+
+
+class TestReviewFindings:
+    """
+    Casos que el code review destapó y que no tenían ni un test.
+
+    Todos comparten el mismo patrón: el reparto salía silenciosamente distinto
+    del que espera el WHS o del que calcula el frontend, sin que nada fallase.
+    """
+
+    def test_falls_back_to_a_genderless_tee(self, service):
+        """
+        Given un campo dado de alta a mano, con la salida sin genero
+        When un participante la elige (el DTO le obliga a mandar color y genero)
+        Then se encuentra igual, en vez de caer al Handicap Index
+
+        Sin la reserva a (color, None) la busqueda no acertaba nunca: un 18.0
+        salia con 18 golpes en vez de 23. Cinco de diferencia, en silencio.
+        """
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("18.0")},
+            tee_ratings={("YELLOW", None): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[a.participant_id].playing_handicap == 23
+
+    def test_allocates_on_the_holes_of_the_tee_being_played(self, service):
+        """
+        Given dos barras del mismo campo con stroke index distintos
+        When cada jugador juega la suya
+        Then cada uno recibe en los hoyos de SU barra
+
+        Pasa en 56 de los 800 campos federados importados. `golf_course.holes`
+        es solo la tarjeta de la primera barra, asi que sin esto el que juega la
+        otra recibia los golpes en los hoyos equivocados.
+        """
+        her = _guest("Ella", 20.0, TeeColor.YELLOW, Gender.FEMALE)
+
+        # Su barra tiene el orden invertido respecto al del campo
+        reversed_order = list(range(18, 0, -1))
+
+        result = service.allocate(
+            participants=[her],
+            handicaps={her.participant_id: Decimal("20.0")},
+            tee_ratings={("YELLOW", "FEMALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+            holes_by_stroke_index_by_tee={("YELLOW", "FEMALE"): reversed_order},
+        )
+
+        strokes = result[her.participant_id]
+        # PH 25: dos golpes en los 7 mas dificiles de SU barra, que son el 18..12
+        assert strokes.strokes_on_hole(18) == 2
+        assert strokes.strokes_on_hole(1) == 1
+
+    def test_allowance_also_applies_without_a_usable_tee(self, service):
+        """
+        Given un participante sin barra valorable en un partido libre al 95%
+        When se calcula su reparto
+        Then el allowance se le aplica igual
+
+        Antes jugaba al 100% de su handicap mientras el resto de la partida
+        jugaba al 95%: salia ganando por no tener datos.
+        """
+        a = _guest("A", 20.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("20.0")},
+            tee_ratings={},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=95,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        # 20 x 0.95 = 19, no 20
+        assert result[a.participant_id].playing_handicap == 19
+
+    def test_rounds_half_away_from_zero_like_the_rest_of_the_calculation(self, service):
+        """
+        Given un Handicap Index acabado en .5 y sin barra valorable
+        When se redondea
+        Then se aleja del cero, como `PlayingHandicapCalculator` y el frontend
+
+        `Decimal.to_integral_value()` redondea al par por defecto: 20.5 -> 20.
+        El resto del calculo usa ROUND_HALF_UP, asi que partia el empate para el
+        lado contrario justo en los handicaps acabados en .5.
+        """
+        a = _guest("A", 20.5, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("20.5")},
+            tee_ratings={},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[a.participant_id].playing_handicap == 21
+
+    def test_fourball_shows_the_playing_handicap_not_the_difference(self, service):
+        """
+        Given un fourball
+        When se reparte
+        Then cada uno conserva SU handicap de juego, aunque reciba la diferencia
+
+        Guardar el diferencial ahi hacia que la tarjeta dijese "Hcp de juego 14
+        - recibe 14 golpes": el mismo numero dos veces, y ninguno era su
+        handicap de juego.
+        """
+        players = [
+            _guest("A1", 5.0, TeeColor.YELLOW, Gender.MALE, team="A"),
+            _guest("A2", 15.0, TeeColor.YELLOW, Gender.MALE, team="A"),
+            _guest("B1", 20.0, TeeColor.YELLOW, Gender.MALE, team="B"),
+            _guest("B2", 25.0, TeeColor.YELLOW, Gender.MALE, team="B"),
+        ]
+
+        result = service.allocate(
+            participants=players,
+            handicaps={
+                p.participant_id: Decimal(str(hi))
+                for p, hi in zip(players, [5, 15, 20, 25], strict=True)
+            },
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.FOURBALL,
+            allowance_percentage=90,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        best = result[players[0].participant_id]
+        worst = result[players[3].participant_id]
+        # El mejor juega off scratch pero conserva su handicap de juego
+        assert best.total_strokes == 0
+        assert best.playing_handicap > 0
+        # Y el peor recibe menos golpes de los que dice su handicap de juego
+        assert worst.playing_handicap > worst.total_strokes
+
+    def test_an_unknown_match_format_fails_loudly(self, service):
+        """Un formato nuevo sin reparto propio no debe caer en el de golpe alterno."""
+
+        class FakeFormat:
+            value = "SCRAMBLE"
+
+        with pytest.raises(ValueError, match="No stroke allocation defined"):
+            service.allocate(
+                participants=[],
+                handicaps={},
+                tee_ratings={},
+                holes_by_stroke_index=_holes_by_stroke_index(),
+                match_format=FakeFormat(),
+                allowance_percentage=100,
+                play_mode=PlayMode.HANDICAP,
+            )

--- a/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
@@ -1,0 +1,357 @@
+"""
+Tests del StrokeAllocationService — reparto de golpes en partida rapida.
+
+El caso que abre el fichero es real: la partida "Prueba" en Golf de Meis que
+destapo el fallo. Un jugador de 18 salia recibiendo 31 golpes y su rival de 20.7
+solo 27, y ademas el resultado se decidia a golpes brutos. Los numeros de ese
+test son los del campo federado, no inventados.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.modules.competition.domain.services.playing_handicap_calculator import TeeRating
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.competition.domain.value_objects.play_mode import PlayMode
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.quick_match.domain.services.stroke_allocation_service import (
+    StrokeAllocationService,
+)
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.shared.domain.value_objects.gender import Gender
+
+# Golf de Meis (RFEG id 487), recorrido Par 72. Amarillas valoradas por genero.
+MEIS_AMARILLAS_M = TeeRating(course_rating=Decimal("73.1"), slope_rating=140, par=72)
+MEIS_AMARILLAS_F = TeeRating(course_rating=Decimal("79.4"), slope_rating=147, par=72)
+
+# Stroke index reales de Meis, hoyo 1..18
+MEIS_STROKE_INDEX = [7, 1, 13, 5, 15, 9, 3, 11, 17, 16, 2, 14, 12, 8, 18, 6, 4, 10]
+
+
+def _holes_by_stroke_index(stroke_index_by_hole: list[int] | None = None) -> list[int]:
+    """Numeros de hoyo ordenados del mas dificil (SI 1) al mas facil (SI 18)."""
+    stroke_index_by_hole = stroke_index_by_hole or list(range(1, 19))
+    holes = list(range(1, len(stroke_index_by_hole) + 1))
+    return sorted(holes, key=lambda h: stroke_index_by_hole[h - 1])
+
+
+def _guest(name: str, handicap: float, color: TeeColor, gender: Gender | None, team=None):
+    return QuickMatchParticipant(
+        participant_id=ParticipantId.generate(),
+        user_id=None,
+        first_name=name,
+        last_name="Test",
+        handicap=handicap,
+        team=team,
+        tee_color=color,
+        tee_gender=gender,
+    )
+
+
+@pytest.fixture
+def service() -> StrokeAllocationService:
+    return StrokeAllocationService()
+
+
+class TestSinglesMeisRegression:
+    """El caso real que destapo el fallo (partida 'Prueba', Golf de Meis)."""
+
+    def test_singles_gives_strokes_only_to_the_higher_handicap(self, service):
+        """
+        Given un 18.0 y un 20.7, ambos desde Amarillas masculino de Meis
+        When se reparte el handicap del match play
+        Then solo recibe el de 20.7, y recibe la diferencia (4 golpes)
+        """
+        me = _guest("Agustin", 18.0, TeeColor.YELLOW, Gender.MALE)
+        rival = _guest("Alberto", 20.7, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[me, rival],
+            handicaps={
+                me.participant_id: Decimal("18.0"),
+                rival.participant_id: Decimal("20.7"),
+            },
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(MEIS_STROKE_INDEX),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        # Playing Handicaps individuales: 18.0 -> 23, 20.7 -> 27
+        assert result[me.participant_id].playing_handicap == 23
+        assert result[rival.participant_id].playing_handicap == 27
+
+        # Pero el reparto es diferencial: el de menos PH juega off scratch
+        assert result[me.participant_id].strokes_received == ()
+        # 27 - 23 = 4 golpes, en los hoyos de SI 1, 2, 3 y 4 -> hoyos 2, 11, 7 y 17
+        assert sorted(result[rival.participant_id].strokes_received) == [2, 7, 11, 17]
+
+    def test_lower_handicap_never_receives_more_than_the_higher_one(self, service):
+        """
+        Given el 18.0 desde la barra femenina y el 20.7 desde la masculina
+        When se reparte el handicap
+        Then el reparto sigue al Playing Handicap, no al Handicap Index
+
+        Es el escenario exacto de la captura: la barra femenina de Meis esta
+        valorada 6.3 de CR y 7 de slope por encima de la masculina, asi que el
+        18.0 saca mas Playing Handicap. Lo que el reparto diferencial garantiza
+        es que solo uno de los dos recibe, nunca los dos a la vez.
+        """
+        me = _guest("Agustin", 18.0, TeeColor.YELLOW, Gender.FEMALE)
+        rival = _guest("Alberto", 20.7, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[me, rival],
+            handicaps={
+                me.participant_id: Decimal("18.0"),
+                rival.participant_id: Decimal("20.7"),
+            },
+            tee_ratings={
+                ("YELLOW", "MALE"): MEIS_AMARILLAS_M,
+                ("YELLOW", "FEMALE"): MEIS_AMARILLAS_F,
+            },
+            holes_by_stroke_index=_holes_by_stroke_index(MEIS_STROKE_INDEX),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[me.participant_id].playing_handicap == 31
+        assert result[rival.participant_id].playing_handicap == 27
+
+        # Uno de los dos recibe; el otro, nada. Nunca los dos.
+        assert result[rival.participant_id].strokes_received == ()
+        assert len(result[me.participant_id].strokes_received) == 4
+
+
+class TestScratch:
+    """SCRATCH no reparte nada, en ningun formato."""
+
+    @pytest.mark.parametrize(
+        "match_format",
+        [MatchFormat.SINGLES, MatchFormat.FOURBALL, MatchFormat.FOURSOMES, None],
+    )
+    def test_scratch_gives_nobody_strokes(self, service, match_format):
+        a = _guest("A", 5.0, TeeColor.YELLOW, Gender.MALE, team="A")
+        b = _guest("B", 30.0, TeeColor.YELLOW, Gender.MALE, team="B")
+
+        result = service.allocate(
+            participants=[a, b],
+            handicaps={a.participant_id: Decimal("5.0"), b.participant_id: Decimal("30.0")},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=match_format,
+            allowance_percentage=100,
+            play_mode=PlayMode.SCRATCH,
+        )
+
+        assert all(ps.strokes_received == () for ps in result.values())
+        assert all(ps.playing_handicap == 0 for ps in result.values())
+
+
+class TestFreePlay:
+    """Partido libre: cada uno contra el campo, con su PH entero."""
+
+    def test_each_participant_keeps_their_own_playing_handicap(self, service):
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+        b = _guest("B", 20.7, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a, b],
+            handicaps={a.participant_id: Decimal("18.0"), b.participant_id: Decimal("20.7")},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(MEIS_STROKE_INDEX),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        # 23 y 27 golpes repartidos: los dos reciben, no hay diferencial
+        assert len(result[a.participant_id].strokes_received) == 23
+        assert len(result[b.participant_id].strokes_received) == 27
+
+    def test_allowance_reduces_the_playing_handicap(self, service):
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("18.0")},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=95,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        # CH 23.40 -> x0.95 = 22.23 -> 22
+        assert result[a.participant_id].playing_handicap == 22
+
+
+class TestFallbacks:
+    """Datos incompletos: la partida sigue siendo jugable."""
+
+    def test_participant_without_handicap_plays_scratch(self, service):
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+        b = _guest("B", 20.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a, b],
+            handicaps={a.participant_id: Decimal("18.0"), b.participant_id: None},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[b.participant_id].playing_handicap == 0
+        # A tiene PH 23 frente a 0: recibe la diferencia entera
+        assert len(result[a.participant_id].strokes_received) == 23
+
+    def test_unknown_tee_falls_back_to_the_handicap_index(self, service):
+        """Sin barra valorada se usa el propio HI, en vez de tratarlo como scratch."""
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+        b = _guest("B", 20.7, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a, b],
+            handicaps={
+                a.participant_id: Decimal("18.0"),
+                b.participant_id: Decimal("20.7"),
+            },
+            tee_ratings={},  # el campo no tiene esa barra
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[a.participant_id].playing_handicap == 18
+        assert result[b.participant_id].playing_handicap == 21
+        assert len(result[b.participant_id].strokes_received) == 3
+
+    def test_incomplete_singles_roster_gives_nobody_strokes(self, service):
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("18.0")},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[a.participant_id].strokes_received == ()
+
+
+class TestFoursomes:
+    """Golpe alterno: el golpe es del equipo, no del jugador."""
+
+    def test_both_team_members_share_the_same_allocation(self, service):
+        a1 = _guest("A1", 10.0, TeeColor.YELLOW, Gender.MALE, team="A")
+        a2 = _guest("A2", 12.0, TeeColor.YELLOW, Gender.MALE, team="A")
+        b1 = _guest("B1", 20.0, TeeColor.YELLOW, Gender.MALE, team="B")
+        b2 = _guest("B2", 24.0, TeeColor.YELLOW, Gender.MALE, team="B")
+
+        result = service.allocate(
+            participants=[a1, a2, b1, b2],
+            handicaps={
+                a1.participant_id: Decimal("10.0"),
+                a2.participant_id: Decimal("12.0"),
+                b1.participant_id: Decimal("20.0"),
+                b2.participant_id: Decimal("24.0"),
+            },
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.FOURSOMES,
+            allowance_percentage=50,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert (
+            result[a1.participant_id].strokes_received
+            == result[a2.participant_id].strokes_received
+        )
+        assert (
+            result[b1.participant_id].strokes_received
+            == result[b2.participant_id].strokes_received
+        )
+        # Solo recibe el equipo de mayor CH promedio
+        assert result[a1.participant_id].strokes_received == ()
+        assert len(result[b1.participant_id].strokes_received) > 0
+
+
+class TestFourball:
+    """Mejor bola: diferencias respecto al menor Course Handicap de los cuatro."""
+
+    def test_lowest_course_handicap_plays_off_scratch(self, service):
+        players = [
+            _guest("A1", 5.0, TeeColor.YELLOW, Gender.MALE, team="A"),
+            _guest("A2", 15.0, TeeColor.YELLOW, Gender.MALE, team="A"),
+            _guest("B1", 20.0, TeeColor.YELLOW, Gender.MALE, team="B"),
+            _guest("B2", 25.0, TeeColor.YELLOW, Gender.MALE, team="B"),
+        ]
+
+        result = service.allocate(
+            participants=players,
+            handicaps={p.participant_id: Decimal(str(hi)) for p, hi in zip(players, [5, 15, 20, 25], strict=True)},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.FOURBALL,
+            allowance_percentage=90,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[players[0].participant_id].strokes_received == ()
+        # Y el resto recibe en orden creciente de handicap
+        counts = [len(result[p.participant_id].strokes_received) for p in players]
+        assert counts == sorted(counts)
+
+
+class TestParticipantStrokes:
+    """El objeto que consumen la tarjeta y el calculo del resultado."""
+
+    def test_net_score_subtracts_the_strokes_of_that_hole(self, service):
+        a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
+        b = _guest("B", 20.7, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a, b],
+            handicaps={
+                a.participant_id: Decimal("18.0"),
+                b.participant_id: Decimal("20.7"),
+            },
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(MEIS_STROKE_INDEX),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        rival = result[b.participant_id]
+        assert rival.strokes_on_hole(2) == 1  # SI 1
+        assert rival.strokes_on_hole(15) == 0  # SI 18
+        assert rival.net_score(2, 6) == 5
+        assert rival.net_score(15, 6) == 6
+
+    def test_net_score_never_goes_below_zero(self, service):
+        a = _guest("A", 54.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("54.0")},
+            tee_ratings={("YELLOW", "MALE"): MEIS_AMARILLAS_M},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[a.participant_id].net_score(1, 1) == 0

--- a/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
@@ -87,9 +87,9 @@ class TestSinglesMeisRegression:
         assert result[rival.participant_id].playing_handicap == 27
 
         # Pero el reparto es diferencial: el de menos PH juega off scratch
-        assert result[me.participant_id].strokes_received == ()
+        assert result[me.participant_id].strokes_by_hole == {}
         # 27 - 23 = 4 golpes, en los hoyos de SI 1, 2, 3 y 4 -> hoyos 2, 11, 7 y 17
-        assert sorted(result[rival.participant_id].strokes_received) == [2, 7, 11, 17]
+        assert sorted(result[rival.participant_id].strokes_by_hole) == [2, 7, 11, 17]
 
     def test_lower_handicap_never_receives_more_than_the_higher_one(self, service):
         """
@@ -125,8 +125,8 @@ class TestSinglesMeisRegression:
         assert result[rival.participant_id].playing_handicap == 27
 
         # Uno de los dos recibe; el otro, nada. Nunca los dos.
-        assert result[rival.participant_id].strokes_received == ()
-        assert len(result[me.participant_id].strokes_received) == 4
+        assert result[rival.participant_id].strokes_by_hole == {}
+        assert result[me.participant_id].total_strokes == 4
 
 
 class TestScratch:
@@ -150,7 +150,7 @@ class TestScratch:
             play_mode=PlayMode.SCRATCH,
         )
 
-        assert all(ps.strokes_received == () for ps in result.values())
+        assert all(ps.strokes_by_hole == {} for ps in result.values())
         assert all(ps.playing_handicap == 0 for ps in result.values())
 
 
@@ -172,8 +172,8 @@ class TestFreePlay:
         )
 
         # 23 y 27 golpes repartidos: los dos reciben, no hay diferencial
-        assert len(result[a.participant_id].strokes_received) == 23
-        assert len(result[b.participant_id].strokes_received) == 27
+        assert result[a.participant_id].total_strokes == 23
+        assert result[b.participant_id].total_strokes == 27
 
     def test_allowance_reduces_the_playing_handicap(self, service):
         a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
@@ -211,7 +211,7 @@ class TestFallbacks:
 
         assert result[b.participant_id].playing_handicap == 0
         # A tiene PH 23 frente a 0: recibe la diferencia entera
-        assert len(result[a.participant_id].strokes_received) == 23
+        assert result[a.participant_id].total_strokes == 23
 
     def test_unknown_tee_falls_back_to_the_handicap_index(self, service):
         """Sin barra valorada se usa el propio HI, en vez de tratarlo como scratch."""
@@ -233,7 +233,7 @@ class TestFallbacks:
 
         assert result[a.participant_id].playing_handicap == 18
         assert result[b.participant_id].playing_handicap == 21
-        assert len(result[b.participant_id].strokes_received) == 3
+        assert result[b.participant_id].total_strokes == 3
 
     def test_incomplete_singles_roster_gives_nobody_strokes(self, service):
         a = _guest("A", 18.0, TeeColor.YELLOW, Gender.MALE)
@@ -248,7 +248,7 @@ class TestFallbacks:
             play_mode=PlayMode.HANDICAP,
         )
 
-        assert result[a.participant_id].strokes_received == ()
+        assert result[a.participant_id].strokes_by_hole == {}
 
 
 class TestFoursomes:
@@ -276,16 +276,16 @@ class TestFoursomes:
         )
 
         assert (
-            result[a1.participant_id].strokes_received
-            == result[a2.participant_id].strokes_received
+            result[a1.participant_id].strokes_by_hole
+            == result[a2.participant_id].strokes_by_hole
         )
         assert (
-            result[b1.participant_id].strokes_received
-            == result[b2.participant_id].strokes_received
+            result[b1.participant_id].strokes_by_hole
+            == result[b2.participant_id].strokes_by_hole
         )
         # Solo recibe el equipo de mayor CH promedio
-        assert result[a1.participant_id].strokes_received == ()
-        assert len(result[b1.participant_id].strokes_received) > 0
+        assert result[a1.participant_id].strokes_by_hole == {}
+        assert result[b1.participant_id].total_strokes > 0
 
 
 class TestFourball:
@@ -309,9 +309,9 @@ class TestFourball:
             play_mode=PlayMode.HANDICAP,
         )
 
-        assert result[players[0].participant_id].strokes_received == ()
+        assert result[players[0].participant_id].strokes_by_hole == {}
         # Y el resto recibe en orden creciente de handicap
-        counts = [len(result[p.participant_id].strokes_received) for p in players]
+        counts = [result[p.participant_id].total_strokes for p in players]
         assert counts == sorted(counts)
 
 
@@ -355,3 +355,115 @@ class TestParticipantStrokes:
         )
 
         assert result[a.participant_id].net_score(1, 1) == 0
+
+
+class TestPlusHandicap:
+    """
+    Handicap plus: el jugador CEDE golpes al campo (Regla WHS 8.2).
+
+    No habia ni un test de esto, y por eso paso desapercibido que el reparto
+    acotaba el Playing Handicap a cero: la tarjeta daba cero golpes y la
+    clasificacion seguia descontandolos, dos totales distintos en la misma
+    pantalla para el mismo jugador.
+    """
+
+    def test_plus_handicap_gives_strokes_back_in_free_play(self, service):
+        """
+        Given un jugador de handicap plus en partido libre
+        When se reparte el handicap
+        Then su Playing Handicap es negativo y cede golpes, no recibe
+        """
+        a = _guest("Plus", -2.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("-2.0")},
+            # Campo neutro (slope 113, CR = par) para que el PH sea el HI exacto
+            tee_ratings={
+                ("YELLOW", "MALE"): TeeRating(
+                    course_rating=Decimal("72.0"), slope_rating=113, par=72
+                )
+            },
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        strokes = result[a.participant_id]
+        assert strokes.playing_handicap == -2
+        assert strokes.total_strokes == -2
+        # Se ceden desde el hoyo mas facil hacia atras: SI 18 y 17
+        assert strokes.strokes_by_hole == {18: -1, 17: -1}
+
+    def test_giving_back_a_stroke_raises_the_net_score(self, service):
+        a = _guest("Plus", -2.0, TeeColor.YELLOW, Gender.MALE)
+
+        result = service.allocate(
+            participants=[a],
+            handicaps={a.participant_id: Decimal("-2.0")},
+            tee_ratings={
+                ("YELLOW", "MALE"): TeeRating(
+                    course_rating=Decimal("72.0"), slope_rating=113, par=72
+                )
+            },
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=None,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        strokes = result[a.participant_id]
+        assert strokes.net_score(18, 4) == 5  # cede golpe: su neto empeora
+        assert strokes.net_score(1, 4) == 4  # aqui no cede nada
+
+    def test_match_play_still_clamps_each_playing_handicap_at_zero(self, service):
+        """
+        Given un plus contra un handicap alto en match play
+        When se reparte
+        Then el plus juega off scratch y el rival recibe la diferencia completa
+
+        En match play la ventaja la recoge la diferencia entre los dos Playing
+        Handicaps, y el WHS acota cada uno a cero antes de restarlos: nadie cede
+        golpes al campo, se los da al rival.
+        """
+        plus = _guest("Plus", -2.0, TeeColor.YELLOW, Gender.MALE)
+        high = _guest("High", 20.0, TeeColor.YELLOW, Gender.MALE)
+        neutral = TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=72)
+
+        result = service.allocate(
+            participants=[plus, high],
+            handicaps={
+                plus.participant_id: Decimal("-2.0"),
+                high.participant_id: Decimal("20.0"),
+            },
+            tee_ratings={("YELLOW", "MALE"): neutral},
+            holes_by_stroke_index=_holes_by_stroke_index(),
+            match_format=MatchFormat.SINGLES,
+            allowance_percentage=100,
+            play_mode=PlayMode.HANDICAP,
+        )
+
+        assert result[plus.participant_id].playing_handicap == 0
+        assert result[high.participant_id].playing_handicap == 20
+        assert result[plus.participant_id].strokes_by_hole == {}
+        assert result[high.participant_id].total_strokes == 20
+
+
+class TestAllocateByHole:
+    """El reparto con signo, aislado."""
+
+    def test_wraps_around_past_eighteen(self, service):
+        allocation = service.allocate_by_hole(23, _holes_by_stroke_index())
+
+        assert allocation[1] == 2  # SI 1
+        assert allocation[5] == 2  # SI 5
+        assert allocation[6] == 1  # SI 6
+        assert allocation[18] == 1  # SI 18
+        assert sum(allocation.values()) == 23
+
+    def test_zero_allocates_nothing(self, service):
+        assert service.allocate_by_hole(0, _holes_by_stroke_index()) == {}
+
+    def test_no_holes_allocates_nothing(self, service):
+        assert service.allocate_by_hole(10, []) == {}


### PR DESCRIPTION
## The bug

A 1 vs 1 match play quick match was **resolved gross**. `_compute_standing` fed the raw `hole_score.score` into `ScoringService.calculate_hole_winner`, whose contract is net scores, so a match between an 18.0 and a 20.7 was decided as if both played scratch. `GetRecentMatchesUseCase` did the same, on its own copy.

The strokes drawn on the card were wrong on top of that: they came from each player's full Playing Handicap, which is the stroke-play method. WHS match play gives only the *difference*, to the higher handicap, on the lowest stroke index holes. The totals looked close but landed on different holes — which is exactly where tight holes are decided.

Reported from a real match at Golf de Meis, where the reporter (18.0) was drawn **more** strokes than his opponent (20.7).

## Quick matches

- **`StrokeAllocationService`** (new, quick_match domain) resolves strokes per participant for every format: singles / fourball / foursomes differential, free play individual, nothing at all in scratch. The card and the result finally share one calculation.
- **`StrokeContextBuilder`** (new, application layer) translates a `GolfCourse` into what that service needs, keeping the domain free of `golf_course` entities.
- Detail and history now compare **net** scores, and the detail exposes `participant_strokes` so the frontend can draw what actually decided the holes.
- **Scratch mode**: quick matches gain `play_mode`, reusing the `PlayMode` value object competitions already use. Free play honours it too. Defaults to HANDICAP, so a caller that omits the field behaves exactly as before.

### Migration

`b4d7e1a9c25f` backfills existing rows to preserve what the app was showing rather than rewriting finished matches:

- match play that is **COMPLETED or CANCELLED** → `SCRATCH` (it was resolved gross, so its stored result does not move)
- everything else → `HANDICAP`, including match play still PENDING or IN_PROGRESS: those have no result to preserve and their players set them up expecting handicaps

## Competitions (closes #209)

An audit of the competition path found most of that family **absent** — every caller of `calculate_hole_winner` already passes `net_score`, all three formats already use the differential, rounding already goes through ROUND_HALF_UP, and the genderless-tee fallback was already there. Two defects were present:

- Strokes were dealt against `golf_course.holes`, which is only the first tee's card. Each tee can carry its own: **56 of the 800** federated courses with more than one carded tee have a stroke index that changes between tees.
- Every tee was rated against the course par instead of its own, shifting `CR - par` and the course handicap. **25 of those 800** have a par that differs between tees.

10% of federated courses are exposed to at least one. `GenerateMatchesUseCase` and `ReassignMatchPlayersUseCase` each had their own copy of the translation and both carried both defects, so the fix is a shared `TeeContextBuilder`, the same shape as `StrokeContextBuilder` in quick_match.

Also: `Match.create` summed each team's `playing_handicap`, which comes out **doubled** in foursomes where both partners carry the same team handicap — a team receiving 7 strokes was shown as 14. Verified the field feeds no calculation (only `MatchCard` and `MatchDetailModal` read it), so no result was ever wrong from this.

### Data already in the database

Competition matches are generated once and **persisted**, so a wrong allocation is frozen and does not correct itself on deploy.

`scripts/regenerate_scheduled_round_strokes.py` recomputes rounds still in `SCHEDULED`, **preserving pairings and match numbers**: it reads the existing pairings, reopens the round via the new `Round.reopen_for_regeneration` and re-runs generation with those pairings as manual ones, so the allocation comes out of the corrected code with no logic duplicated. Run `--dry-run` first.

Rounds that have started are deliberately left alone: they have results, and changing their strokes would rewrite holes already played.

## Review passes

An architecture/OWASP audit and a code review were run over this branch. Findings worth knowing:

- Plus handicaps were clamped at zero, so the card and the classification disagreed on screen. `ParticipantStrokes` now carries a **signed** hole → strokes map, which a list of hole numbers could not represent.
- The quick match tee lookup had no `(colour, None)` fallback — copied from competition, which did have it.
- The no-tee fallback dropped the allowance and rounded half-to-even, both out of step with the rest of the handicap calculation.
- `play_mode` was ignored by the Stableford and to-par paths, so a scratch round was credited in the history and the player average as if strokes had been given.

## Parity with the frontend

`scripts/generate_parity_fixtures.py` runs the quick match service over 12 scenarios and writes the exact results where the frontend's parity test reads them. It caught three live divergences the first time it ran. The companion frontend PR consumes it.

## Verification

- 2859 unit tests pass
- `ruff` clean, `mypy` clean over 605 files
- Single Alembic head

## Known limitations, tracked separately

- #206 — pitch & putt courses fall back to the raw Handicap Index (`TeeRating` rejects par 54)
- #207 — `play_mode` cannot be changed after creation

## Merge order

**Merge this before the frontend PR** (agustinEDev/RyderCupWeb#399). The frontend consumes `participant_strokes`; the reverse order leaves the card recomputing locally, which still works but is the situation this branch exists to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y4Jo33BPFFPYz7oDb8vaM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quick matches now support **Handicap** or **Scratch** play modes.
  - Match details show each participant’s playing handicap and strokes by hole.
  - Handicap strokes use tee-specific ratings and stroke indexes.
  - Standings and recent-match results account for net scores where applicable.
  - Scheduled-round strokes can be regenerated with dry-run reporting.

- **Bug Fixes**
  - Scratch matches no longer apply handicaps to statistics or standings.
  - Improved handling of missing or invalid tee and handicap data.

- **Tests**
  - Expanded coverage for play modes, stroke allocation, standings, and regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->