### PR TITLE
chore(merge): Sync develop with main after v2.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **En las competiciones los golpes se repartían contra la tarjeta del campo, que es la de la primera salida**: cada barra puede llevar la suya, y **56 de los 802 campos federados** tienen un índice de dificultad que cambia de una barra a otra. Además cada salida se valoraba contra el par del campo en vez del suyo propio, lo que desplaza `CR - par` y con él el hándicap de campo; **25 de esos 802** tienen un par distinto entre barras. Un 10% está expuesto a al menos uno de los dos. `GenerateMatchesUseCase` y `ReassignMatchPlayersUseCase` tenían cada uno su copia de la traducción y ambas arrastraban los dos defectos, así que ahora comparten un `TeeContextBuilder`.
 
+- **El regenerador de rondas programadas no llegaba a arrancar**: `scripts/regenerate_scheduled_round_strokes.py` moría en su primera consulta con `ArgumentError: ... got <class Competition>`. Fuera de la aplicación nadie registra el mapeo imperativo de las entidades —`main.py` lo hace en el lifespan y `alembic/env.py` en el suyo—, así que las consultas del script salían contra entidades de dominio sin mapear. No lo vio ninguna suite porque `conftest.py` deja los mappers puestos antes de cualquier test, y el script nunca se había ejecutado contra una base de datos. Verificado con `--dry-run` contra el clúster local.
+
 - **El hándicap de equipo de un foursomes salía doblado**: `Match.create` sumaba el `playing_handicap` de los dos miembros, que en foursomes ya es el del equipo, así que un equipo con 7 golpes se mostraba con 14. El campo no alimenta ningún cálculo —solo lo leen la tarjeta y el detalle del partido—, de modo que ningún resultado llegó a ser incorrecto por esto.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-08-16
+
+### Fixed
+
+- **El match play de las partidas rápidas se decidía a golpes brutos**: `_compute_standing` pasaba el resultado tal cual a `calculate_hole_winner`, cuya firma pide netos, así que un 1 contra 1 entre un 18.0 y un 20.7 se resolvía como si los dos jugaran scratch. `GetRecentMatchesUseCase` tenía su propia copia del mismo fallo, de modo que el historial y el detalle podían discrepar sobre quién había ganado. Salió de una partida real en Golf de Meis.
+
+- **La tarjeta repartía el hándicap de juego entero a cada jugador**, que es el método del stroke play. En match play el WHS da solo la **diferencia**, al de más hándicap, en los hoyos de menor índice de dificultad. Los totales se parecían, pero los golpes caían en hoyos distintos: justo donde se deciden los hoyos ajustados. El nuevo `StrokeAllocationService` resuelve los golpes de cada participante para todos los formatos —individual, fourball y foursomes por diferencia, partido libre por hándicap entero, nada en scratch— y la tarjeta y el resultado por fin salen del mismo cálculo. El detalle expone `participant_strokes` para que el cliente dibuje lo que de verdad decidió cada hoyo.
+
+- **En las competiciones los golpes se repartían contra la tarjeta del campo, que es la de la primera salida**: cada barra puede llevar la suya, y **56 de los 802 campos federados** tienen un índice de dificultad que cambia de una barra a otra. Además cada salida se valoraba contra el par del campo en vez del suyo propio, lo que desplaza `CR - par` y con él el hándicap de campo; **25 de esos 802** tienen un par distinto entre barras. Un 10% está expuesto a al menos uno de los dos. `GenerateMatchesUseCase` y `ReassignMatchPlayersUseCase` tenían cada uno su copia de la traducción y ambas arrastraban los dos defectos, así que ahora comparten un `TeeContextBuilder`.
+
+- **El hándicap de equipo de un foursomes salía doblado**: `Match.create` sumaba el `playing_handicap` de los dos miembros, que en foursomes ya es el del equipo, así que un equipo con 7 golpes se mostraba con 14. El campo no alimenta ningún cálculo —solo lo leen la tarjeta y el detalle del partido—, de modo que ningún resultado llegó a ser incorrecto por esto.
+
+### Added
+
+- **Modo scratch en las partidas rápidas**: `play_mode` reutiliza el objeto de valor `PlayMode` que ya usaban las competiciones. Nadie recibe golpes y los hoyos se deciden a bruto. El partido libre también lo respeta. Por defecto `HANDICAP`, así que un cliente que omita el campo se comporta exactamente igual que antes.
+
+- **Arnés de paridad con el frontend** (`scripts/generate_parity_fixtures.py`): ejecuta el `StrokeAllocationService` real sobre 12 escenarios y vuelca entradas y resultados a un JSON que consume el test del cliente. La duplicación del cálculo entre backend y frontend no se puede retirar —sin ella no hay anotación sin conexión—, así que esta es la única garantía de que los dos no se separen. **Cazó tres divergencias vivas** en cuanto se ejecutó, ninguna visible para los tests escritos a mano de cada lado.
+
+- **Regenerador de las rondas ya programadas** (`scripts/regenerate_scheduled_round_strokes.py`): los partidos de competición se generan una vez y se **persisten**, así que un reparto mal calculado se queda congelado y no se corrige al desplegar. El script recalcula las rondas en `SCHEDULED` conservando emparejamientos y numeración, reabriéndolas y volviendo a generar con los mismos cruces para que el reparto salga del código corregido sin duplicar lógica. Tiene `--dry-run`, y conviene usarlo: borra y recrea filas de `matches`.
+
+### Changed
+
+- **Migración `b4d7e1a9c25f`**, que rellena el `play_mode` de las partidas existentes conservando lo que la aplicación venía enseñando en vez de reescribir partidas terminadas: el match play **completado o cancelado** pasa a `SCRATCH`, porque se resolvió a bruto y su resultado guardado no se mueve; todo lo demás pasa a `HANDICAP`, incluido el match play aún pendiente o en curso, que no tiene resultado que preservar y cuyos jugadores lo montaron contando con los hándicaps.
+
 ## [2.8.0] - 2026-08-13
 
 ### Changed

--- a/scripts/regenerate_scheduled_round_strokes.py
+++ b/scripts/regenerate_scheduled_round_strokes.py
@@ -60,17 +60,47 @@ from src.modules.competition.domain.value_objects.round_status import RoundStatu
 from src.modules.competition.infrastructure.persistence.sqlalchemy.competition_unit_of_work import (
     SQLAlchemyCompetitionUnitOfWork,
 )
+from src.modules.competition.infrastructure.persistence.sqlalchemy.mappers import (
+    start_mappers as start_competition_mappers,
+)
+from src.modules.golf_course.infrastructure.persistence.mappers.golf_course_mapper import (
+    start_golf_course_mappers,
+)
 from src.modules.golf_course.infrastructure.persistence.sqlalchemy.golf_course_unit_of_work import (
     SQLAlchemyGolfCourseUnitOfWork,
 )
+from src.modules.user.infrastructure.persistence.sqlalchemy.mappers import (
+    start_mappers as start_user_mappers,
+)
 from src.modules.user.infrastructure.persistence.sqlalchemy.unit_of_work import (
     SQLAlchemyUnitOfWork,
+)
+from src.shared.infrastructure.persistence.sqlalchemy.country_mappers import (
+    start_mappers as start_country_mappers,
 )
 
 COMPETITIONS_PAGE = 200
 
 
+def start_mappers() -> None:
+    """Registra el mapeo imperativo de las entidades que toca este script.
+
+    Fuera de la aplicacion nadie lo hace por nosotros: `main.py` lo ejecuta en
+    el lifespan y `alembic/env.py` en el suyo, asi que un script suelto se
+    queda con las entidades sin mapear y la primera consulta revienta con
+    `ArgumentError: ... got <class Competition>`.
+
+    El orden importa: GolfCourse antes que Competition, que la referencia.
+    """
+    start_user_mappers()
+    start_country_mappers()
+    start_golf_course_mappers()
+    start_competition_mappers()
+
+
 async def main(dry_run: bool) -> int:
+    start_mappers()
+
     regenerated_rounds = 0
     regenerated_matches = 0
     skipped = 0

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -10,7 +10,7 @@ una release ha llegado realmente a produccion.
 
 import os
 
-APP_VERSION = "2.8.0"
+APP_VERSION = "2.9.0"
 
 
 def get_deployed_commit() -> str:

--- a/tests/unit/scripts/test_regenerate_scheduled_round_strokes.py
+++ b/tests/unit/scripts/test_regenerate_scheduled_round_strokes.py
@@ -1,0 +1,85 @@
+"""
+Tests del arranque del comando que regenera los golpes de las rondas SCHEDULED.
+
+Solo cubren el registro del mapeo imperativo: lo que el comando hace con la base
+de datos se prueba a través del caso de uso que invoca.
+
+El resto de la suite no vale para esto. `conftest.py` ya deja los mappers
+registrados antes de cualquier test, así que un test que se limite a ejecutar el
+comando pasa aunque el comando no los registre — que es justo como el fallo
+llegó hasta una ejecución real contra una base de datos.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from scripts import regenerate_scheduled_round_strokes as command
+
+
+def test_the_command_registers_the_mappers_before_querying():
+    """
+    GIVEN: El comando ejecutado fuera de la aplicación
+    WHEN: Arranca
+    THEN: Registra el mapeo imperativo antes de abrir la sesión
+
+    Sin esto la primera consulta muere con `ArgumentError: Column expression,
+    FROM clause, or other columns clause element expected, got <class
+    Competition>`: fuera de `main.py` y de `alembic/env.py` nadie registra el
+    mapeo de las entidades de dominio.
+    """
+    order = []
+
+    with (
+        patch.object(command, "start_mappers", side_effect=lambda: order.append("mappers")),
+        patch.object(
+            command,
+            "async_session_maker",
+            side_effect=lambda: order.append("session") or _RaisingSession(),
+        ),
+        pytest.raises(_SessionOpenedError),
+    ):
+        asyncio.run(command.main(dry_run=True))
+
+    assert order == ["mappers", "session"]
+
+
+def test_the_mappers_are_registered_with_golf_course_before_competition():
+    """
+    GIVEN: El registro del mapeo del comando
+    WHEN: Se ejecuta
+    THEN: GolfCourse se registra antes que Competition
+
+    Competition referencia a GolfCourse en una relación, y al revés SQLAlchemy
+    falla con `UnmappedClassError: Class GolfCourse is not mapped`.
+    """
+    order = []
+
+    with (
+        patch.object(command, "start_user_mappers", side_effect=lambda: order.append("user")),
+        patch.object(command, "start_country_mappers", side_effect=lambda: order.append("country")),
+        patch.object(
+            command, "start_golf_course_mappers", side_effect=lambda: order.append("golf_course")
+        ),
+        patch.object(
+            command, "start_competition_mappers", side_effect=lambda: order.append("competition")
+        ),
+    ):
+        command.start_mappers()
+
+    assert order.index("golf_course") < order.index("competition")
+
+
+class _SessionOpenedError(Exception):
+    """Corta la ejecución en cuanto el comando pide una sesión."""
+
+
+class _RaisingSession:
+    """Sesión de mentira: solo sirve para saber que se ha llegado a pedirla."""
+
+    async def __aenter__(self):
+        raise _SessionOpenedError
+
+    async def __aexit__(self, *_):
+        return False


### PR DESCRIPTION
Brings `develop` back in sync with `main` after the v2.9.0 release.

No new content: the release commit (`APP_VERSION`, CHANGELOG) plus the regenerator fix that was added to the release branch after testing it against the local cluster.

Skipping this step is what left `develop` behind on 13 Aug — `APP_VERSION` is what `/health` reports, so a deploy from `develop` would announce the wrong version, and the next release would start from a CHANGELOG missing an entry.

Check after merging:

```bash
git log origin/develop..origin/main --oneline   # must return 0 commits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scratch quick matches.
  * Added frontend parity fixtures.
  * Added scheduled-round stroke regeneration.
  * Migrated existing matches to the `play_mode` format.

* **Bug Fixes**
  * Improved match-play handicap calculations and stroke allocation.
  * Corrected tee-specific course data.
  * Fixed scheduled-round regeneration.
  * Improved foursomes team handicap calculations.

* **Release**
  * Updated the application to version 2.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->