### PR TITLE
feat(scoring): Score every player against their own tee

### DIFF
--- a/src/modules/competition/application/dto/scoring_dto.py
+++ b/src/modules/competition/application/dto/scoring_dto.py
@@ -46,14 +46,20 @@ class ScoringPlayerDTO(BaseModel):
     tee_color: str
     playing_handicap: int
     strokes_received: list[int]
+    # El par, el índice y los metros son de la barra de cada jugador, no del
+    # campo: en 56 de los 800 campos federados el índice cambia de una barra a
+    # otra y en 25 el par. Se manda resuelto para que el cliente no tenga que
+    # volver a resolverlo — y no lo resuelva de otra manera.
+    hole_card: list["HoleInfoDTO"] = []
 
 
 class HoleInfoDTO(BaseModel):
-    """Info de un hoyo."""
+    """Info de un hoyo, tal y como se juega desde una salida concreta."""
 
     hole_number: int
     par: int
     stroke_index: int
+    meters: int | None = None
 
 
 class PlayerHoleScoreDTO(BaseModel):
@@ -118,6 +124,10 @@ class ScoringViewResponseDTO(BaseModel):
     team_b_name: str
     marker_assignments: list[MarkerAssignmentResponseDTO]
     players: list[ScoringPlayerDTO]
+    # Tarjeta de referencia del campo (la de la primera salida con tarjeta).
+    # Sirve para saber qué hoyos se juegan; lo que se pinta y con lo que se
+    # puntúa a un jugador es su `hole_card`. Se retira cuando el cliente deje
+    # de leerla.
     holes: list[HoleInfoDTO]
     scores: list[HoleScoreEntryDTO]
     match_standing: MatchStandingDTO

--- a/src/modules/competition/application/services/tee_context_builder.py
+++ b/src/modules/competition/application/services/tee_context_builder.py
@@ -27,7 +27,7 @@ class TeeContext:
 
     tee_ratings: dict[tuple[str, str | None], TeeRating]
     holes_by_stroke_index: list[int]
-    # Orden propio de cada barra. `golf_course.holes` es solo la tarjeta de la
+    # Orden propio de cada barra. `golf_course.reference_card` es solo la tarjeta de la
     # PRIMERA barra (ver `GolfCourse._sync_holes_and_tees`), y el importador de
     # la RFEG guarda una por barra: de los 800 campos federados con mas de una
     # barra con tarjeta, 56 tienen stroke index distinto entre ellas y 25 par
@@ -59,9 +59,9 @@ class TeeContextBuilder:
 
     @staticmethod
     def build(golf_course: GolfCourse) -> TeeContext:
-        course_par = sum(h.par for h in golf_course.holes)
+        course_par = sum(h.par for h in golf_course.reference_card)
         holes_by_stroke_index = [
-            h.number for h in sorted(golf_course.holes, key=lambda h: h.stroke_index)
+            h.number for h in sorted(golf_course.reference_card, key=lambda h: h.stroke_index)
         ]
 
         tee_ratings: dict[tuple[str, str | None], TeeRating] = {}

--- a/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
+++ b/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
@@ -32,6 +32,19 @@ from src.modules.user.domain.repositories.user_repository_interface import (
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
+def _hole_card_dto(holes) -> list[HoleInfoDTO]:
+    """Traduce una tarjeta de dominio a DTO, ordenada por número de hoyo."""
+    return [
+        HoleInfoDTO(
+            hole_number=hole.number,
+            par=hole.par,
+            stroke_index=hole.stroke_index,
+            meters=hole.meters,
+        )
+        for hole in sorted(holes, key=lambda hole: hole.number)
+    ]
+
+
 class GetScoringViewUseCase:
     """Obtiene la vista completa de scoring para un partido."""
 
@@ -68,18 +81,12 @@ class GetScoringViewUseCase:
             # Cargar golf course para obtener holes y nombre
             golf_course_name = ""
             holes_dto: list[HoleInfoDTO] = []
+            golf_course = None
             if self._gc_repo:
                 golf_course = await self._gc_repo.find_by_id(round_entity.golf_course_id)
                 if golf_course:
                     golf_course_name = golf_course.name
-                    holes_dto = [
-                        HoleInfoDTO(
-                            hole_number=h.number,
-                            par=h.par,
-                            stroke_index=h.stroke_index,
-                        )
-                        for h in sorted(golf_course.holes, key=lambda h: h.number)
-                    ]
+                    holes_dto = _hole_card_dto(golf_course.reference_card)
 
             round_info = RoundInfoDTO(
                 id=str(round_entity.id),
@@ -89,7 +96,7 @@ class GetScoringViewUseCase:
             )
 
             marker_assignments_dto = self._build_marker_assignments(match, user_names)
-            players_dto = self._build_players(match, user_names)
+            players_dto = self._build_players(match, user_names, golf_course)
             scores_dto, hole_results_list = self._build_scores(hole_scores, round_entity)
 
             standing = self._scoring_service.calculate_match_standing(hole_results_list)
@@ -136,8 +143,14 @@ class GetScoringViewUseCase:
             for ma in match.marker_assignments
         ]
 
-    def _build_players(self, match, user_names):
-        """Construye DTOs de jugadores."""
+    def _build_players(self, match, user_names, golf_course=None):
+        """
+        Construye DTOs de jugadores, cada uno con la tarjeta de su barra.
+
+        Sin campo cargado se quedan sin tarjeta: el cliente ya tiene que
+        aguantar esa vista sin hoyos, que es lo que pasa cuando el repositorio
+        de campos no está disponible.
+        """
         return [
             ScoringPlayerDTO(
                 user_id=str(p.user_id),
@@ -146,6 +159,11 @@ class GetScoringViewUseCase:
                 tee_color=p.tee_color.value,
                 playing_handicap=p.playing_handicap,
                 strokes_received=list(p.strokes_received),
+                hole_card=(
+                    _hole_card_dto(golf_course.hole_card_for(p.tee_color, p.tee_gender))
+                    if golf_course
+                    else []
+                ),
             )
             for p in (*match.team_a_players, *match.team_b_players)
         ]

--- a/src/modules/competition/infrastructure/api/v1/competition_golf_course_routes.py
+++ b/src/modules/competition/infrastructure/api/v1/competition_golf_course_routes.py
@@ -258,7 +258,7 @@ async def list_competition_golf_courses(
                                     par=hole.par,
                                     stroke_index=hole.stroke_index,
                                 )
-                                for hole in (golf_course.holes or [])
+                                for hole in (golf_course.reference_card or [])
                             ],
                         ),
                     )

--- a/src/modules/golf_course/application/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/application/mappers/golf_course_mapper.py
@@ -190,7 +190,7 @@ class GolfCourseMapper:
                     stroke_index=hole.stroke_index,
                     meters=hole.meters,
                 )
-                for hole in golf_course.holes
+                for hole in golf_course.reference_card
             ],
             approval_status=golf_course.approval_status.value,
             rejection_reason=golf_course.rejection_reason,

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -1017,9 +1017,25 @@ class GolfCourse:
         cuando el campo no las distingue. Un campo dado de alta a mano suele
         tener una sola barra amarilla, mientras que el jugador siempre manda
         color y género juntos: sin la reserva no se encontraría ninguna.
+
+        Con color OTHER se resuelve igual, por color y género, y no por
+        identificador: ni `MatchPlayer` ni `QuickMatchParticipant` guardan el
+        identificador de la salida, así que exigirlo dejaba sin resolver
+        precisamente a las "Championship" y las combinadas, que son las que más
+        veces traen tarjeta propia. Es el mismo criterio con el que los context
+        builders reparten los golpes, que indexan por `(color, género)`.
+        Mientras un campo pueda tener dos salidas OTHER del mismo género (#190)
+        no hay forma de distinguirlas aquí, y se coge la primera — que es lo que
+        ya hacía el reparto.
         """
-        return self.find_tee(color, gender, identifier) or self.find_tee(
-            color, None, identifier
+        if identifier is not None:
+            exact = self.find_tee(color, gender, identifier)
+            if exact is not None:
+                return exact
+
+        same_color = [tee for tee in self._tees if tee.color == color]
+        return next((tee for tee in same_color if tee.gender == gender), None) or next(
+            (tee for tee in same_color if tee.gender is None), None
         )
 
     def hole_card_for(

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -1057,4 +1057,16 @@ class GolfCourse:
         par ni índice no se puede ni puntuar ni repartir.
         """
         tee = self.tee_for(color, gender, identifier)
-        return list(tee.holes) if tee and tee.holes else self.reference_card
+        if tee is not None and tee.holes:
+            return list(tee.holes)
+
+        # La barra existe pero no trae tarjeta: antes que la del campo va la de
+        # la salida sin género de ese color, que es de donde el reparto saca el
+        # orden de dificultad (`TeeContext.holes_for`). Si aquí se cayera antes,
+        # al jugador se le repartirían los golpes con una tarjeta y se le
+        # puntuaría con otra.
+        fallback = self.find_tee(color, None, identifier)
+        if fallback is not None and fallback.holes:
+            return list(fallback.holes)
+
+        return self.reference_card

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -264,7 +264,7 @@ class GolfCourse:
         - Con una tarjeta por salida (lo que publica la RFEG): en ese caso la
           tarjeta de referencia del campo se toma de la primera salida.
 
-        Así los consumidores que solo leen `golf_course.holes` siguen
+        Así los consumidores que solo leen la tarjeta de referencia siguen
         funcionando, y quien necesite la distancia o el índice exactos de una
         barra concreta los pide a su Tee.
         """
@@ -635,7 +635,7 @@ class GolfCourse:
             course_type=clone.course_type,
             creator_id=clone.creator_id,
             tees=clone.tees,
-            holes=clone.holes,
+            holes=clone.reference_card,
             approval_status=ApprovalStatus.PENDING_APPROVAL,
             rejection_reason=None,
             created_at=clone.created_at,
@@ -711,7 +711,7 @@ class GolfCourse:
             self._tees.append(new_tee)
 
         del self._holes[:]  # Elimina todos los elementos in-place
-        for hole in clone.holes:
+        for hole in clone.reference_card:
             self._holes.append(replace(hole))
 
         self._updated_at = datetime.now(UTC).replace(tzinfo=None)
@@ -739,7 +739,7 @@ class GolfCourse:
         Raises:
             ValueError: Si la validación falla
         """
-        reference_card = self.holes
+        reference_card = self.reference_card
         if len(reference_card) != HOLES_PER_ROUND:
             raise ValueError(
                 f"Golf course must have exactly {HOLES_PER_ROUND} holes, got {len(reference_card)}"
@@ -881,7 +881,7 @@ class GolfCourse:
         return self._tees.copy()
 
     @property
-    def holes(self) -> list[Hole]:
+    def reference_card(self) -> list[Hole]:
         """
         Tarjeta de referencia del campo.
 
@@ -919,7 +919,7 @@ class GolfCourse:
     @property
     def total_par(self) -> int:
         """Retorna el par total del campo, según su tarjeta de referencia."""
-        return sum(h.par for h in self.holes)
+        return sum(h.par for h in self.reference_card)
 
     @property
     def original_golf_course_id(self) -> GolfCourseId | None:
@@ -1006,3 +1006,39 @@ class GolfCourse:
             ):
                 return tee
         return None
+
+    def tee_for(
+        self, color: TeeColor, gender: Gender | None, identifier: str | None = None
+    ) -> Tee | None:
+        """
+        Salida desde la que juega quien eligió ese color y ese género.
+
+        `find_tee` busca una salida exacta; esta reserva a la salida sin género
+        cuando el campo no las distingue. Un campo dado de alta a mano suele
+        tener una sola barra amarilla, mientras que el jugador siempre manda
+        color y género juntos: sin la reserva no se encontraría ninguna.
+        """
+        return self.find_tee(color, gender, identifier) or self.find_tee(
+            color, None, identifier
+        )
+
+    def hole_card_for(
+        self, color: TeeColor, gender: Gender | None, identifier: str | None = None
+    ) -> list[Hole]:
+        """
+        Tarjeta tal y como se juega desde esa salida: su par, su stroke index y
+        sus metros.
+
+        El par y el índice son de la salida, no del campo. `holes` es solo la
+        tarjeta derivada de la primera que tenga una, y de los 800 campos
+        federados con más de una barra con tarjeta, 56 cambian de stroke index
+        entre ellas y 25 de par. Repartir golpes o puntuar con la tarjeta de
+        referencia aplica a quien juega otra salida un par y un orden que no
+        son los suyos.
+
+        Cae a la tarjeta de referencia cuando la salida no trae la suya, que es
+        como quedan las salidas dadas de alta a mano: es lo único que hay, y sin
+        par ni índice no se puede ni puntuar ni repartir.
+        """
+        tee = self.tee_for(color, gender, identifier)
+        return list(tee.holes) if tee and tee.holes else self.reference_card

--- a/src/modules/golf_course/domain/entities/golf_course.py
+++ b/src/modules/golf_course/domain/entities/golf_course.py
@@ -1025,18 +1025,33 @@ class GolfCourse:
         veces traen tarjeta propia. Es el mismo criterio con el que los context
         builders reparten los golpes, que indexan por `(color, género)`.
         Mientras un campo pueda tener dos salidas OTHER del mismo género (#190)
-        no hay forma de distinguirlas aquí, y se coge la primera — que es lo que
-        ya hacía el reparto.
+        no hay forma de distinguirlas aquí, y se coge **la última**, que es la
+        que resuelve el reparto: `TeeContextBuilder` y `StrokeContextBuilder`
+        van indexando por `(color, género)` dentro de un bucle, así que una
+        salida repetida sobrescribe a la anterior. Coger aquí la primera hacía
+        que a ese jugador se le repartieran los golpes con una barra y se le
+        puntuara con otra, que es la fractura que esta resolución existe para
+        cerrar.
         """
         if identifier is not None:
             exact = self.find_tee(color, gender, identifier)
             if exact is not None:
                 return exact
 
-        same_color = [tee for tee in self._tees if tee.color == color]
-        return next((tee for tee in same_color if tee.gender == gender), None) or next(
-            (tee for tee in same_color if tee.gender is None), None
-        )
+        return self._last_tee(color, gender) or self._last_tee(color, None)
+
+    def _last_tee(self, color: TeeColor, gender: Gender | None) -> Tee | None:
+        """
+        Última salida de ese color y género, sin mirar el identificador.
+
+        Ignorar el identificador es deliberado: el jugador nunca lo manda. La
+        última, y no la primera, para coincidir con los context builders.
+        """
+        found = None
+        for tee in self._tees:
+            if tee.color == color and tee.gender == gender:
+                found = tee
+        return found
 
     def hole_card_for(
         self, color: TeeColor, gender: Gender | None, identifier: str | None = None
@@ -1062,10 +1077,15 @@ class GolfCourse:
 
         # La barra existe pero no trae tarjeta: antes que la del campo va la de
         # la salida sin género de ese color, que es de donde el reparto saca el
-        # orden de dificultad (`TeeContext.holes_for`). Si aquí se cayera antes,
-        # al jugador se le repartirían los golpes con una tarjeta y se le
-        # puntuaría con otra.
-        fallback = self.find_tee(color, None, identifier)
+        # orden de dificultad (`TeeContext.holes_for`). Hoy no se llega aquí
+        # —`_sync_holes_and_tees` copia la tarjeta del campo a toda salida que
+        # no traiga la suya—, así que esto es una red por si esa copia deja de
+        # hacerse, no un camino vivo. Se busca con el mismo
+        # escaneo que `tee_for` y no con `find_tee`, que exige que el
+        # identificador coincida: pasándole `None` se saltaba precisamente la
+        # salida sin género que sí tiene identificador y tarjeta, y el jugador
+        # caía a la tarjeta del campo mientras el reparto usaba la de la barra.
+        fallback = self._last_tee(color, None)
         if fallback is not None and fallback.holes:
             return list(fallback.holes)
 

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -312,7 +312,7 @@ golf_course_tees_table = Table(
 
 # Los hoyos cuelgan de la salida, no del campo: el par, el índice de dificultad
 # y la distancia dependen de la barra desde la que se juega. La tarjeta del
-# campo (GolfCourse.holes) es derivada, se reconstruye desde la primera salida
+# campo (GolfCourse.reference_card) es derivada: se reconstruye desde la primera salida
 # al cargar el agregado.
 golf_course_tee_holes_table = Table(
     "golf_course_tee_holes",

--- a/src/modules/quick_match/application/services/stroke_context_builder.py
+++ b/src/modules/quick_match/application/services/stroke_context_builder.py
@@ -38,7 +38,7 @@ class StrokeContext:
     tee_ratings: dict[tuple[str, str | None], TeeRating]
     holes_by_stroke_index: list[int]
     par_by_hole: dict[int, int]
-    # Orden de dificultad propio de cada barra. `golf_course.holes` es solo la
+    # Orden de dificultad propio de cada barra. `golf_course.reference_card` es solo la
     # tarjeta de la PRIMERA barra (ver `GolfCourse._sync_holes_and_tees`), y el
     # importador de la RFEG guarda una tarjeta por barra: en 56 de los 800
     # campos federados el stroke index cambia de una a otra. Repartir con el
@@ -65,7 +65,7 @@ class StrokeContextBuilder:
             StrokeContext con los ratings por (color, genero), el orden de hoyos
             por stroke index y el par de cada hoyo.
         """
-        holes = sorted(golf_course.holes, key=lambda h: h.number)
+        holes = sorted(golf_course.reference_card, key=lambda h: h.number)
         par_by_hole = {hole.number: hole.par for hole in holes}
         course_par = sum(par_by_hole.values())
 

--- a/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
@@ -190,7 +190,12 @@ class PublishRoundAchievementsUseCase:
                     for score in scores
                     if score.participant_id == participant.participant_id
                 }
-                jugados = countable_holes(scores_by_hole, course)
+                # El par y el índice son de la barra que juega: un birdie se
+                # mide contra el par de su tarjeta, no contra el del campo
+                jugados = countable_holes(
+                    scores_by_hole,
+                    course.hole_card_for(participant.tee_color, participant.tee_gender),
+                )
                 if jugados is None:
                     # Tarjeta incompleta: si no vale para la media, no vale para
                     # presumir (BE #173)

--- a/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
@@ -220,7 +220,22 @@ class PublishTournamentAchievementsUseCase:
             for hole_score in hole_scores
             if hole_score.own_score is not None
         }
-        jugados = countable_holes(scores_by_hole, course)
+        # El par y el índice son de la barra que juega: un birdie se mide
+        # contra el par de su tarjeta, no contra el del campo
+        jugador = next(
+            (
+                player
+                for player in (*partido.team_a_players, *partido.team_b_players)
+                if player.user_id == user_id
+            ),
+            None,
+        )
+        jugados = countable_holes(
+            scores_by_hole,
+            course.hole_card_for(jugador.tee_color, jugador.tee_gender)
+            if jugador is not None
+            else course.reference_card,
+        )
         if jugados is None:
             return None
 

--- a/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_tournament_achievements_use_case.py
@@ -222,14 +222,7 @@ class PublishTournamentAchievementsUseCase:
         }
         # El par y el índice son de la barra que juega: un birdie se mide
         # contra el par de su tarjeta, no contra el del campo
-        jugador = next(
-            (
-                player
-                for player in (*partido.team_a_players, *partido.team_b_players)
-                if player.user_id == user_id
-            ),
-            None,
-        )
+        jugador = partido.find_player(user_id)
         jugados = countable_holes(
             scores_by_hole,
             course.hole_card_for(jugador.tee_color, jugador.tee_gender)

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -422,7 +422,13 @@ class GetPlayerStatsUseCase:
             return TeeRating(
                 course_rating=Decimal(str(tee.course_rating)),
                 slope_rating=tee.slope_rating,
-                par=sum(hole.par for hole in course.reference_card),
+                # El par es el de la barra: entra en el Course Handicap como
+                # (CR - Par), así que con la tarjeta de referencia el jugador de
+                # otra barra sale con una base de golpes que no es la suya, y
+                # con ella el tope de doble bogey neto y el diferencial.
+                par=tee.par_total if tee.holes else sum(
+                    hole.par for hole in course.reference_card
+                ),
             )
         except ValueError:
             return None

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -418,20 +418,31 @@ class GetPlayerStatsUseCase:
         if tee is None:
             return None
 
+        course_rating = Decimal(str(tee.course_rating))
+        course_par = sum(hole.par for hole in course.reference_card)
         try:
             return TeeRating(
-                course_rating=Decimal(str(tee.course_rating)),
+                course_rating=course_rating,
                 slope_rating=tee.slope_rating,
                 # El par es el de la barra: entra en el Course Handicap como
                 # (CR - Par), así que con la tarjeta de referencia el jugador de
                 # otra barra sale con una base de golpes que no es la suya, y
                 # con ella el tope de doble bogey neto y el diferencial.
-                par=tee.par_total if tee.holes else sum(
-                    hole.par for hole in course.reference_card
-                ),
+                par=tee.par_total if tee.holes else course_par,
             )
-        except ValueError:
-            return None
+        except (ValueError, TypeError):
+            # Una barra con el par fuera del rango WHS es un dato suelto del
+            # importador, no una vuelta que no se jugó: se valora contra el par
+            # del campo en vez de perder la vuelta y con ella el diferencial.
+            # Mismo criterio que `TeeContextBuilder._rating_for`.
+            try:
+                return TeeRating(
+                    course_rating=course_rating,
+                    slope_rating=tee.slope_rating,
+                    par=course_par,
+                )
+            except (ValueError, TypeError):
+                return None
 
     # ==================== Lectura de tarjetas ====================
 
@@ -540,14 +551,7 @@ class GetPlayerStatsUseCase:
     @staticmethod
     def _find_match_player(match, user_id: UserId):
         """El jugador dentro del partido, mire en el equipo que mire."""
-        return next(
-            (
-                player
-                for player in (*match.team_a_players, *match.team_b_players)
-                if player.user_id == user_id
-            ),
-            None,
-        )
+        return match.find_player(user_id)
 
     @staticmethod
     def _effective_handicap(participant, profile_handicap: float | None) -> float | None:

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -223,7 +223,9 @@ class GetPlayerStatsUseCase:
                     for score in scores
                     if score.participant_id == participant.participant_id
                 }
-                played = self._computable_holes(scores_by_hole, course)
+                played = self._computable_holes(
+                    scores_by_hole, self._hole_card(course, participant)
+                )
                 if played is None:
                     continue
 
@@ -307,7 +309,9 @@ class GetPlayerStatsUseCase:
                     continue
 
                 hole_scores = scorecards.get(match.id, [])
-                to_par = self._scorecard_to_par(hole_scores, course)
+                player = self._find_match_player(match, user_id)
+                hole_card = self._hole_card(course, player)
+                to_par = self._scorecard_to_par(hole_scores, hole_card)
                 if to_par is None:
                     continue
 
@@ -318,8 +322,7 @@ class GetPlayerStatsUseCase:
                 }
                 # El diferencial mide los mismos hoyos que la media, no el campo
                 # entero: en media vuelta, los otros nueve no se jugaron
-                played = self._computable_holes(scores_by_hole, course) or []
-                player = self._find_match_player(match, user_id)
+                played = self._computable_holes(scores_by_hole, hole_card) or []
                 holes = [
                     HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in played
                 ]
@@ -419,7 +422,7 @@ class GetPlayerStatsUseCase:
             return TeeRating(
                 course_rating=Decimal(str(tee.course_rating)),
                 slope_rating=tee.slope_rating,
-                par=sum(hole.par for hole in course.holes),
+                par=sum(hole.par for hole in course.reference_card),
             )
         except ValueError:
             return None
@@ -427,7 +430,7 @@ class GetPlayerStatsUseCase:
     # ==================== Lectura de tarjetas ====================
 
     @staticmethod
-    def _computable_holes(scores_by_hole: dict, course) -> list | None:
+    def _computable_holes(scores_by_hole: dict, hole_card: list) -> list | None:
         """
         Los hoyos que forman una vuelta computable, o None si no forman ninguna.
 
@@ -435,7 +438,7 @@ class GetPlayerStatsUseCase:
         aplicar exactamente la misma: una tarjeta que no vale para la media
         tampoco vale para presumir.
         """
-        return countable_holes(scores_by_hole, course)
+        return countable_holes(scores_by_hole, hole_card)
 
     @staticmethod
     def _to_eighteen(value: int, holes_played: int) -> int:
@@ -472,7 +475,7 @@ class GetPlayerStatsUseCase:
         round_ = rounds_by_match.get(match.id)
         return round_.golf_course_id if round_ is not None else None
 
-    def _scorecard_to_par(self, hole_scores: list, course) -> int | None:
+    def _scorecard_to_par(self, hole_scores: list, hole_card: list) -> int | None:
         """
         Neto respecto al par de la tarjeta, o None si no forma una vuelta.
 
@@ -487,7 +490,7 @@ class GetPlayerStatsUseCase:
             for hole_score in hole_scores
             if hole_score.own_score is not None
         }
-        played = self._computable_holes(scored, course)
+        played = self._computable_holes(scored, hole_card)
         if played is None:
             return None
 
@@ -502,6 +505,24 @@ class GetPlayerStatsUseCase:
         return self._to_eighteen(to_par, len(played))
 
     # ==================== Jugadores y hándicaps ====================
+
+    @staticmethod
+    def _hole_card(course, player) -> list:
+        """
+        Tarjeta de la barra que juega ese jugador.
+
+        El par y el índice son de la barra: puntuar con la tarjeta de referencia
+        del campo mide a quien no juega la primera contra un par que no es el
+        suyo. Sin campo o sin barra elegida cae a la de referencia, que es lo
+        único que hay.
+        """
+        if course is None:
+            return []
+        if player is None:
+            # El jugador puede no aparecer en el partido; el resto del cálculo
+            # ya lo contempla y sigue con lo que haya.
+            return course.reference_card
+        return course.hole_card_for(player.tee_color, player.tee_gender)
 
     @staticmethod
     def _find_participant(match, user_id: UserId):

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -344,14 +344,7 @@ class GetRecentMatchesUseCase:
         ]
         opponents = [self._user_name(player.user_id, users_by_id) for player in rival_team]
         # El par y el indice son de la barra de quien juega, no del campo
-        own_player = next(
-            (
-                player
-                for player in (*match.team_a_players, *match.team_b_players)
-                if player.user_id == user_id
-            ),
-            None,
-        )
+        own_player = match.find_player(user_id)
         hole_card = (
             []
             if course is None

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -343,7 +343,23 @@ class GetRecentMatchesUseCase:
             if player.user_id != user_id
         ]
         opponents = [self._user_name(player.user_id, users_by_id) for player in rival_team]
-        total_strokes, holes_played, points = self._scorecard_totals(raw, course)
+        # El par y el indice son de la barra de quien juega, no del campo
+        own_player = next(
+            (
+                player
+                for player in (*match.team_a_players, *match.team_b_players)
+                if player.user_id == user_id
+            ),
+            None,
+        )
+        hole_card = (
+            []
+            if course is None
+            else course.hole_card_for(own_player.tee_color, own_player.tee_gender)
+            if own_player is not None
+            else course.reference_card
+        )
+        total_strokes, holes_played, points = self._scorecard_totals(raw, hole_card)
 
         return RecentMatchDTO(
             id=str(match.id.value),
@@ -491,7 +507,12 @@ class GetRecentMatchesUseCase:
         if not scores_by_hole:
             return None
 
-        holes = [HoleSetup(hole.number, hole.par, hole.stroke_index) for hole in course.holes]
+        holes = [
+            HoleSetup(hole.number, hole.par, hole.stroke_index)
+            for hole in course.hole_card_for(
+                raw.participant.tee_color, raw.participant.tee_gender
+            )
+        ]
         # En una partida scratch nadie recibe golpes, tampoco para los puntos
         # Stableford ni el resultado contra el par: sin esto, una vuelta jugada a
         # bruto se apuntaba como si le hubieran dado golpes.
@@ -507,7 +528,7 @@ class GetRecentMatchesUseCase:
             allowance_percentage=raw.match.get_effective_allowance(),
         )
 
-    def _scorecard_totals(self, raw: _CompetitionMatchRaw, course) -> tuple:
+    def _scorecard_totals(self, raw: _CompetitionMatchRaw, hole_card: list) -> tuple:
         """
         Golpes, hoyos y puntos Stableford de una tarjeta de torneo.
 
@@ -517,10 +538,10 @@ class GetRecentMatchesUseCase:
         el hoyo, y una tarjeta legítima sin validar cerrar se quedaría sin
         cifras que enseñar.
         """
-        if course is None:
+        if not hole_card:
             return None, None, None
 
-        pars = {hole.number: hole.par for hole in course.holes}
+        pars = {hole.number: hole.par for hole in hole_card}
         scored = [
             hole_score
             for hole_score in raw.hole_scores

--- a/src/shared/domain/services/countable_round.py
+++ b/src/shared/domain/services/countable_round.py
@@ -12,7 +12,7 @@ la media del jugador, tampoco lo es para presumir de ella delante de sus amigos.
 HALF_ROUND_HOLES = 9
 
 
-def countable_holes(scores_by_hole: dict, course) -> list | None:
+def countable_holes(scores_by_hole: dict, hole_card: list) -> list | None:
     """
     Los hoyos que forman una vuelta computable, o None si no forman ninguna.
 
@@ -23,8 +23,13 @@ def countable_holes(scores_by_hole: dict, course) -> list | None:
 
     De ahí que a la media vuelta se le exija tener **exactamente** sus nueve: con
     diez anotados no hay ni vuelta entera ni mitad limpia.
+
+    Recibe la tarjeta ya resuelta y no el campo: el par y el índice son de la
+    barra que juega cada uno, y quien llama es el único que sabe cuál es. Sacar
+    aquí la tarjeta de referencia le colaba la de otra barra a quien no juega la
+    primera.
     """
-    holes = sorted(course.holes, key=lambda hole: hole.number)
+    holes = sorted(hole_card, key=lambda hole: hole.number)
     # Sin hoyos no hay vuelta que contar. Hay que decirlo explícitamente porque
     # `all()` sobre una lista vacía es cierto, así que un campo sin hoyos
     # devolvería `[]` — que no es `None` y pasaría por vuelta válida de cero

--- a/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
+++ b/tests/integration/modules/golf_course/infrastructure/persistence/test_golf_course_repository.py
@@ -166,7 +166,7 @@ async def test_save_and_find_by_id(db_session, creator_id, valid_tees, valid_hol
     assert retrieved.approval_status == ApprovalStatus.PENDING_APPROVAL
     assert retrieved.rejection_reason is None
     assert len(retrieved.tees) == 3
-    assert len(retrieved.holes) == 18
+    assert len(retrieved.reference_card) == 18
     assert retrieved.total_par == 72
 
 
@@ -1004,6 +1004,6 @@ async def test_repository_preserves_hole_order(db_session, creator_id, valid_tee
     # Assert
     retrieved = await repository.find_by_id(golf_course.id)
     assert retrieved is not None
-    assert len(retrieved.holes) == 18
-    hole_numbers = [hole.number for hole in retrieved.holes]
+    assert len(retrieved.reference_card) == 18
+    hole_numbers = [hole.number for hole in retrieved.reference_card]
     assert hole_numbers == list(range(1, 19))  # Orden preservado 1-18

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -2,7 +2,7 @@
 Tests del TeeContextBuilder.
 
 Los dos fallos que motivaron este servicio venian de valorar todas las barras
-contra la tarjeta de referencia del campo: `golf_course.holes` es solo la de la
+contra la tarjeta de referencia del campo: `golf_course.reference_card` es solo la de la
 PRIMERA barra. De los 800 campos federados importados con mas de una barra con
 tarjeta, 25 tienen par distinto entre barras y 56 stroke index distinto.
 """

--- a/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_generate_matches_use_case.py
@@ -621,7 +621,7 @@ class TestGenerateMatchesUseCase:
 
         golf_course = MagicMock()
         golf_course.tees = tees
-        golf_course.holes = holes
+        golf_course.reference_card = holes
 
         return golf_course
 

--- a/tests/unit/modules/competition/application/use_cases/test_get_scoring_view_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_get_scoring_view_use_case.py
@@ -1,0 +1,184 @@
+"""
+Tests de GetScoringViewUseCase, centrados en la tarjeta de cada jugador.
+
+El par, el índice y los metros son de la barra desde la que se juega, no del
+campo: `reference_card` es solo la tarjeta derivada de la primera salida con
+tarjeta, y de los 800 campos federados con más de una, 56 cambian de stroke
+index entre ellas y 25 de par. Servir esa tarjeta a todo el partido le enseña a
+quien no juega la primera barra un par que no es el suyo, mientras sus golpes
+sí se reparten con el índice de la suya.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.competition.application.use_cases.get_scoring_view_use_case import (
+    GetScoringViewUseCase,
+)
+from src.modules.competition.domain.entities.match import Match
+from src.modules.competition.domain.services.scoring_service import ScoringService
+from src.modules.competition.domain.value_objects.match_player import MatchPlayer
+from src.modules.competition.domain.value_objects.round_id import RoundId
+from src.modules.competition.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
+    InMemoryUnitOfWork,
+)
+from src.modules.golf_course.domain.entities.golf_course import GolfCourse
+from src.modules.golf_course.domain.entities.hole import Hole
+from src.modules.golf_course.domain.entities.tee import Tee
+from src.modules.golf_course.domain.value_objects.course_type import CourseType
+from src.modules.golf_course.domain.value_objects.tee_color import TeeColor
+from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.domain.value_objects.country_code import CountryCode
+from src.shared.domain.value_objects.gender import Gender
+
+PAR_72 = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
+
+
+def _card(pars: list[int], meters: int) -> list[Hole]:
+    return [
+        Hole(number=i + 1, par=pars[i], stroke_index=i + 1, meters=meters) for i in range(18)
+    ]
+
+
+def _course_two_tees() -> GolfCourse:
+    """
+    Amarillas y rojas con tarjetas distintas.
+
+    El hoyo 1 juega par 4 desde amarillas y par 5 desde rojas: es el caso real
+    del hoyo que las mujeres juegan como par 5 y los hombres como par 4.
+    """
+    red_pars = list(PAR_72)
+    red_pars[0] = 5
+    return GolfCourse.create(
+        name="Test Course",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=UserId.generate(),
+        tees=[
+            Tee(
+                color=TeeColor.YELLOW,
+                gender=Gender.MALE,
+                course_rating=71.0,
+                slope_rating=128,
+                holes=_card(PAR_72, meters=350),
+            ),
+            Tee(
+                color=TeeColor.RED,
+                gender=Gender.FEMALE,
+                course_rating=73.0,
+                slope_rating=131,
+                holes=_card(red_pars, meters=300),
+            ),
+        ],
+        holes=_card(PAR_72, meters=350),
+    )
+
+
+@pytest.fixture
+def uow():
+    return InMemoryUnitOfWork()
+
+
+@pytest.fixture
+def user_repo():
+    def _make_mock_user(uid):
+        user = MagicMock()
+        user.first_name = "Player"
+        user.last_name = str(uid)[:8]
+        return user
+
+    repo = AsyncMock()
+    repo.find_by_id = AsyncMock(side_effect=_make_mock_user)
+    return repo
+
+
+async def _setup(uow, course: GolfCourse | None):
+    """Un partido de dos jugadores, uno por barra, listo para pedir la vista."""
+    yellow = MatchPlayer.create(
+        user_id=UserId.generate(),
+        playing_handicap=10,
+        tee_color=TeeColor.YELLOW,
+        tee_gender=Gender.MALE,
+        strokes_received=[],
+    )
+    red = MatchPlayer.create(
+        user_id=UserId.generate(),
+        playing_handicap=18,
+        tee_color=TeeColor.RED,
+        tee_gender=Gender.FEMALE,
+        strokes_received=[],
+    )
+    round_id = RoundId.generate()
+    mock_round = MagicMock()
+    mock_round.id = round_id
+    mock_round.competition_id = MagicMock()
+    mock_round.round_date = None
+    mock_round.session_type = MagicMock(value="MORNING")
+    mock_round.match_format = MagicMock(value="SINGLES")
+    mock_round.golf_course_id = MagicMock()
+
+    match = Match.create(
+        round_id=round_id, match_number=1, team_a_players=[yellow], team_b_players=[red]
+    )
+    match.start()
+    await uow.matches.add(match)
+    uow._rounds._rounds[round_id] = mock_round
+
+    mock_comp = MagicMock()
+    mock_comp.id = mock_round.competition_id
+    mock_comp.team_1_name = "Team A"
+    mock_comp.team_2_name = "Team B"
+    uow._competitions._competitions[mock_comp.id] = mock_comp
+
+    gc_repo = AsyncMock()
+    gc_repo.find_by_id = AsyncMock(return_value=course)
+    return match, yellow, red, gc_repo
+
+
+class TestHoleCardPerPlayer:
+    @pytest.mark.asyncio
+    async def test_cada_jugador_recibe_la_tarjeta_de_su_barra(self, uow, user_repo):
+        match, yellow, red, gc_repo = await _setup(uow, _course_two_tees())
+        uc = GetScoringViewUseCase(uow, user_repo, ScoringService(), gc_repo)
+
+        view = await uc.execute(str(match.id))
+
+        cards = {p.user_id: p.hole_card for p in view.players}
+        assert cards[str(yellow.user_id)][0].par == 4
+        assert cards[str(red.user_id)][0].par == 5
+
+    @pytest.mark.asyncio
+    async def test_la_tarjeta_lleva_los_metros_de_su_barra(self, uow, user_repo):
+        match, yellow, red, gc_repo = await _setup(uow, _course_two_tees())
+        uc = GetScoringViewUseCase(uow, user_repo, ScoringService(), gc_repo)
+
+        view = await uc.execute(str(match.id))
+
+        cards = {p.user_id: p.hole_card for p in view.players}
+        assert cards[str(yellow.user_id)][0].meters == 350
+        assert cards[str(red.user_id)][0].meters == 300
+
+    @pytest.mark.asyncio
+    async def test_la_tarjeta_viene_ordenada_y_completa(self, uow, user_repo):
+        match, yellow, _, gc_repo = await _setup(uow, _course_two_tees())
+        uc = GetScoringViewUseCase(uow, user_repo, ScoringService(), gc_repo)
+
+        view = await uc.execute(str(match.id))
+
+        card = next(p.hole_card for p in view.players if p.user_id == str(yellow.user_id))
+        assert [hole.hole_number for hole in card] == list(range(1, 19))
+
+    @pytest.mark.asyncio
+    async def test_sin_campo_cargado_los_jugadores_van_sin_tarjeta(self, uow, user_repo):
+        """
+        La vista ya sale sin hoyos cuando no hay campo; lo que no puede es
+        reventar ni inventarse una tarjeta.
+        """
+        match, _, _, gc_repo = await _setup(uow, None)
+        uc = GetScoringViewUseCase(uow, user_repo, ScoringService(), gc_repo)
+
+        view = await uc.execute(str(match.id))
+
+        assert view.holes == []
+        assert all(p.hole_card == [] for p in view.players)

--- a/tests/unit/modules/golf_course/application/use_cases/test_approve_update_golf_course.py
+++ b/tests/unit/modules/golf_course/application/use_cases/test_approve_update_golf_course.py
@@ -128,7 +128,7 @@ class TestApproveUpdateGolfCourseUseCase:
             course_type=clone.course_type,
             creator_id=clone.creator_id,
             tees=clone.tees,
-            holes=clone.holes,
+            holes=clone.reference_card,
             approval_status=ApprovalStatus.PENDING_APPROVAL,
             rejection_reason=None,
             created_at=clone.created_at,

--- a/tests/unit/modules/golf_course/application/use_cases/test_reject_update_golf_course.py
+++ b/tests/unit/modules/golf_course/application/use_cases/test_reject_update_golf_course.py
@@ -128,7 +128,7 @@ class TestRejectUpdateGolfCourseUseCase:
             course_type=clone.course_type,
             creator_id=clone.creator_id,
             tees=clone.tees,
-            holes=clone.holes,
+            holes=clone.reference_card,
             approval_status=ApprovalStatus.PENDING_APPROVAL,
             rejection_reason=None,
             created_at=clone.created_at,

--- a/tests/unit/modules/golf_course/domain/entities/test_golf_course.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_golf_course.py
@@ -116,7 +116,7 @@ def test_create_golf_course_success(valid_tees, valid_holes):
     assert golf_course.course_type == course_type
     assert golf_course.creator_id == creator_id
     assert len(golf_course.tees) == 3
-    assert len(golf_course.holes) == 18
+    assert len(golf_course.reference_card) == 18
     assert golf_course.approval_status == ApprovalStatus.PENDING_APPROVAL
     assert golf_course.rejection_reason is None
     assert golf_course.total_par == 72  # sum of pars
@@ -686,7 +686,7 @@ def test_golf_course_holes_property_returns_copy(valid_tees, valid_holes):
     )
 
     # When
-    holes_copy = golf_course.holes
+    holes_copy = golf_course.reference_card
 
     # Then
     assert holes_copy is not golf_course._holes  # Es una copia

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -635,3 +635,39 @@ class TestHoleCardFor:
 
         assert male[0].meters == 350
         assert female[0].meters == 300
+
+    def test_resuelve_una_salida_other_sin_su_identificador(self) -> None:
+        """
+        Las "Championship" y las combinadas se guardan como OTHER, y son de las
+        que más veces traen tarjeta propia. Ni `MatchPlayer` ni
+        `QuickMatchParticipant` guardan el identificador de la salida, así que
+        exigirlo aquí las dejaba sin resolver: al jugador se le repartían los
+        golpes con su barra —los context builders indexan por (color, género)—
+        y se le puntuaba con la tarjeta de referencia.
+        """
+        champ_pars = list(PAR_72)
+        champ_pars[0] = 5
+        course = build_course(
+            [
+                Tee(
+                    color=TeeColor.OTHER,
+                    gender=Gender.MALE,
+                    identifier="Championship",
+                    course_rating=74.0,
+                    slope_rating=140,
+                    holes=build_holes(champ_pars, meters=400),
+                ),
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=Gender.MALE,
+                    course_rating=71.0,
+                    slope_rating=128,
+                    holes=build_holes(meters=350),
+                ),
+            ]
+        )
+
+        card = course.hole_card_for(TeeColor.OTHER, Gender.MALE)
+
+        assert card[0].par == 5
+        assert card[0].meters == 400

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -671,3 +671,81 @@ class TestHoleCardFor:
 
         assert card[0].par == 5
         assert card[0].meters == 400
+
+    def test_con_dos_salidas_other_coge_la_misma_que_el_reparto(self) -> None:
+        """
+        Dos salidas OTHER del mismo género son legales: `unique_key` las separa
+        por identificador (#190). Los context builders indexan por
+        `(color, género)` dentro de un bucle, así que se quedan con la última;
+        coger aquí la primera repartía los golpes con una barra y puntuaba con
+        la otra.
+        """
+        champ_pars = list(PAR_72)
+        champ_pars[0] = 5
+        combi_pars = list(PAR_72)
+        combi_pars[1] = 3
+        course = build_course(
+            [
+                Tee(
+                    color=TeeColor.OTHER,
+                    gender=Gender.MALE,
+                    identifier="Championship",
+                    course_rating=74.0,
+                    slope_rating=140,
+                    holes=build_holes(champ_pars, meters=400),
+                ),
+                Tee(
+                    color=TeeColor.OTHER,
+                    gender=Gender.MALE,
+                    identifier="Combinadas",
+                    course_rating=71.0,
+                    slope_rating=125,
+                    holes=build_holes(combi_pars, meters=330),
+                ),
+            ]
+        )
+
+        card = course.hole_card_for(TeeColor.OTHER, Gender.MALE)
+
+        assert course.tee_for(TeeColor.OTHER, Gender.MALE).identifier == "Combinadas"
+        assert card[1].par == 3
+        assert card[0].meters == 330
+
+    def test_resuelve_una_salida_sin_genero_con_identificador(self) -> None:
+        """
+        El jugador manda color y género; la salida puede no tener género y sí
+        identificador, que es como quedan las OTHER. `find_tee` exige que el
+        identificador coincida, así que buscar por ahí se la saltaba y el
+        jugador acababa contra la tarjeta del campo.
+
+        Nota: esto cubre la reserva de `tee_for`, no la caída de
+        `hole_card_for` a la salida sin género. Esa segunda es defensiva y hoy
+        no se puede alcanzar: `_sync_holes_and_tees` copia la tarjeta del campo
+        a toda salida que no traiga la suya, así que ninguna se queda sin ella.
+        """
+        sin_genero_pars = list(PAR_72)
+        sin_genero_pars[0] = 5
+        course = build_course(
+            [
+                Tee(
+                    color=TeeColor.OTHER,
+                    gender=None,
+                    identifier="Championship",
+                    course_rating=74.0,
+                    slope_rating=140,
+                    holes=build_holes(sin_genero_pars, meters=400),
+                ),
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=Gender.MALE,
+                    course_rating=71.0,
+                    slope_rating=128,
+                    holes=build_holes(meters=350),
+                ),
+            ]
+        )
+
+        card = course.hole_card_for(TeeColor.OTHER, Gender.MALE)
+
+        assert card[0].par == 5
+        assert card[0].meters == 400

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -749,3 +749,16 @@ class TestHoleCardFor:
 
         assert card[0].par == 5
         assert card[0].meters == 400
+
+    def test_sin_barra_elegida_devuelve_la_tarjeta_de_referencia(self) -> None:
+        """
+        `QuickMatchParticipant.tee_color` es opcional: una partida creada antes
+        de que el frontend exigiera la barra no dice desde dónde se jugó. Sin
+        color no hay barra que resolver y queda la tarjeta del campo, que es lo
+        único que hay — pero conviene fijarlo, porque hoy sale de que ningún
+        `tee.color` iguala a `None` y no de una decisión escrita.
+        """
+        course = self._course_with_two_cards()
+
+        assert course.hole_card_for(None, None) == course.reference_card
+        assert course.hole_card_for(None, Gender.MALE) == course.reference_card

--- a/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
+++ b/tests/unit/modules/golf_course/domain/entities/test_tee_scorecard.py
@@ -232,7 +232,7 @@ def test_course_holes_are_derived_from_first_tee_when_absent():
     WHEN: Se crea sin tarjeta de campo
     THEN: La tarjeta de referencia sale de la primera salida
 
-    Así los consumidores que leen golf_course.holes siguen funcionando.
+    Así los consumidores que leen golf_course.reference_card siguen funcionando.
     """
     # Given
     tees = [
@@ -256,7 +256,7 @@ def test_course_holes_are_derived_from_first_tee_when_absent():
     course = build_course(tees, holes=[])
 
     # Then
-    assert len(course.holes) == 18
+    assert len(course.reference_card) == 18
     assert course.total_par == sum(PAR_72)
 
 
@@ -542,3 +542,96 @@ def test_pitch_and_putt_rejects_standard_par():
 
     with pytest.raises(ValueError, match="Total par for a PITCH_AND_PUTT"):
         build_course(tees, course_type=CourseType.PITCH_AND_PUTT)
+
+
+class TestHoleCardFor:
+    """
+    Tarjeta que juega cada salida.
+
+    El par, el índice y los metros son de la barra: `reference_card` es solo la
+    derivada de la primera que tenga tarjeta. Resolver la barra estaba copiado
+    en los dos context builders y en el frontend; vive aquí para que haya una
+    sola respuesta a "qué tarjeta juega este jugador".
+    """
+
+    @staticmethod
+    def _course_with_two_cards() -> GolfCourse:
+        """Amarillas y rojas con par e índice distintos en el hoyo 1."""
+        yellow_pars = list(PAR_72)
+        red_pars = list(PAR_72)
+        red_pars[0] = 5  # el 1 juega par 5 desde rojas y par 4 desde amarillas
+        return build_course(
+            [
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=Gender.MALE,
+                    course_rating=71.0,
+                    slope_rating=128,
+                    holes=build_holes(yellow_pars, meters=350),
+                ),
+                Tee(
+                    color=TeeColor.RED,
+                    gender=Gender.FEMALE,
+                    course_rating=73.0,
+                    slope_rating=131,
+                    holes=build_holes(red_pars, meters=300),
+                ),
+            ]
+        )
+
+    def test_devuelve_la_tarjeta_de_esa_salida(self) -> None:
+        course = self._course_with_two_cards()
+
+        yellow = course.hole_card_for(TeeColor.YELLOW, Gender.MALE)
+        red = course.hole_card_for(TeeColor.RED, Gender.FEMALE)
+
+        assert yellow[0].par == 4
+        assert red[0].par == 5
+        assert yellow[0].meters == 350
+        assert red[0].meters == 300
+
+    def test_reserva_a_la_salida_sin_genero(self) -> None:
+        """
+        El jugador siempre manda color y género; un campo dado de alta a mano
+        puede tener la barra sin género. Sin la reserva no se encontraría.
+        """
+        course = build_course(
+            [
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=None,
+                    course_rating=71.0,
+                    slope_rating=128,
+                    holes=build_holes(meters=333),
+                ),
+                Tee(color=TeeColor.RED, gender=None, course_rating=70.0, slope_rating=120),
+            ]
+        )
+
+        card = course.hole_card_for(TeeColor.YELLOW, Gender.MALE)
+
+        assert card[0].meters == 333
+
+    def test_cae_a_la_tarjeta_de_referencia_si_la_salida_no_trae_la_suya(self) -> None:
+        course = self._course_with_two_cards()
+
+        card = course.hole_card_for(TeeColor.BLUE, Gender.MALE)
+
+        assert [hole.par for hole in card] == [hole.par for hole in course.reference_card]
+
+    def test_el_genero_exacto_gana_a_la_reserva(self) -> None:
+        """
+        Con la barra valorada por género, cada jugador juega la suya.
+
+        El dominio prohíbe que un mismo color tenga a la vez salida con género y
+        sin él (`cannot mix gendered and non-gendered tees`), así que la reserva
+        de `tee_for` solo entra cuando el campo no distingue género en absoluto:
+        no puede tapar la salida propia de nadie.
+        """
+        course = self._course_with_two_cards()
+
+        male = course.hole_card_for(TeeColor.YELLOW, Gender.MALE)
+        female = course.hole_card_for(TeeColor.RED, Gender.FEMALE)
+
+        assert male[0].meters == 350
+        assert female[0].meters == 300

--- a/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stroke_allocation_service.py
@@ -506,7 +506,7 @@ class TestReviewFindings:
         When cada jugador juega la suya
         Then cada uno recibe en los hoyos de SU barra
 
-        Pasa en 56 de los 800 campos federados importados. `golf_course.holes`
+        Pasa en 56 de los 800 campos federados importados. `golf_course.reference_card`
         es solo la tarjeta de la primera barra, asi que sin esto el que juega la
         otra recibia los golpes en los hoyos equivocados.
         """

--- a/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_publish_round_achievements_use_case.py
@@ -165,6 +165,8 @@ async def _played_match(
     scores_by_hole: dict | None = None,
     others=(),
     complete: bool = True,
+    tee_color: TeeColor = TeeColor.YELLOW,
+    tee_gender: Gender = Gender.MALE,
 ):
     """Una partida rapida terminada con la vuelta anotada."""
     match = QuickMatch.create(
@@ -172,8 +174,8 @@ async def _played_match(
         creator_id=user.id,
         golf_course_id=course.id,
         scoring_format=ScoringFormat.MEDAL,
-        creator_tee_color=TeeColor.YELLOW,
-        creator_tee_gender=Gender.MALE,
+        creator_tee_color=tee_color,
+        creator_tee_gender=tee_gender,
     )
     for participant in others:
         match.add_participant(participant)
@@ -520,3 +522,77 @@ class TestIdempotencia:
 
         eventos = await _feed_de(social_uow, user)
         assert len(eventos) == 2  # BIRDIE + NEW_COURSE, una sola vez cada uno
+
+
+class TestParPorBarra:
+    """
+    Un birdie se mide contra el par de la barra que se juega.
+
+    En 25 de los 800 campos federados el par cambia entre barras. Con la
+    tarjeta de referencia, a quien juega otra barra se le cuenta como par lo
+    que fue birdie — y al revés.
+    """
+
+    @staticmethod
+    async def _course_with_longer_red(golf_course_uow, creator_id):
+        """El hoyo 1 es par 5 desde rojas y par 4 en la tarjeta del campo."""
+        course = GolfCourse.create(
+            name="Two Cards Club",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.STANDARD_18,
+            creator_id=creator_id,
+            tees=[
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=Gender.MALE,
+                    identifier="Yellow",
+                    course_rating=70.0,
+                    slope_rating=125,
+                    holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+                ),
+                Tee(
+                    color=TeeColor.RED,
+                    gender=Gender.FEMALE,
+                    identifier="Red",
+                    course_rating=72.0,
+                    slope_rating=130,
+                    holes=[
+                        Hole(number=i, par=PAR + 1 if i == 1 else PAR, stroke_index=i)
+                        for i in range(1, 19)
+                    ],
+                ),
+            ],
+            holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+        )
+        course.approve()
+        async with golf_course_uow:
+            await golf_course_uow.golf_courses.save(course)
+        return course
+
+    async def test_el_birdie_se_mide_contra_el_par_de_su_barra(
+        self, social_uow, qm_uow, golf_course_uow, user_uow
+    ):
+        """
+        Un 4 en el hoyo 1 es birdie desde rojas (par 5) y solo par desde la
+        tarjeta del campo, que es contra la que se medía antes.
+        """
+        user = await _create_user(user_uow)
+        course = await self._course_with_longer_red(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 19), PAR)
+        match = await _played_match(
+            qm_uow,
+            course,
+            user,
+            scores_by_hole=tarjeta,
+            tee_color=TeeColor.RED,
+            tee_gender=Gender.FEMALE,
+        )
+
+        await _use_case(social_uow, qm_uow, golf_course_uow, user_uow).execute(
+            str(match.id.value)
+        )
+
+        eventos = await _feed_de(social_uow, user)
+        birdies = [e for e in eventos if e.type == ActivityEventType.BIRDIE]
+        assert len(birdies) == 1
+        assert birdies[0].payload["holes"] == [1]

--- a/tests/unit/modules/social/application/use_cases/test_publish_tournament_achievements_use_case.py
+++ b/tests/unit/modules/social/application/use_cases/test_publish_tournament_achievements_use_case.py
@@ -164,6 +164,8 @@ async def _completed_tournament(
     matches: int = 1,
     round_date: date = ROUND_DATE,
     complete: bool = True,
+    tee_color: TeeColor = TeeColor.YELLOW,
+    tee_gender: Gender = Gender.MALE,
 ):
     """Un torneo terminado con la tarjeta del jugador anotada en cada partido."""
     competition = Competition.create(
@@ -194,8 +196,8 @@ async def _completed_tournament(
         return MatchPlayer(
             user_id=user_id,
             playing_handicap=0,
-            tee_color=TeeColor.YELLOW,
-            tee_gender=Gender.MALE,
+            tee_color=tee_color,
+            tee_gender=tee_gender,
             # Scratch: no recibe golpe en ningun hoyo
             strokes_received=(),
         )
@@ -415,3 +417,65 @@ async def test_un_torneo_que_no_existe_no_rompe(
     ).execute(str(uuid4()))
 
     assert publicados == 0
+
+
+async def test_el_birdie_de_torneo_se_mide_contra_el_par_de_su_barra(
+    social_uow, competition_uow, golf_course_uow, user_uow
+):
+    """
+    Un 4 en el hoyo 1 es birdie desde rojas (par 5) y solo par en la tarjeta
+    del campo, que es contra la que se medía antes. En 25 de los 800 campos
+    federados el par cambia de una barra a otra.
+    """
+    player = await _create_user(user_uow)
+    rival = await _create_user(user_uow)
+    course = GolfCourse.create(
+        name="Two Cards Club",
+        country_code=CountryCode("ES"),
+        course_type=CourseType.STANDARD_18,
+        creator_id=player.id,
+        tees=[
+            Tee(
+                color=TeeColor.YELLOW,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+                holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+            ),
+            Tee(
+                color=TeeColor.RED,
+                gender=Gender.FEMALE,
+                identifier="Red",
+                course_rating=72.0,
+                slope_rating=130,
+                holes=[
+                    Hole(number=i, par=PAR + 1 if i == 1 else PAR, stroke_index=i)
+                    for i in range(1, 19)
+                ],
+            ),
+        ],
+        holes=[Hole(number=i, par=PAR, stroke_index=i) for i in range(1, 19)],
+    )
+    course.approve()
+    async with golf_course_uow:
+        await golf_course_uow.golf_courses.save(course)
+
+    competition, _ = await _completed_tournament(
+        competition_uow,
+        course,
+        player,
+        rival,
+        scores_by_hole=dict.fromkeys(range(1, 19), PAR),
+        tee_color=TeeColor.RED,
+        tee_gender=Gender.FEMALE,
+    )
+
+    await _use_case(social_uow, competition_uow, golf_course_uow, user_uow).execute(
+        str(competition.id.value)
+    )
+
+    eventos = await _feed_de(social_uow, player)
+    birdies = [e for e in eventos if e.type == ActivityEventType.BIRDIE]
+    assert len(birdies) == 1
+    assert birdies[0].payload["holes"] == [1]

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -1125,3 +1125,76 @@ class TestScoringRecordWindow:
         assert stats.rounds_with_differential == 21
         assert len(stats.differentials) == 20
         assert min(stats.differentials) == stats.best_differential
+
+
+class TestParPorBarra:
+    """
+    La media se mide contra el par de la barra jugada.
+
+    En 25 de los 800 campos federados el par cambia de una barra a otra. Medir
+    a todos contra la tarjeta de referencia le cuenta a quien juega otra barra
+    una vuelta mejor o peor de la que hizo.
+    """
+
+    @staticmethod
+    async def _course_with_longer_red(golf_course_uow, creator_id):
+        """Rojas juegan par 5 los hoyos 1 y 2 (par 74); el campo, par 72."""
+        tees = [
+            Tee(
+                color=TeeColor.YELLOW,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+                holes=[Hole(number=i, par=4, stroke_index=i) for i in range(1, 19)],
+            ),
+            Tee(
+                color=TeeColor.RED,
+                gender=Gender.FEMALE,
+                identifier="Red",
+                course_rating=72.0,
+                slope_rating=130,
+                holes=[
+                    Hole(number=i, par=5 if i in (1, 2) else 4, stroke_index=i)
+                    for i in range(1, 19)
+                ],
+            ),
+        ]
+        course = GolfCourse.create(
+            name="Two Cards Club",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.STANDARD_18,
+            creator_id=creator_id,
+            tees=tees,
+            holes=[Hole(number=i, par=4, stroke_index=i) for i in range(1, 19)],
+        )
+        course.approve()
+        async with golf_course_uow:
+            await golf_course_uow.golf_courses.save(course)
+        return course
+
+    @pytest.mark.asyncio
+    async def test_la_media_va_contra_el_par_de_su_barra(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Scratch de rojas (par 74) firmando 4 en todos los hoyos: 72 golpes,
+        dos bajo su par. Contra la tarjeta del campo (par 72) daría 0, que es
+        lo que salía antes.
+        """
+        user = await create_user(user_uow, unique_email("red"), handicap=0)
+        course = await self._course_with_longer_red(golf_course_uow, user.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            user,
+            strokes_per_hole=4,
+            tee_color=TeeColor.RED,
+            tee_gender=Gender.FEMALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.scoring_avg == -2.0

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -151,6 +151,7 @@ async def _played_quick_match(
     holes: list[int] | None = None,
     tee_color: TeeColor | None = None,
     tee_gender: Gender | None = None,
+    scores_by_hole: dict[int, int] | None = None,
 ):
     """
     Una partida rápida terminada con la vuelta anotada.
@@ -190,7 +191,7 @@ async def _played_quick_match(
                         quick_match_id=match.id,
                         hole_number=hole_number,
                         participant_id=participant.participant_id,
-                        score=strokes_per_hole,
+                        score=(scores_by_hole or {}).get(hole_number, strokes_per_hole),
                         recorded_by_participant_id=creator_participant_id,
                     )
                 )
@@ -1198,3 +1199,37 @@ class TestParPorBarra:
         )
 
         assert stats.scoring_avg == -2.0
+
+    @pytest.mark.asyncio
+    async def test_la_base_de_golpes_sale_del_par_de_su_barra(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El par entra en el Course Handicap como `(CR - Par)`, así que con el par
+        del campo el jugador de otra barra recibe golpes de más y su tope de
+        doble bogey neto sube: el diferencial sale mejor de lo que jugó.
+
+        Índice 10 desde rojas (par 74, CR 72, SR 130): 10 x 130/113 - 2 = 9.5,
+        que redondea a 10 golpes. Con el par del campo serían 11.5 -> 12, dos
+        golpes de más, y el desastre del hoyo con índice 11 se topa un golpe más
+        arriba.
+        """
+        user = await create_user(user_uow, unique_email("base"), handicap=10)
+        course = await self._course_with_longer_red(golf_course_uow, user.id)
+        tarjeta = dict.fromkeys(range(1, 19), 4)
+        tarjeta[11] = 9  # el hoyo de stroke index 11, donde cambia el reparto
+        await _played_quick_match(
+            qm_uow,
+            course,
+            user,
+            holes=list(range(1, 19)),
+            tee_color=TeeColor.RED,
+            tee_gender=Gender.FEMALE,
+            scores_by_hole=tarjeta,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.best_differential == 1.7

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -1233,3 +1233,64 @@ class TestParPorBarra:
         )
 
         assert stats.best_differential == 1.7
+
+    @pytest.mark.asyncio
+    async def test_una_barra_con_par_fuera_de_rango_no_borra_la_vuelta(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        `TeeRating` rechaza el par fuera de 66-76, y valorar la barra por su
+        propio par metió ese rechazo donde antes no llegaba: la vuelta se
+        quedaba sin rating, sin diferencial y desaparecía de las estadísticas.
+        Un dato suelto del importador no puede borrar una vuelta que sí se
+        jugó, así que se valora contra el par del campo.
+        """
+        user = await create_user(user_uow, unique_email("short"), handicap=10)
+        referencia = [Hole(number=i, par=4 if i <= 13 else 3, stroke_index=i) for i in range(1, 19)]
+        roja = [Hole(number=i, par=4 if i <= 11 else 3, stroke_index=i) for i in range(1, 19)]
+        assert sum(h.par for h in roja) == 65  # fuera del rango WHS, a propósito
+
+        course = GolfCourse.create(
+            name="Short Course",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.STANDARD_18,
+            creator_id=user.id,
+            tees=[
+                Tee(
+                    color=TeeColor.YELLOW,
+                    gender=Gender.MALE,
+                    identifier="Yellow",
+                    course_rating=67.0,
+                    slope_rating=113,
+                    holes=referencia,
+                ),
+                Tee(
+                    color=TeeColor.RED,
+                    gender=Gender.FEMALE,
+                    identifier="Red",
+                    course_rating=66.0,
+                    slope_rating=110,
+                    holes=roja,
+                ),
+            ],
+            holes=referencia,
+        )
+        course.approve()
+        async with golf_course_uow:
+            await golf_course_uow.golf_courses.save(course)
+
+        await _played_quick_match(
+            qm_uow,
+            course,
+            user,
+            strokes_per_hole=4,
+            tee_color=TeeColor.RED,
+            tee_gender=Gender.FEMALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_with_differential == 1
+        assert stats.best_differential is not None

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -152,6 +152,8 @@ async def played_quick_match(
     strokes_by_participant_index: dict[int, int] | None = None,
     strokes_per_hole: int = 4,
     holes_played: int = 18,
+    creator_tee_color: TeeColor | None = None,
+    creator_tee_gender: Gender | None = None,
 ):
     """
     Una partida rápida terminada con la vuelta anotada.
@@ -167,6 +169,8 @@ async def played_quick_match(
         golf_course_id=golf_course.id,
         match_format=match_format,
         scoring_format=scoring_format,
+        creator_tee_color=creator_tee_color,
+        creator_tee_gender=creator_tee_gender,
     )
     for participant in others:
         match.add_participant(participant)
@@ -692,3 +696,79 @@ class TestComparableFigures:
         assert entry.holes_played == 9
         assert entry.total_strokes == 45
         assert entry.stableford_points == 9
+
+
+class TestParPorBarra:
+    """
+    Los puntos se cuentan contra el par de la barra que se juega.
+
+    `reference_card` es la tarjeta derivada de la primera salida. En 25 de los
+    800 campos federados el par cambia de una barra a otra —normalmente el hoyo
+    que las mujeres juegan como par 5 y los hombres como par 4—, así que
+    puntuar a todos contra la de referencia le cuenta a quien juega otra barra
+    un birdie como par.
+    """
+
+    @staticmethod
+    async def _course_with_longer_red(golf_course_uow, creator_id):
+        """Rojas juegan par 5 los hoyos 1 y 2; la tarjeta del campo, par 4."""
+        red_holes = [
+            Hole(number=i, par=5 if i in (1, 2) else 4, stroke_index=i) for i in HOLES
+        ]
+        tees = [
+            Tee(
+                color=TeeColor.YELLOW,
+                gender=Gender.MALE,
+                identifier="Yellow",
+                course_rating=70.0,
+                slope_rating=125,
+                holes=[Hole(number=i, par=4, stroke_index=i) for i in HOLES],
+            ),
+            Tee(
+                color=TeeColor.RED,
+                gender=Gender.FEMALE,
+                identifier="Red",
+                course_rating=72.0,
+                slope_rating=130,
+                holes=red_holes,
+            ),
+        ]
+        course = GolfCourse.create(
+            name="Two Cards Club",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.STANDARD_18,
+            creator_id=creator_id,
+            tees=tees,
+            holes=[Hole(number=i, par=4, stroke_index=i) for i in HOLES],
+        )
+        course.approve()
+        async with golf_course_uow:
+            await golf_course_uow.golf_courses.save(course)
+        return course
+
+    @pytest.mark.asyncio
+    async def test_los_puntos_salen_contra_el_par_de_su_barra(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Scratch de rojas firmando 4 en todos los hoyos.
+
+        Contra su tarjeta son dos birdies (hoyos 1 y 2, par 5) y dieciséis
+        pares: 3 + 3 + 16 x 2 = 38 puntos. Contra la del campo serían 36, que es
+        lo que salía antes.
+        """
+        user = await create_user(user_uow, "Roja", handicap=0)
+        course = await self._course_with_longer_red(golf_course_uow, user.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            user,
+            scoring_format=ScoringFormat.STABLEFORD,
+            strokes_per_hole=4,
+            creator_tee_color=TeeColor.RED,
+            creator_tee_gender=Gender.FEMALE,
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
+
+        assert feed.matches[0].stableford_points == 38


### PR DESCRIPTION
Backend half of the per-tee hole data work. Frontend half is agustinEDev/RyderCupWeb#412 and must deploy right after this.

## The problem

Par, stroke index and distance belong to the **tee**, not to the course. `GolfCourse.holes` was only the card derived from the first tee that had one. Of the 800 imported federated courses with two or more tees:

| Between tees | Courses | |
|---|---|---|
| the metres differ | 574 | 71.8% |
| the stroke index differs | 56 | 7.0% |
| the par differs | 25 | 3.1% |

Stroke allocation already resolved each player's tee — `StrokeContextBuilder` and `TeeContextBuilder` both do. **Everything else did not.** Seven call sites read the reference card:

- Stableford points for a quick match (`get_recent_matches`)
- the round that counts towards a player's average, and its differential (`get_player_stats`, 3 sites)
- the achievement feed, for both quick matches and tournaments (`social`, 2 sites)
- the tournament scoring view (`get_scoring_view`)

So a player not on the first tee was measured against someone else's par, while their strokes were allocated with their own tee's index. The two halves of the same calculation disagreed.

## The fix, and why the rename is the important part

The resolution now lives **once**, in the aggregate: `GolfCourse.tee_for` and `GolfCourse.hole_card_for`, including the gender fallback that both context builders and the frontend had each copied.

**`GolfCourse.holes` is renamed to `reference_card`.** This is the part that stops it happening again. That property is what five different call sites reached for by accident, in two repositories, written at different times — because it was called "the holes" and sat right there. Named for what it actually is, it is no longer the obvious thing to grab. It is derived and never persisted (the mapper rebuilds it from the first tee on load), so no mapping, migration or contract changes.

`countable_holes` now takes the card rather than the course: choosing the card is the caller's job, because only the caller knows who played.

## Contract change

`HoleInfoDTO` gains `meters`, and each `ScoringPlayerDTO` carries its own `hole_card`, resolved server-side so the client cannot resolve it a different way.

`holes` **stays** on the response as the reference card, deprecated in its docstring. Removing it now would break production in the window between deploying this and the frontend — the lesson from the last incompatible change. It goes once the client stops reading it.

## Testing

- `pytest tests/unit/` — 2872 passing
- `mypy src/ --ignore-missing-imports` — clean, 605 files
- `ruff check src/` — clean (the 6 repo-wide warnings are in `main.py` and an integration test, both untouched here)

New tests:

- `GetScoringViewUseCase` **had no unit tests at all**. Four now cover the card per player: par per tee, metres per tee, ordering, and no course loaded.
- `GolfCourse.hole_card_for`: own card, gender fallback, fallback to the reference card, exact gender winning.
- History: a scratch player on the red tee, where holes 1 and 2 play as par 5, firing 4 everywhere.

Both new suites were verified to fail with the bug put back — the history one reports **36 points instead of 38**.

## Deliberately not here

- **The arnés de paridad FE/BE was not regenerated**: it covers stroke allocation, which is unchanged.
- **Pitch & putt** still falls outside the WHS ratings (`MIN_PAR = 66`) — that is #206.
- **Hand-entered courses** have no per-tee metres to serve, because the form never collected them. That is #200 and RyderCupWeb#413.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoring views now show each player’s hole card, including tee-specific pars, stroke indexes, and distances.
  * Hole cards are selected according to tee color, gender, and identifier, with sensible fallbacks.
* **Bug Fixes**
  * Scoring, handicaps, Stableford points, round validity, and achievement detection now use the player’s actual tee card.
  * Course listings and totals consistently use the reference card.
* **Tests**
  * Added coverage for tee-specific scoring, hole cards, achievement calculations, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->