### PR TITLE
Fix: Score foursomes crossed, as a 1 vs 1

### DIFF
--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -3,7 +3,6 @@
 from decimal import Decimal
 
 from src.modules.competition.domain.services.scoring_service import ScoringService
-from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
@@ -24,6 +23,9 @@ from src.modules.quick_match.application.services.stroke_context_builder import 
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.services.hole_completion_service import (
+    hole_is_complete,
 )
 from src.modules.quick_match.domain.services.scoring_coverage_service import (
     ScoringCoverageService,
@@ -232,9 +234,7 @@ class GetQuickMatchUseCase:
             scores = scores_by_hole.get(hole_number)
             if not scores:
                 continue
-            if not self._hole_is_complete(
-                scores, team_a_ids, team_b_ids, quick_match.match_format
-            ):
+            if not hole_is_complete(scores, team_a_ids, team_b_ids, quick_match.match_format):
                 continue
 
             # `calculate_hole_winner` compara scores NETOS. Pasarle el bruto hacia
@@ -267,40 +267,6 @@ class GetQuickMatchUseCase:
             holes_remaining=standing["holes_remaining"],
             is_decided=self._scoring_service.is_match_decided(standing),
         )
-
-    @staticmethod
-    def _hole_is_complete(
-        scores: dict[ParticipantId, int],
-        team_a_ids: set[ParticipantId],
-        team_b_ids: set[ParticipantId],
-        match_format: MatchFormat,
-    ) -> bool:
-        """
-        Un hoyo cuenta para el resultado cuando cada bando ha entregado su bola.
-
-        FOURSOMES se juega a golpes alternos con UNA bola por bando, y la anota
-        cualquiera de los dos companeros. Exigir los cuatro scores —que es lo
-        correcto en FOURBALL, donde cada bando juega dos bolas y la mejor puede
-        cambiar con la que falte— dejaba sin puntuar cualquier tarjeta llevada
-        como se juega: el partido entero se quedaba sin un solo hoyo valido.
-
-        `ScoringService._best_ball` ya resolvia este caso —ignora los None y se
-        queda con el unico score que hay—, asi que el supuesto de las cuatro
-        bolas vivia solo en este filtro.
-
-        Ojo con esa ultima parte: `_best_ball` no mira el formato, devuelve el
-        MENOR de los scores que reciba. En foursomes hay uno solo porque la bola
-        del bando se guarda a nombre de un unico participante —el primero del
-        bando, lo anote quien lo anote—, no porque el motor sepa que el bando
-        juega una bola. Si algun dia llegaran dos filas del mismo bando con
-        golpes distintos, ganaria la menor en silencio en vez de la ultima
-        anotada.
-        """
-        if match_format == MatchFormat.FOURSOMES:
-            return any(pid in scores for pid in team_a_ids) and any(
-                pid in scores for pid in team_b_ids
-            )
-        return all(pid in scores for pid in team_a_ids | team_b_ids)
 
     @staticmethod
     def _net(

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -189,6 +189,7 @@ class GetQuickMatchUseCase:
             participants=quick_match.participants,
             scorer_ids=quick_match.scorer_ids,
             creator_participant_id=quick_match.creator_participant_id,
+            match_format=quick_match.match_format,
         )
 
         result = []

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -284,9 +284,17 @@ class GetQuickMatchUseCase:
         cambiar con la que falte— dejaba sin puntuar cualquier tarjeta llevada
         como se juega: el partido entero se quedaba sin un solo hoyo valido.
 
-        `ScoringService._best_ball` ya resolvia este caso —ignora los None y en
-        FOURSOMES toma el unico score—, asi que el supuesto de las cuatro bolas
-        vivia solo en este filtro.
+        `ScoringService._best_ball` ya resolvia este caso —ignora los None y se
+        queda con el unico score que hay—, asi que el supuesto de las cuatro
+        bolas vivia solo en este filtro.
+
+        Ojo con esa ultima parte: `_best_ball` no mira el formato, devuelve el
+        MENOR de los scores que reciba. En foursomes hay uno solo porque la bola
+        del bando se guarda a nombre de un unico participante —el primero del
+        bando, lo anote quien lo anote—, no porque el motor sepa que el bando
+        juega una bola. Si algun dia llegaran dos filas del mismo bando con
+        golpes distintos, ganaria la menor en silencio en vez de la ultima
+        anotada.
         """
         if match_format == MatchFormat.FOURSOMES:
             return any(pid in scores for pid in team_a_ids) and any(

--- a/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
@@ -72,6 +72,7 @@ class SubmitProxyHoleScoreUseCase:
                 participants=quick_match.participants,
                 scorer_ids=quick_match.scorer_ids,
                 creator_participant_id=quick_match.creator_participant_id,
+                match_format=quick_match.match_format,
             )
             if target_participant_id not in assignments.get(scorer_participant_id, []):
                 raise NotAssignedScorerViolation(

--- a/src/modules/quick_match/domain/services/hole_completion_service.py
+++ b/src/modules/quick_match/domain/services/hole_completion_service.py
@@ -1,0 +1,52 @@
+"""
+Cuando un hoyo de una partida rapida cuenta para el resultado.
+
+La regla vivia escrita a mano en cada pantalla que calcula el resultado —el
+detalle de la partida y el historial— y solo se arreglo en una: el historial
+seguia exigiendo los cuatro scores y dejaba **todas** las partidas de foursomes
+sin resultado mientras el detalle ya las puntuaba. Vive aqui una sola vez.
+"""
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+
+from ..value_objects.participant_id import ParticipantId
+
+
+def hole_is_complete(
+    scored_ids: set[ParticipantId] | dict[ParticipantId, int],
+    team_a_ids: set[ParticipantId],
+    team_b_ids: set[ParticipantId],
+    match_format: MatchFormat | None,
+) -> bool:
+    """
+    Un hoyo cuenta para el resultado cuando cada bando ha entregado su bola.
+
+    FOURSOMES se juega a golpes alternos con UNA bola por bando, y la anota
+    cualquiera de los dos companeros. Exigir los cuatro scores —que es lo
+    correcto en FOURBALL, donde cada bando juega dos bolas y la mejor puede
+    cambiar con la que falte— dejaba sin puntuar cualquier tarjeta llevada como
+    se juega: el partido entero se quedaba sin un solo hoyo valido.
+
+    Ojo con quien decide luego el hoyo: `ScoringService._best_ball` no mira el
+    formato y devuelve el MENOR de los scores que reciba. En foursomes hay uno
+    solo porque la bola del bando se guarda a nombre de un unico participante
+    —el primero del bando, lo anote quien lo anote—, no porque el motor sepa que
+    el bando juega una bola. Y dos filas del mismo bando con golpes distintos ya
+    no es hipotetico: `ScoringCoverageService` da a los dos anotadores cobertura
+    de los cuatro a proposito. Si llegan dos, gana la menor en silencio, no la
+    ultima anotada.
+
+    `match_format` admite None —una partida en juego libre no tiene formato— y
+    entonces cae en la regla general de exigir a todos.
+
+    Args:
+        scored_ids: participantes con score en ese hoyo (basta la pertenencia)
+        team_a_ids: participantes del bando A
+        team_b_ids: participantes del bando B
+        match_format: formato de la partida, o None en juego libre
+    """
+    if match_format == MatchFormat.FOURSOMES:
+        return any(pid in scored_ids for pid in team_a_ids) and any(
+            pid in scored_ids for pid in team_b_ids
+        )
+    return all(pid in scored_ids for pid in team_a_ids | team_b_ids)

--- a/src/modules/quick_match/domain/services/scoring_coverage_service.py
+++ b/src/modules/quick_match/domain/services/scoring_coverage_service.py
@@ -11,8 +11,10 @@ Reglas (confirmadas con el usuario):
 - El creador es siempre uno de los anotadores.
 - El reparto de no-anotadores entre anotadores es lo mas uniforme posible.
 - El sobrante de un reparto no exacto lo absorbe el creador.
-- FOURSOMES no se anota por jugador: **una pareja marca a la otra**. Ahi la
-  unidad es el bando, no el jugador, y el reparto uniforme no aplica.
+- FOURSOMES no se anota por jugador: el bando juega UNA bola, asi que solo
+  hay dos tarjetas y se anotan **cruzadas, como en un 1 vs 1**. Cada anotador
+  apunta los golpes de su propio bando y marca los del contrario, de modo que
+  cubre a los cuatro participantes y el reparto uniforme no aplica.
 """
 
 from src.modules.competition.domain.value_objects.match_format import MatchFormat
@@ -40,6 +42,9 @@ class ScoringCoverageService:
         reparten a partes iguales (division entera) entre TODOS los
         anotadores, incluido el creador; el sobrante de una division no
         exacta lo absorbe el creador.
+
+        En FOURSOMES no hay reparto: la anotacion es cruzada y cada anotador
+        cubre a los cuatro (ver `_foursomes_assignments`).
 
         Returns:
             Dict {scorer_participant_id: [participant_ids cubiertos]}
@@ -77,37 +82,21 @@ class ScoringCoverageService:
         scorer_ids: list[ParticipantId],
     ) -> dict[ParticipantId, list[ParticipantId]]:
         """
-        En foursomes marca la pareja rival, no cada jugador por su cuenta.
+        En foursomes se anota cruzado: cada anotador cubre a los cuatro.
 
-        El bando juega UNA bola, asi que solo hay dos tarjetas que llevar y la
-        unidad es la pareja: cada anotador cubre a los dos del bando contrario.
-        Repartir jugador a jugador —lo que vale cuando cada uno juega su bola—
-        dejaba a un anotador con un rival y sin su propio companero, sin que eso
-        significara nada en un formato de bola alterna.
+        El bando juega UNA bola, asi que en la partida solo hay dos tarjetas y
+        funciona como un 1 vs 1: cada anotador apunta los golpes de su propio
+        bando y marca los del contrario. Con un anotador en cada bando las dos
+        bolas se llevan por duplicado; con uno solo, ese lleva las dos. En
+        ningun caso queda una bola sin quien pueda anotarla, que es lo que si
+        pasaba al repartir jugador a jugador: ese reparto vale cuando cada uno
+        juega su bola, y aqui dejaba a un anotador con un rival y sin su propio
+        companero, sin que eso significara nada en un formato de bola alterna.
 
-        Si el bando contrario no tiene ningun anotador, este ademas lleva la
-        suya: alguien tiene que anotarla, y es preferible a que esa bola se
-        quede sin tarjeta.
+        Que dos anotadores puedan escribir la misma bola es deliberado y es lo
+        mismo que ya ocurre en un 1 vs 1: si las anotaciones no coinciden se
+        aclara entre las parejas y se corrige el hoyo. Las partidas rapidas no
+        llevan validacion jugador/marcador; esa vive en el modulo competition.
         """
-        sides: dict[str, list[ParticipantId]] = {}
-        for participant in participants:
-            sides.setdefault(participant.team or "A", []).append(participant.participant_id)
-
-        side_of = {pid: side for side, pids in sides.items() for pid in pids}
-
-        assignments: dict[ParticipantId, list[ParticipantId]] = {}
-        for scorer_id in scorer_ids:
-            own_side = side_of.get(scorer_id)
-            rival_sides = [side for side in sides if side != own_side]
-
-            covered = [pid for side in rival_sides for pid in sides[side]]
-
-            rival_has_scorer = any(
-                pid in scorer_ids for side in rival_sides for pid in sides[side]
-            )
-            if not rival_has_scorer and own_side is not None:
-                covered.extend(sides[own_side])
-
-            assignments[scorer_id] = covered
-
-        return assignments
+        all_ids = [p.participant_id for p in participants]
+        return {scorer_id: list(all_ids) for scorer_id in scorer_ids}

--- a/src/modules/quick_match/domain/services/scoring_coverage_service.py
+++ b/src/modules/quick_match/domain/services/scoring_coverage_service.py
@@ -11,7 +11,11 @@ Reglas (confirmadas con el usuario):
 - El creador es siempre uno de los anotadores.
 - El reparto de no-anotadores entre anotadores es lo mas uniforme posible.
 - El sobrante de un reparto no exacto lo absorbe el creador.
+- FOURSOMES no se anota por jugador: **una pareja marca a la otra**. Ahi la
+  unidad es el bando, no el jugador, y el reparto uniforme no aplica.
 """
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
 
 from ..exceptions.quick_match_violations import InvalidScorerConfigurationViolation
 from ..value_objects.participant_id import ParticipantId
@@ -26,6 +30,7 @@ class ScoringCoverageService:
         participants: list[QuickMatchParticipant],
         scorer_ids: list[ParticipantId],
         creator_participant_id: ParticipantId,
+        match_format: MatchFormat | None = None,
     ) -> dict[ParticipantId, list[ParticipantId]]:
         """
         Calcula que participantes cubre cada anotador.
@@ -44,6 +49,9 @@ class ScoringCoverageService:
                 "creator_participant_id must be included in scorer_ids."
             )
 
+        if match_format == MatchFormat.FOURSOMES:
+            return self._foursomes_assignments(participants, scorer_ids)
+
         all_ids = [p.participant_id for p in participants]
         non_scorer_ids = [pid for pid in all_ids if pid not in scorer_ids]
 
@@ -60,5 +68,46 @@ class ScoringCoverageService:
 
         if remainder:
             assignments[creator_participant_id].extend(non_scorer_ids[idx:])
+
+        return assignments
+
+    @staticmethod
+    def _foursomes_assignments(
+        participants: list[QuickMatchParticipant],
+        scorer_ids: list[ParticipantId],
+    ) -> dict[ParticipantId, list[ParticipantId]]:
+        """
+        En foursomes marca la pareja rival, no cada jugador por su cuenta.
+
+        El bando juega UNA bola, asi que solo hay dos tarjetas que llevar y la
+        unidad es la pareja: cada anotador cubre a los dos del bando contrario.
+        Repartir jugador a jugador —lo que vale cuando cada uno juega su bola—
+        dejaba a un anotador con un rival y sin su propio companero, sin que eso
+        significara nada en un formato de bola alterna.
+
+        Si el bando contrario no tiene ningun anotador, este ademas lleva la
+        suya: alguien tiene que anotarla, y es preferible a que esa bola se
+        quede sin tarjeta.
+        """
+        sides: dict[str, list[ParticipantId]] = {}
+        for participant in participants:
+            sides.setdefault(participant.team or "A", []).append(participant.participant_id)
+
+        side_of = {pid: side for side, pids in sides.items() for pid in pids}
+
+        assignments: dict[ParticipantId, list[ParticipantId]] = {}
+        for scorer_id in scorer_ids:
+            own_side = side_of.get(scorer_id)
+            rival_sides = [side for side in sides if side != own_side]
+
+            covered = [pid for side in rival_sides for pid in sides[side]]
+
+            rival_has_scorer = any(
+                pid in scorer_ids for side in rival_sides for pid in sides[side]
+            )
+            if not rival_has_scorer and own_side is not None:
+                covered.extend(sides[own_side])
+
+            assignments[scorer_id] = covered
 
         return assignments

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -114,13 +114,20 @@ class RecentMatchDTO(BaseModel):
     stableford_points: int | None = Field(
         default=None,
         description=(
-            "Puntos Stableford de la vuelta, **calculados en cualquier formato**: "
-            "36 puntos es jugar a tu hándicap, así que es la única cifra que "
-            "compara vueltas de medal, Stableford y match play entre sí."
+            "Puntos Stableford de la vuelta: 36 puntos es jugar a tu hándicap, "
+            "así que es la única cifra que compara vueltas de medal, Stableford "
+            "y match play entre sí. Se calcula en todos los formatos **menos "
+            "foursomes**, donde la pareja juega una bola y no hay vuelta propia "
+            "que puntuar: ahí siempre es None."
         ),
     )
     total_strokes: int | None = Field(
-        default=None, description="Golpes brutos de los hoyos anotados"
+        default=None,
+        description=(
+            "Golpes brutos de los hoyos anotados. En **foursomes** son los del "
+            "BANDO —una bola por hoyo, la anote quien la anote— y los mismos "
+            "para los dos de la pareja, no los del jugador por su cuenta."
+        ),
     )
     holes_played: int | None = Field(
         default=None, description="Cuántos hoyos se anotaron: 18 en vuelta entera, 9 en media"

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -12,6 +12,7 @@ from src.modules.competition.domain.services.score_differential_calculator impor
     PlayedRound,
     ScoreDifferentialCalculator,
 )
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
 )
@@ -195,6 +196,14 @@ class GetPlayerStatsUseCase:
         `list_for_user` ya descarta las que el propio usuario ocultó (#127), y
         lo hace por participante: una partida que A ocultó sigue contando para
         B. Esa regla se hereda tal cual en lugar de reimplementarse aquí.
+
+        FOURSOMES se queda fuera: la pareja juega UNA bola a golpes alternos,
+        así que ninguno de los dos ha jugado esa vuelta entera y no dice a qué
+        nivel juega ninguno. Además la bola se guarda a nombre de un solo
+        participante, así que contarla metía una vuelta de 18 hoyos —con el
+        hándicap individual de ese— en la media y en el diferencial WHS de uno
+        de los compañeros, mientras la del otro se caía por vacía: dos
+        estadísticas distintas de una sola bola compartida.
         """
         results: list[_ComputableRound] = []
 
@@ -205,6 +214,9 @@ class GetPlayerStatsUseCase:
 
             for match in matches:
                 if golf_course_id is not None and match.golf_course_id != golf_course_id:
+                    continue
+
+                if match.match_format == MatchFormat.FOURSOMES:
                     continue
 
                 participant = self._find_participant(match, user_id)
@@ -281,9 +293,12 @@ class GetPlayerStatsUseCase:
         """
         Vueltas de torneo computables del jugador.
 
-        El formato del partido da igual: en match play también firmas una
-        tarjeta con tus golpes, y esa tarjeta dice a qué nivel jugaste tan bien
-        como la de una vuelta de medal. Solo entran las que estén enteras.
+        En match play también firmas una tarjeta con tus golpes, y esa tarjeta
+        dice a qué nivel jugaste tan bien como la de una vuelta de medal. La
+        excepción es FOURSOMES: ahí la pareja juega UNA bola a golpes alternos,
+        la tarjeta no son los golpes de ninguno de los dos por separado y no
+        entra ni en la media ni en el diferencial WHS. Solo entran las que estén
+        enteras.
 
         Se usa `own_score`, no el `net_score` de la entidad: ese solo se calcula
         cuando el marcador ha validado el hoyo, así que media tarjeta legítima
@@ -299,6 +314,8 @@ class GetPlayerStatsUseCase:
                 round_ = rounds_by_match.get(match.id)
                 course_id = self._match_course(match, rounds_by_match)
                 if round_ is None or course_id is None:
+                    continue
+                if round_.match_format == MatchFormat.FOURSOMES:
                     continue
                 if course_id not in courses:
                     courses[course_id] = await self._golf_course_uow.golf_courses.find_by_id(

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -516,10 +516,12 @@ class GetRecentMatchesUseCase:
         """
         Golpes brutos y hoyos del BANDO en foursomes: una bola por hoyo.
 
-        Se toma la del primer participante del bando que la tenga —el mismo
-        criterio que usa el frontend, que guarda la bola a nombre del primero—
-        y nunca se suman los dos: comparten bola, así que sumarlas doblaría la
-        vuelta.
+        Normalmente hay una sola: el frontend guarda la bola a nombre del primer
+        jugador del bando, la anote quien la anote. Si llegan dos se toma la
+        MENOR, que es la que usa `ScoringService._best_ball` para adjudicar el
+        hoyo: contar aquí una y adjudicar con la otra dejaría la partida con
+        unos golpes que no explican su resultado. Lo que nunca se hace es
+        sumarlas, porque comparten bola y eso doblaría la vuelta.
 
         Devuelve None si no hay bandos resolubles o el bando no anotó nada.
         """

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -10,6 +10,7 @@ from src.modules.competition.domain.repositories.competition_unit_of_work_interf
     CompetitionUnitOfWorkInterface,
 )
 from src.modules.competition.domain.services.scoring_service import ScoringService
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
 from src.modules.golf_course.domain.repositories.golf_course_unit_of_work_interface import (
     GolfCourseUnitOfWorkInterface,
@@ -21,6 +22,9 @@ from src.modules.quick_match.application.services.stroke_context_builder import 
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
+)
+from src.modules.quick_match.domain.services.hole_completion_service import (
+    hole_is_complete,
 )
 from src.modules.quick_match.domain.services.stableford_calculator import (
     HoleSetup,
@@ -293,6 +297,15 @@ class GetRecentMatchesUseCase:
         # Stableford son la única cifra que compara vueltas entre sí, porque 36
         # puntos es jugar a tu hándicap en cualquier campo y cualquier formato
         totals = self._participant_totals(raw, course, profile_handicap)
+        # En foursomes no hay vuelta propia que enseñar —la pareja juega una
+        # bola— pero sí los golpes brutos del bando, y los mismos para los dos.
+        # Leyendo solo lo anotado a nombre de cada uno, el que llevaba la fila
+        # salía con una vuelta entera de 72 golpes y su compañero sin nada.
+        side_strokes = (
+            self._foursomes_side_strokes(raw)
+            if raw.match.match_format == MatchFormat.FOURSOMES
+            else None
+        )
 
         if match.match_format is not None:
             result, score = self._quick_match_play_outcome(raw, course, users_by_id)
@@ -314,9 +327,15 @@ class GetRecentMatchesUseCase:
             tournament_name=None,
             result=result,
             score=score,
-            stableford_points=totals.stableford_points if totals else None,
-            total_strokes=totals.total_strokes if totals else None,
-            holes_played=totals.holes_played if totals else None,
+            stableford_points=None if side_strokes else (
+                totals.stableford_points if totals else None
+            ),
+            total_strokes=side_strokes[0] if side_strokes else (
+                totals.total_strokes if totals else None
+            ),
+            holes_played=side_strokes[1] if side_strokes else (
+                totals.holes_played if totals else None
+            ),
             partners=partners,
             opponents=opponents,
         )
@@ -426,7 +445,10 @@ class GetRecentMatchesUseCase:
         El resultado no está guardado en ningún sitio: se recalcula hoyo a hoyo
         con el mismo motor que usa el detalle de la partida. Solo cuentan los
         hoyos donde anotaron los dos bandos, porque un hoyo a medias no se puede
-        adjudicar.
+        adjudicar, y con la misma regla que el detalle —`hole_is_complete`— y no
+        con una copia: escrita aquí a mano, exigía los cuatro scores y dejaba el
+        historial sin resultado en todas las partidas de foursomes mientras la
+        partida abierta ya las puntuaba.
 
         Los golpes se reparten con el mismo servicio que el detalle: si aquí se
         compararan los brutos, el historial contaría una película distinta de la
@@ -446,7 +468,9 @@ class GetRecentMatchesUseCase:
                 for participant_id, holes in raw.scores_by_participant.items()
                 if hole_number in holes
             }
-            if not all(pid in scores for pid in team_a_ids | team_b_ids):
+            if not hole_is_complete(
+                scores, team_a_ids, team_b_ids, raw.match.match_format
+            ):
                 continue
 
             def net(pid, hole=hole_number, values=scores):
@@ -455,10 +479,12 @@ class GetRecentMatchesUseCase:
                     return values[pid]
                 return allocation.net_score(hole, values[pid])
 
+            # Solo los que anotaron: en foursomes el bando entrega UNA bola, asi
+            # que el companero no tiene score y `values[pid]` reventaria.
             hole_results.append(
                 self._scoring_service.calculate_hole_winner(
-                    [net(pid) for pid in team_a_ids],
-                    [net(pid) for pid in team_b_ids],
+                    [net(pid) for pid in team_a_ids if pid in scores],
+                    [net(pid) for pid in team_b_ids if pid in scores],
                     raw.match.match_format,
                 )
             )
@@ -485,6 +511,48 @@ class GetRecentMatchesUseCase:
             self._result_for_team(standing["leading_team"], own_team),
             standing["status"],
         )
+
+    def _foursomes_side_strokes(self, raw: _QuickMatchRaw) -> tuple[int, int] | None:
+        """
+        Golpes brutos y hoyos del BANDO en foursomes: una bola por hoyo.
+
+        Se toma la del primer participante del bando que la tenga —el mismo
+        criterio que usa el frontend, que guarda la bola a nombre del primero—
+        y nunca se suman los dos: comparten bola, así que sumarlas doblaría la
+        vuelta.
+
+        Devuelve None si no hay bandos resolubles o el bando no anotó nada.
+        """
+        rosters = raw.match.team_rosters()
+        if rosters is None:
+            return None
+
+        team_a_ids, team_b_ids = rosters
+        my_side = team_a_ids if raw.participant.participant_id in team_a_ids else team_b_ids
+        side_in_order = [
+            p.participant_id for p in raw.match.participants if p.participant_id in my_side
+        ]
+
+        total_strokes = 0
+        holes_played = 0
+        for hole_number in range(1, TOTAL_HOLES + 1):
+            scores = [
+                score
+                for participant_id in side_in_order
+                if (score := raw.scores_by_participant.get(participant_id, {}).get(hole_number))
+                is not None
+            ]
+            if not scores:
+                continue
+            # El menor, que es lo que hace `ScoringService._best_ball` al decidir
+            # el hoyo. Normalmente solo hay uno —la bola se guarda a nombre del
+            # primero del bando—, pero si llegan dos que no coinciden, contar
+            # aquí uno y adjudicar el hoyo con el otro dejaría la misma partida
+            # con unos golpes que no explican su resultado.
+            total_strokes += min(scores)
+            holes_played += 1
+
+        return (total_strokes, holes_played) if holes_played else None
 
     def _participant_totals(
         self,

--- a/tests/unit/modules/quick_match/domain/services/test_hole_completion_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_hole_completion_service.py
@@ -1,0 +1,74 @@
+"""Tests del servicio de dominio hole_completion_service."""
+
+from uuid import uuid4
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.quick_match.domain.services.hole_completion_service import hole_is_complete
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
+
+A1 = ParticipantId(uuid4())
+A2 = ParticipantId(uuid4())
+B1 = ParticipantId(uuid4())
+B2 = ParticipantId(uuid4())
+
+TEAM_A = {A1, A2}
+TEAM_B = {B1, B2}
+
+
+class TestFoursomes:
+    """
+    Una bola por bando: el hoyo cuenta cuando cada bando ha entregado la suya,
+    la haya anotado cualquiera de los dos companeros.
+    """
+
+    def test_one_score_per_side_completes_the_hole(self):
+        assert hole_is_complete({A1, B1}, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+
+    def test_the_partner_may_be_the_one_who_delivered_the_ball(self):
+        assert hole_is_complete({A2, B2}, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+
+    def test_a_side_without_its_ball_leaves_the_hole_open(self):
+        assert not hole_is_complete({A1, A2}, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+        assert not hole_is_complete({B1}, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+
+    def test_an_empty_hole_is_not_complete(self):
+        assert not hole_is_complete(set(), TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+
+    def test_the_four_scores_also_complete_it(self):
+        """Una tarjeta antigua, con los cuatro anotados, sigue valiendo."""
+        assert hole_is_complete({A1, A2, B1, B2}, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+
+
+class TestEveryOtherFormat:
+    """
+    Con una bola por jugador el hoyo necesita las cuatro: en FOURBALL la mejor
+    del bando puede cambiar con la que falte.
+    """
+
+    def test_fourball_needs_every_participant(self):
+        assert hole_is_complete({A1, A2, B1, B2}, TEAM_A, TEAM_B, MatchFormat.FOURBALL)
+
+    def test_fourball_with_a_missing_participant_is_not_complete(self):
+        assert not hole_is_complete({A1, A2, B1}, TEAM_A, TEAM_B, MatchFormat.FOURBALL)
+
+    def test_singles_needs_both_players(self):
+        assert hole_is_complete({A1, B1}, {A1}, {B1}, MatchFormat.SINGLES)
+        assert not hole_is_complete({A1}, {A1}, {B1}, MatchFormat.SINGLES)
+
+    def test_without_a_format_it_falls_back_to_asking_everyone(self):
+        """Juego libre: no hay formato, y la regla general es la estricta."""
+        assert not hole_is_complete({A1, B1}, TEAM_A, TEAM_B, None)
+        assert hole_is_complete({A1, A2, B1, B2}, TEAM_A, TEAM_B, None)
+
+
+class TestItReadsAMappingToo:
+    """
+    Los llamadores pasan el dict {participante: golpes} del hoyo, no un set: lo
+    que se mira es la pertenencia, y un dict responde igual.
+    """
+
+    def test_a_scores_mapping_works_like_the_set(self):
+        scores = {A1: 4, B1: 5}
+
+        assert hole_is_complete(scores, TEAM_A, TEAM_B, MatchFormat.FOURSOMES)
+        assert not hole_is_complete(scores, TEAM_A, TEAM_B, MatchFormat.FOURBALL)

--- a/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
@@ -2,6 +2,7 @@
 
 from uuid import uuid4
 
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
 from src.modules.quick_match.domain.services.scoring_coverage_service import (
     ScoringCoverageService,
 )
@@ -97,3 +98,106 @@ class TestScoringCoverageService:
         )
 
         assert assignments[creator.participant_id] == [creator.participant_id]
+
+
+def _registered_on(team):
+    return QuickMatchParticipant.for_user(UserId(uuid4()), team=team)
+
+
+def _guest_on(team):
+    return QuickMatchParticipant.for_guest(first_name="Guest", last_name="Player", team=team)
+
+
+class TestFoursomesSideMarksSide:
+    """
+    En foursomes el bando juega UNA bola, asi que solo hay dos tarjetas que
+    llevar: marca la pareja rival, no cada jugador por su cuenta.
+    """
+
+    def setup_method(self):
+        self.service = ScoringCoverageService()
+
+    def test_each_scorer_marks_the_rival_pair(self):
+        me = _registered_on("A")
+        partner = _registered_on("A")
+        rival_one = _registered_on("B")
+        rival_two = _guest_on("B")
+        participants = [me, partner, rival_one, rival_two]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[me.participant_id, rival_one.participant_id],
+            creator_participant_id=me.participant_id,
+            match_format=MatchFormat.FOURSOMES,
+        )
+
+        # Cada uno lleva la tarjeta de la pareja de enfrente, entera.
+        assert set(assignments[me.participant_id]) == {
+            rival_one.participant_id,
+            rival_two.participant_id,
+        }
+        assert set(assignments[rival_one.participant_id]) == {
+            me.participant_id,
+            partner.participant_id,
+        }
+
+    def test_the_only_scorer_also_carries_its_own_ball(self):
+        me = _registered_on("A")
+        partner = _guest_on("A")
+        rival_one = _guest_on("B")
+        rival_two = _guest_on("B")
+        participants = [me, partner, rival_one, rival_two]
+
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[me.participant_id],
+            creator_participant_id=me.participant_id,
+            match_format=MatchFormat.FOURSOMES,
+        )
+
+        # Sin nadie enfrente que la lleve, su propia bola se quedaria sin tarjeta.
+        assert set(assignments[me.participant_id]) == {p.participant_id for p in participants}
+
+    def test_a_partner_is_never_split_between_scorers(self):
+        me = _registered_on("A")
+        partner = _registered_on("A")
+        rival_one = _registered_on("B")
+        rival_two = _guest_on("B")
+
+        assignments = self.service.compute_assignments(
+            participants=[me, partner, rival_one, rival_two],
+            scorer_ids=[me.participant_id, partner.participant_id],
+            creator_participant_id=me.participant_id,
+            match_format=MatchFormat.FOURSOMES,
+        )
+
+        # Los dos del mismo bando llevan la MISMA tarjeta rival: la pareja no se
+        # reparte jugador a jugador.
+        rival_pair = {rival_one.participant_id, rival_two.participant_id}
+        assert set(assignments[me.participant_id]) >= rival_pair
+        assert set(assignments[partner.participant_id]) >= rival_pair
+
+    def test_fourball_still_splits_player_by_player(self):
+        me = _registered_on("A")
+        partner = _registered_on("A")
+        rival_one = _guest_on("B")
+        rival_two = _guest_on("B")
+
+        assignments = self.service.compute_assignments(
+            participants=[me, partner, rival_one, rival_two],
+            scorer_ids=[me.participant_id, partner.participant_id],
+            creator_participant_id=me.participant_id,
+            match_format=MatchFormat.FOURBALL,
+        )
+
+        # Cada uno juega su bola: el reparto uniforme sigue teniendo sentido y
+        # cada anotador se cubre a si mismo.
+        assert me.participant_id in assignments[me.participant_id]
+        assert partner.participant_id in assignments[partner.participant_id]
+        covered = set(assignments[me.participant_id]) | set(assignments[partner.participant_id])
+        assert covered == {
+            me.participant_id,
+            partner.participant_id,
+            rival_one.participant_id,
+            rival_two.participant_id,
+        }

--- a/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
+++ b/tests/unit/modules/quick_match/domain/services/test_scoring_coverage_service.py
@@ -108,21 +108,22 @@ def _guest_on(team):
     return QuickMatchParticipant.for_guest(first_name="Guest", last_name="Player", team=team)
 
 
-class TestFoursomesSideMarksSide:
+class TestFoursomesScoresCrossed:
     """
-    En foursomes el bando juega UNA bola, asi que solo hay dos tarjetas que
-    llevar: marca la pareja rival, no cada jugador por su cuenta.
+    En foursomes el bando juega UNA bola, asi que solo hay dos tarjetas y se
+    anotan cruzadas, como en un 1 vs 1: cada anotador apunta las dos.
     """
 
     def setup_method(self):
         self.service = ScoringCoverageService()
 
-    def test_each_scorer_marks_the_rival_pair(self):
+    def test_each_scorer_covers_the_four_participants(self):
         me = _registered_on("A")
         partner = _registered_on("A")
         rival_one = _registered_on("B")
         rival_two = _guest_on("B")
         participants = [me, partner, rival_one, rival_two]
+        everyone = {p.participant_id for p in participants}
 
         assignments = self.service.compute_assignments(
             participants=participants,
@@ -131,17 +132,11 @@ class TestFoursomesSideMarksSide:
             match_format=MatchFormat.FOURSOMES,
         )
 
-        # Cada uno lleva la tarjeta de la pareja de enfrente, entera.
-        assert set(assignments[me.participant_id]) == {
-            rival_one.participant_id,
-            rival_two.participant_id,
-        }
-        assert set(assignments[rival_one.participant_id]) == {
-            me.participant_id,
-            partner.participant_id,
-        }
+        # Cada uno anota los golpes de su bando y marca los del contrario.
+        assert set(assignments[me.participant_id]) == everyone
+        assert set(assignments[rival_one.participant_id]) == everyone
 
-    def test_the_only_scorer_also_carries_its_own_ball(self):
+    def test_the_only_scorer_carries_both_balls(self):
         me = _registered_on("A")
         partner = _guest_on("A")
         rival_one = _guest_on("B")
@@ -155,27 +150,51 @@ class TestFoursomesSideMarksSide:
             match_format=MatchFormat.FOURSOMES,
         )
 
-        # Sin nadie enfrente que la lleve, su propia bola se quedaria sin tarjeta.
+        # Sin nadie enfrente, lleva las dos tarjetas: ninguna bola se queda sin
+        # quien pueda anotarla.
         assert set(assignments[me.participant_id]) == {p.participant_id for p in participants}
 
-    def test_a_partner_is_never_split_between_scorers(self):
+    def test_a_scorer_covers_its_own_ball_even_with_a_rival_scorer(self):
+        """
+        La regresion que motiva el cruce: con anotador enfrente, el propio bando
+        se quedaba sin nadie que pudiera anotarlo si ese rival no abria la app.
+        """
         me = _registered_on("A")
-        partner = _registered_on("A")
+        partner = _guest_on("A")
         rival_one = _registered_on("B")
         rival_two = _guest_on("B")
 
         assignments = self.service.compute_assignments(
             participants=[me, partner, rival_one, rival_two],
-            scorer_ids=[me.participant_id, partner.participant_id],
+            scorer_ids=[me.participant_id, rival_one.participant_id],
             creator_participant_id=me.participant_id,
             match_format=MatchFormat.FOURSOMES,
         )
 
-        # Los dos del mismo bando llevan la MISMA tarjeta rival: la pareja no se
-        # reparte jugador a jugador.
-        rival_pair = {rival_one.participant_id, rival_two.participant_id}
-        assert set(assignments[me.participant_id]) >= rival_pair
-        assert set(assignments[partner.participant_id]) >= rival_pair
+        assert me.participant_id in assignments[me.participant_id]
+        assert partner.participant_id in assignments[me.participant_id]
+
+    def test_two_scorers_on_the_same_side_both_carry_everything(self):
+        me = _registered_on("A")
+        partner = _registered_on("A")
+        rival_one = _registered_on("B")
+        rival_two = _guest_on("B")
+        participants = [me, partner, rival_one, rival_two]
+        everyone = {p.participant_id for p in participants}
+
+        # Con anotador tambien enfrente: el caso que el test anterior no llegaba
+        # a ejercitar, porque sin rival anotador caia en la rama de respaldo.
+        assignments = self.service.compute_assignments(
+            participants=participants,
+            scorer_ids=[me.participant_id, partner.participant_id, rival_one.participant_id],
+            creator_participant_id=me.participant_id,
+            match_format=MatchFormat.FOURSOMES,
+        )
+
+        # Una pareja no se reparte jugador a jugador: los tres llevan lo mismo.
+        assert set(assignments[me.participant_id]) == everyone
+        assert set(assignments[partner.participant_id]) == everyone
+        assert set(assignments[rival_one.participant_id]) == everyone
 
     def test_fourball_still_splits_player_by_player(self):
         me = _registered_on("A")

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -152,6 +152,7 @@ async def _played_quick_match(
     tee_color: TeeColor | None = None,
     tee_gender: Gender | None = None,
     scores_by_hole: dict[int, int] | None = None,
+    match_format: MatchFormat | None = None,
 ):
     """
     Una partida rápida terminada con la vuelta anotada.
@@ -168,7 +169,8 @@ async def _played_quick_match(
         id=QuickMatchId.generate(),
         creator_id=user.id,
         golf_course_id=golf_course.id,
-        scoring_format=ScoringFormat.MEDAL,
+        match_format=match_format,
+        scoring_format=None if match_format else ScoringFormat.MEDAL,
         creator_tee_color=tee_color,
         creator_tee_gender=tee_gender,
     )
@@ -212,6 +214,7 @@ async def _played_competition_match(
     unscored_holes: list[int] | None = None,
     decided_early: bool = False,
     round_date: date = date(2026, 6, 1),
+    match_format: MatchFormat = MatchFormat.SINGLES,
 ):
     """
     Un partido de torneo terminado con la tarjeta del jugador anotada.
@@ -235,7 +238,7 @@ async def _played_competition_match(
         golf_course_id=golf_course.id,
         round_date=round_date,
         session_type=SessionType.MORNING,
-        match_format=MatchFormat.SINGLES,
+        match_format=match_format,
     )
 
     def match_player(user_id):
@@ -387,6 +390,79 @@ class TestRoundsAndAverage:
         )
 
         assert stats.scoring_avg == 0.0
+
+
+@pytest.mark.asyncio
+class TestFoursomesIsNotAPersonalRound:
+    """
+    En foursomes la pareja juega UNA bola a golpes alternos: ninguno de los dos
+    ha jugado esa vuelta entera, así que no dice a qué nivel juega ninguno y no
+    entra ni en la media ni en el diferencial WHS.
+    """
+
+    async def test_a_foursomes_quick_match_does_not_count_as_a_round(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("fours"), handicap=0)
+        partner = await create_user(user_uow, unique_email("mate"), handicap=0)
+        rival_one = await create_user(user_uow, unique_email("riv1"), handicap=0)
+        rival_two = await create_user(user_uow, unique_email("riv2"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(
+            qm_uow,
+            course,
+            user,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            tee_color=TeeColor.YELLOW,
+            tee_gender=Gender.MALE,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+
+    async def test_a_singles_quick_match_still_counts(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """La exclusión es de foursomes, no de las partidas por equipos."""
+        user = await create_user(user_uow, unique_email("single"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user)
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 1
+
+    async def test_a_foursomes_tournament_match_does_not_count_either(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """En torneo la bola alterna es la misma: la tarjeta no es de nadie."""
+        player = await create_user(user_uow, unique_email("tfours"), handicap=0)
+        rival = await create_user(user_uow, unique_email("trival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow,
+            course,
+            player,
+            rival,
+            strokes_per_hole=5,
+            match_format=MatchFormat.FOURSOMES,
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert stats.rounds_played == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -152,6 +152,7 @@ async def played_quick_match(
     strokes_by_participant_index: dict[int, int] | None = None,
     strokes_per_hole: int = 4,
     holes_played: int = 18,
+    scoring_participant_indexes: set[int] | None = None,
     creator_tee_color: TeeColor | None = None,
     creator_tee_gender: Gender | None = None,
 ):
@@ -162,6 +163,8 @@ async def played_quick_match(
     participante por su posición en el roster (0 = creador); sin él todos
     firman los mismos. `holes_played` deja la vuelta a medias, que es como
     acaba un match play que se cierra antes del 18.
+    `scoring_participant_indexes` limita quién tiene golpes anotados: en
+    foursomes el bando entrega UNA bola, así que solo hay dos tarjetas.
     """
     match = QuickMatch.create(
         id=QuickMatchId.generate(),
@@ -182,6 +185,8 @@ async def played_quick_match(
     async with qm_uow:
         await qm_uow.quick_matches.add(match)
         for index, participant_id in enumerate(participant_ids):
+            if scoring_participant_indexes is not None and index not in scoring_participant_indexes:
+                continue
             strokes = (strokes_by_participant_index or {}).get(index, strokes_per_hole)
             for hole_number in range(1, holes_played + 1):
                 await qm_uow.quick_match_hole_scores.add(
@@ -403,6 +408,184 @@ class TestTeamQuickMatch:
         assert won.result == "WON"
         assert lost.result == "LOST"
         assert won.score == lost.score == "18UP"
+
+    async def test_a_foursomes_match_is_decided_with_one_ball_per_side(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        FOURSOMES: el bando juega UNA bola, así que solo hay dos tarjetas. El
+        historial exigía las cuatro —una copia a mano de la regla que el detalle
+        de la partida ya había arreglado— y dejaba TODAS las partidas de este
+        formato sin resultado, mientras la partida abierta sí las puntuaba.
+        """
+        creator = await create_user(user_uow, "Foursomes", handicap=0)
+        partner = await create_user(user_uow, "Partner", handicap=0)
+        rival_one = await create_user(user_uow, "RivalOne", handicap=0)
+        rival_two = await create_user(user_uow, "RivalTwo", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            # Una bola por bando: la del creador y la del primer rival.
+            scoring_participant_indexes={0, 2},
+            strokes_by_participant_index={0: 4, 2: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        won = (await use_case.execute(creator.id)).matches[0]
+        lost = (await use_case.execute(rival_one.id)).matches[0]
+
+        assert won.result == "WON"
+        assert lost.result == "LOST"
+        assert won.score == lost.score == "18UP"
+
+    async def test_the_partner_ball_counts_for_the_side_in_the_history(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """La bola del bando la anota cualquiera de los dos: aquí, el compañero."""
+        creator = await create_user(user_uow, "Silent", handicap=0)
+        partner = await create_user(user_uow, "Striker", handicap=0)
+        rival_one = await create_user(user_uow, "RivalA", handicap=0)
+        rival_two = await create_user(user_uow, "RivalB", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            scoring_participant_indexes={1, 3},
+            strokes_by_participant_index={1: 4, 3: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        assert (await use_case.execute(creator.id)).matches[0].result == "WON"
+
+    async def test_both_partners_see_the_side_strokes_in_foursomes(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        En foursomes no hay vuelta propia —la pareja juega una bola— pero sí los
+        golpes del bando, y los mismos para los dos. Leyendo solo lo anotado a
+        nombre de cada uno, el que llevaba la fila salía con una vuelta entera y
+        su compañero sin nada, en el mismo partido.
+        """
+        creator = await create_user(user_uow, "Holder", handicap=0)
+        partner = await create_user(user_uow, "Mate", handicap=0)
+        rival_one = await create_user(user_uow, "Rival", handicap=0)
+        rival_two = await create_user(user_uow, "Guest", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            scoring_participant_indexes={0, 2},
+            strokes_by_participant_index={0: 4, 2: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        holder = (await use_case.execute(creator.id)).matches[0]
+        mate = (await use_case.execute(partner.id)).matches[0]
+
+        assert holder.total_strokes == mate.total_strokes == 72
+        assert holder.holes_played == mate.holes_played == 18
+        # Sin vuelta propia: los puntos Stableford medirían una que no existe.
+        assert holder.stableford_points is None
+        assert mate.stableford_points is None
+
+    async def test_the_side_strokes_never_add_both_partners(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Comparten bola: sumar las dos filas doblaría la vuelta del bando. Y con
+        dos que no coinciden se toma la misma que decide el hoyo —la menor—, o
+        la partida saldría con unos golpes que no explican su resultado.
+        """
+        creator = await create_user(user_uow, "Both", handicap=0)
+        partner = await create_user(user_uow, "Twice", handicap=0)
+        rival_one = await create_user(user_uow, "Other", handicap=0)
+        rival_two = await create_user(user_uow, "More", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            # Los dos del bando A con fila y sin coincidir, como dejaría un
+            # cliente antiguo: 5 a nombre del creador, 4 a nombre del compañero.
+            scoring_participant_indexes={0, 1, 2},
+            strokes_by_participant_index={0: 5, 1: 4, 2: 6},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        entry = (await use_case.execute(creator.id)).matches[0]
+        # 4 por hoyo, no 9 (las dos sumadas) ni 5 (la del primero del bando).
+        assert entry.total_strokes == 72
+        # Y esos golpes son los que ganaron el partido.
+        assert entry.result == "WON"
+
+    async def test_fourball_still_needs_every_ball_in_the_history(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        FOURBALL juega dos bolas por bando y la mejor puede cambiar con la que
+        falte: un hoyo a medias sigue sin poder adjudicarse.
+        """
+        creator = await create_user(user_uow, "Fourball", handicap=0)
+        partner = await create_user(user_uow, "Mate", handicap=0)
+        rival_one = await create_user(user_uow, "Opp1", handicap=0)
+        rival_two = await create_user(user_uow, "Opp2", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURBALL,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            scoring_participant_indexes={0, 2},
+            strokes_by_participant_index={0: 4, 2: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        entry = (await use_case.execute(creator.id)).matches[0]
+        assert entry.result is None
+        assert entry.score is None
 
     async def test_a_match_closed_early_reports_the_holes_that_were_left(
         self, user_uow, competition_uow, qm_uow, golf_course_uow


### PR DESCRIPTION
## Why

Foursomes plays **one ball per side**, so there are only two cards in the match — and they are kept **crossed, exactly like a 1 vs 1**: each scorer writes down their own side's strokes and marks the rival's.

`ScoringCoverageService` shared the non-scorers out **player by player**, evenly, ignoring sides. That rule is right for a format where everyone plays their own ball. In alternate shot it produced assignments that mean nothing — a scorer carrying one rival but not their own partner.

## The bug this closes

The first attempt gave each scorer the rival pair **and nothing else**, with a safety net for "carry your own ball too when the other side has no scorer". Review showed that net was **dead code for side B** (the creator is always team A and always a scorer) and **switched off for side A** the moment any B player was ticked.

Concrete failure: creator A1 and registered rival B1 both ticked as scorers, B1 never opens the app → **side A's ball cannot be recorded by anyone** and the match ends with no standing. The very failure this work set out to fix.

## What changes

In FOURSOMES, **every scorer covers all four participants**. With a scorer on each side both balls are carried twice; with a single scorer, that one carries both. No ball is ever left without someone able to record it, and no separate fallback rule is needed.

That also restores the invariant the **deployed frontend v2.13.0** relies on (`useQuickMatchScoring.js:87`): a scorer always covers themselves. A backend-first deploy no longer breaks the UI silently.

FOURBALL and SINGLES keep the even, player-by-player split: with a ball each, that is exactly what they need.

## Two scorers writing the same ball

Deliberate, and the same thing that already happens in a 1 vs 1: if the entries disagree, **the pairs sort it out and correct the hole**. Quick matches carry no player/marker validation — that lives in the `competition` module, and it stays there.

RyderCupWeb#421 stores a side's ball under **one canonical participant** (the first player of the side), so in practice the two scorers write the same row and the last entry wins.

## Tests

`TestFoursomesScoresCrossed`:

- with a scorer on each side, each covers all four
- the only scorer carries both balls
- **a scorer covers its own ball even with a rival scorer** — the regression above; fails without this change
- two scorers on the same side plus a rival scorer: exact coverage, not a superset. The previous test claimed this but built a scenario with no rival scorer, so it exercised the fallback branch instead, and its `>=` assertions hid it.

Full unit suite: 2890 passed. `ruff` and `mypy` clean on the touched files.

## Also here

Corrects the `_hole_is_complete` docstring merged in #217: it claimed `_best_ball` "takes the single score in FOURSOMES". It does not — it ignores `match_format` and returns `min()` of whatever it receives. There is a single score because the frontend stores a side's ball under one participant, not because the engine knows the format.

## Related

- RyderCupAm#217 — a hole counts with one ball per side (merged)
- RyderCupWeb#421 / #422 — one box and one card per side, and who keeps the card

## Also fixed here: the history

Found while reviewing this. `GetRecentMatchesUseCase` carried its **own hand-written copy** of the four-score rule and #217 did not touch it, so every finished foursomes quick match would have shown up in "Partidas recientes" **with no result at all** while the same match already read 2UP on its own screen. The rule now lives once, in `hole_completion_service`, and both screens call it.

The entry's own numbers were the other half of the same defect: they came from the scores stored under the reader's participant, so the partner whose name the side's ball happens to be under got a **full 18-hole personal round** — 72 strokes, 36 Stableford points, computed with their individual handicap — while the other partner, in the same match, got nothing. Foursomes has no personal round: both partners now read the **side's gross strokes**, one ball per hole, and no Stableford points. The DTO descriptions that promised points "in any format" say so too.

A side's stroke for a hole is the **lowest** of its rows, which is what `ScoringService._best_ball` uses to decide the hole. There is normally one row — the ball is stored under the first player of the side — but counting one here and awarding the hole with another would leave a match whose strokes do not explain its result.

## And foursomes is not a personal round

`GetPlayerStatsUseCase` had the same asymmetry, with more consequences: in a finished foursomes, the partner holding the ball rows fed a full 18-hole round into the house average **and the WHS differential**, computed with their individual handicap, while the other partner'''s identical round was dropped for having no scores. Two players of one shared alternate-shot ball ended up with different handicap statistics.

Decision taken with the user: **a foursomes round counts for neither**. The pair plays one ball, so neither player played that round whole and it says nothing about how well either of them plays. Tournament foursomes goes out for the same reason. Singles and fourball are untouched — there each player plays their own ball and signs their own round.

## Full check

2898 unit tests pass, `ruff` and `mypy` clean on `src/`. Every behaviour test was checked to fail without its fix.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for foursomes scoring in recent match history, including shared team scores and results for both partners.
  * Improved completion handling for foursomes and other match formats.
  * Updated scorer coverage for foursomes and fourball matches.
* **Updates**
  * Excluded foursomes from individual player statistics.
  * Clarified foursomes score and Stableford data in match history.
* **Bug Fixes**
  * Corrected results when only one shared team score is recorded.
  * Prevented incomplete fourball scorecards from being treated as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->