### PR TITLE
Fix: Count a foursomes hole with one ball per side

### DIFF
--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 
 from src.modules.competition.domain.services.scoring_service import ScoringService
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
@@ -230,7 +231,9 @@ class GetQuickMatchUseCase:
             scores = scores_by_hole.get(hole_number)
             if not scores:
                 continue
-            if not all(pid in scores for pid in team_a_ids | team_b_ids):
+            if not self._hole_is_complete(
+                scores, team_a_ids, team_b_ids, quick_match.match_format
+            ):
                 continue
 
             # `calculate_hole_winner` compara scores NETOS. Pasarle el bruto hacia
@@ -239,10 +242,12 @@ class GetQuickMatchUseCase:
             team_a_scores = [
                 self._net(scores[pid], pid, hole_number, strokes_by_participant)
                 for pid in team_a_ids
+                if pid in scores
             ]
             team_b_scores = [
                 self._net(scores[pid], pid, hole_number, strokes_by_participant)
                 for pid in team_b_ids
+                if pid in scores
             ]
             hole_results.append(
                 self._scoring_service.calculate_hole_winner(
@@ -261,6 +266,32 @@ class GetQuickMatchUseCase:
             holes_remaining=standing["holes_remaining"],
             is_decided=self._scoring_service.is_match_decided(standing),
         )
+
+    @staticmethod
+    def _hole_is_complete(
+        scores: dict[ParticipantId, int],
+        team_a_ids: set[ParticipantId],
+        team_b_ids: set[ParticipantId],
+        match_format: MatchFormat,
+    ) -> bool:
+        """
+        Un hoyo cuenta para el resultado cuando cada bando ha entregado su bola.
+
+        FOURSOMES se juega a golpes alternos con UNA bola por bando, y la anota
+        cualquiera de los dos companeros. Exigir los cuatro scores —que es lo
+        correcto en FOURBALL, donde cada bando juega dos bolas y la mejor puede
+        cambiar con la que falte— dejaba sin puntuar cualquier tarjeta llevada
+        como se juega: el partido entero se quedaba sin un solo hoyo valido.
+
+        `ScoringService._best_ball` ya resolvia este caso —ignora los None y en
+        FOURSOMES toma el unico score—, asi que el supuesto de las cuatro bolas
+        vivia solo en este filtro.
+        """
+        if match_format == MatchFormat.FOURSOMES:
+            return any(pid in scores for pid in team_a_ids) and any(
+                pid in scores for pid in team_b_ids
+            )
+        return all(pid in scores for pid in team_a_ids | team_b_ids)
 
     @staticmethod
     def _net(

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -311,3 +311,129 @@ class TestStandingAppliesHandicap:
         assert other_strokes.strokes_by_hole
         # Y recibe en los hoyos mas dificiles: el campo de prueba tiene SI = numero de hoyo
         assert min(other_strokes.strokes_by_hole) == 1
+
+
+async def _create_team_match(qm_uow, match_format, creator_id, partner_id, rival_ids):
+    """Partida 2v2 en marcha: el creador queda en el bando A y anota para todos."""
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=match_format,
+    )
+    qm.add_participant(QuickMatchParticipant.for_user(partner_id, team="A"))
+    for rival_id in rival_ids:
+        qm.add_participant(QuickMatchParticipant.for_user(rival_id, team="B"))
+    qm.start([qm.creator_participant_id])
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm
+
+
+async def _score(qm_uow, qm, scorer_id, player_id, hole_number, score):
+    """Anota un golpe: propio si el jugador es el anotador, delegado si no."""
+    if player_id == scorer_id:
+        await SubmitQuickMatchHoleScoreUseCase(qm_uow).execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=player_id.value,
+                hole_number=hole_number,
+                score=score,
+            )
+        )
+        return
+    await SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService()).execute(
+        SubmitProxyHoleScoreRequestDTO(
+            quick_match_id=qm.id.value,
+            scorer_user_id=scorer_id.value,
+            target_participant_id=player_id.value,
+            hole_number=hole_number,
+            score=score,
+        )
+    )
+
+
+class TestFoursomesScoresOneBallPerSide:
+    """
+    FOURSOMES se juega a golpes alternos con UNA bola por bando.
+
+    El filtro del standing exigia los cuatro scores por hoyo, asi que una tarjeta
+    llevada como se juega —cada hoyo anotado por quien golpeo— no puntuaba ni un
+    solo hoyo y el partido se quedaba sin resultado.
+    """
+
+    async def _players(self, user_uow, tag):
+        return [
+            await create_user(user_uow, unique_email(f"{tag}-{i}")) for i in range(4)
+        ]
+
+    async def test_hole_counts_with_one_score_per_side(self, qm_uow, user_uow, golf_course_uow):
+        creator, partner, rival_a, rival_b = await self._players(user_uow, "foursomes-ok")
+        qm = await _create_team_match(
+            qm_uow, MatchFormat.FOURSOMES, creator.id, partner.id, [rival_a.id, rival_b.id]
+        )
+
+        # Una bola por bando: la del bando A la anota el creador, la del B un rival.
+        await _score(qm_uow, qm, creator.id, creator.id, 1, 4)
+        await _score(qm_uow, qm, creator.id, rival_a.id, 1, 5)
+
+        detail = await GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        ).execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is not None
+        assert detail.standing.holes_played == 1
+        assert detail.standing.leading_team == "A"
+        assert detail.standing.status == "1UP"
+
+    async def test_the_partner_may_be_the_one_who_enters_it(self, qm_uow, user_uow, golf_course_uow):
+        creator, partner, rival_a, rival_b = await self._players(user_uow, "foursomes-partner")
+        qm = await _create_team_match(
+            qm_uow, MatchFormat.FOURSOMES, creator.id, partner.id, [rival_a.id, rival_b.id]
+        )
+
+        # La bola del bando A entra a nombre del companero, no del creador: el
+        # golpe es del bando y lo anota cualquiera de los dos.
+        await _score(qm_uow, qm, creator.id, partner.id, 1, 4)
+        await _score(qm_uow, qm, creator.id, rival_b.id, 1, 6)
+
+        detail = await GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        ).execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is not None
+        assert detail.standing.holes_played == 1
+        assert detail.standing.leading_team == "A"
+
+    async def test_hole_still_needs_both_sides(self, qm_uow, user_uow, golf_course_uow):
+        creator, partner, rival_a, rival_b = await self._players(user_uow, "foursomes-half")
+        qm = await _create_team_match(
+            qm_uow, MatchFormat.FOURSOMES, creator.id, partner.id, [rival_a.id, rival_b.id]
+        )
+
+        # Solo el bando A ha entregado: no hay hoyo que comparar.
+        await _score(qm_uow, qm, creator.id, creator.id, 1, 4)
+
+        detail = await GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        ).execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is None
+
+    async def test_fourball_still_requires_every_player(self, qm_uow, user_uow, golf_course_uow):
+        creator, partner, rival_a, rival_b = await self._players(user_uow, "fourball-strict")
+        qm = await _create_team_match(
+            qm_uow, MatchFormat.FOURBALL, creator.id, partner.id, [rival_a.id, rival_b.id]
+        )
+
+        # FOURBALL si tiene dos bolas por bando: con una sin anotar, la mejor del
+        # bando aun puede cambiar, asi que el hoyo no cuenta.
+        await _score(qm_uow, qm, creator.id, creator.id, 1, 4)
+        await _score(qm_uow, qm, creator.id, rival_a.id, 1, 5)
+        await _score(qm_uow, qm, creator.id, rival_b.id, 1, 6)
+
+        detail = await GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        ).execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is None


### PR DESCRIPTION
## What was broken

A foursomes card kept the way the format is actually played — one ball per side, each hole entered by whoever hit it — produced **no result at all**. Not a wrong standing: no standing.

Reproduced on the local cluster before the fix (quick match `654c58f1`, Son Parc - Par 71): hole 1 entered on my box (5), hole 2 on my partner's (4) — nine strokes over two holes — and the classification tab read *"Todavía no hay hoyos completados"*.

## Why

`_compute_standing` skipped any hole not filled in by all four players:

```python
if not all(pid in scores for pid in team_a_ids | team_b_ids):
    continue
```

That is right for FOURBALL, which really does play two balls per side, and impossible in FOURSOMES, which plays one.

## The fix

The hole counts when **each side** has delivered its ball, whichever partner entered it. Fourball is untouched and still requires every player: with a ball missing, the side's best ball can still change.

The assumption lived only in this filter — `ScoringService._best_ball` already ignored the `None`s and, in foursomes, took the single score. The team score lists are now built only from the participants who actually have a score, so a side with one entry no longer raises.

## Tests

Four new cases in `TestFoursomesScoresOneBallPerSide`:

- a hole with one score per side counts, and the standing reads 1UP
- the **partner** may be the one who enters the side's ball
- a hole with only one side entered still does not count
- fourball still requires all four scores

Checked that the two behaviour cases **fail without the fix** (the other two pass either way, which is what makes them useful as guards).

Full unit suite: 2885 passed. `ruff` and `mypy` clean on the touched files.

## Frontend

RyderCupWeb#420 turns the four entry boxes into one per side. It depends on this, and both deploys should go out together: a client sending four scores keeps working with this change, so the order backend-then-frontend is safe.

Closes #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FOURSOMES match scoring, requiring one result per team.
  * Improved net score calculations when participants are absent.
  * Added clearer handling of incomplete holes across match formats.

* **Bug Fixes**
  * Prevented errors when scores are unavailable for absent participants.
  * Ensured FOURBALL matches still require scores from all participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->