### PR TITLE
fix(competition): Rate short courses instead of refusing them

### DIFF
--- a/scripts/generate_parity_fixtures.py
+++ b/scripts/generate_parity_fixtures.py
@@ -48,6 +48,10 @@ OUTPUT = (
 MEIS_STROKE_INDEX = [7, 1, 13, 5, 15, 9, 3, 11, 17, 16, 2, 14, 12, 8, 18, 6, 4, 10]
 MEIS_PAR = [4, 5, 4, 4, 3, 4, 5, 4, 3, 3, 4, 5, 4, 4, 3, 4, 5, 4]
 
+# Un pitch & putt federado: 18 hoyos que suman par 58
+SHORT_PAR = [3] * 14 + [4] * 4
+SHORT_STROKE_INDEX = list(range(1, 19))
+
 TEES = {
     ("YELLOW", "MALE"): TeeRating(course_rating=Decimal("73.1"), slope_rating=140, par=72),
     ("YELLOW", "FEMALE"): TeeRating(course_rating=Decimal("79.4"), slope_rating=147, par=72),
@@ -83,7 +87,23 @@ def _order(stroke_index_by_hole: list[int]) -> list[int]:
     return sorted(range(1, 19), key=lambda hole: stroke_index_by_hole[hole - 1])
 
 
-def run(name, players, match_format, allowance, play_mode, tees=None, by_tee=None) -> None:
+def run(
+    name,
+    players,
+    match_format,
+    allowance,
+    play_mode,
+    tees=None,
+    by_tee=None,
+    pars=None,
+    stroke_index=None,
+) -> None:
+    # El par y el indice son del campo del escenario, no siempre los de Meis: un
+    # pitch & putt tiene par 58, y el cliente deriva el par sumando los hoyos que
+    # le llegan aqui. Emitir el par 72 de Meis junto a un TeeRating de par 58
+    # compararia dos campos distintos y la paridad no probaria nada.
+    pars = MEIS_PAR if pars is None else pars
+    stroke_index = MEIS_STROKE_INDEX if stroke_index is None else stroke_index
     tees = TEES if tees is None else tees
     result = service.allocate(
         participants=players,
@@ -92,7 +112,7 @@ def run(name, players, match_format, allowance, play_mode, tees=None, by_tee=Non
             for p in players
         },
         tee_ratings=tees,
-        holes_by_stroke_index=_order(MEIS_STROKE_INDEX),
+        holes_by_stroke_index=_order(stroke_index),
         match_format=match_format,
         allowance_percentage=allowance,
         play_mode=play_mode,
@@ -105,7 +125,7 @@ def run(name, players, match_format, allowance, play_mode, tees=None, by_tee=Non
             "allowancePercentage": allowance,
             "playMode": play_mode.value,
             "holes": [
-                {"holeNumber": i + 1, "par": MEIS_PAR[i], "strokeIndex": MEIS_STROKE_INDEX[i]}
+                {"holeNumber": i + 1, "par": pars[i], "strokeIndex": stroke_index[i]}
                 for i in range(18)
             ],
             "tees": [
@@ -212,6 +232,28 @@ def main() -> None:
         100,
         handicap,
         by_tee={("YELLOW", "FEMALE"): list(range(18, 0, -1))},
+    )
+    # Pitch & putt federado: par 58, CR 54.9, SR 91. Hasta RyderCupAm#206 estos
+    # campos no se podian valorar y los dos lados jugaban con el Handicap Index
+    # a pelo, asi que la paridad no cubria ninguna barra corta. Es justo donde
+    # los dos calculos se pueden separar, porque el cliente deriva el par de los
+    # hoyos y el backend lo lleva en el TeeRating.
+    run(
+        "campo corto",
+        [
+            guest("x", 18.0, TeeColor.ORANGE, male),
+            guest("y", 30.0, TeeColor.ORANGE, male),
+        ],
+        MatchFormat.SINGLES,
+        100,
+        handicap,
+        tees={
+            ("ORANGE", "MALE"): TeeRating(
+                course_rating=Decimal("54.9"), slope_rating=91, par=58
+            )
+        },
+        pars=SHORT_PAR,
+        stroke_index=SHORT_STROKE_INDEX,
     )
     run(
         "sin handicap",

--- a/src/modules/competition/application/services/tee_context_builder.py
+++ b/src/modules/competition/application/services/tee_context_builder.py
@@ -114,41 +114,58 @@ class TeeContextBuilder:
         evitar—. Ver RyderCupAm#219.
         """
         course_rating = Decimal(str(tee.course_rating))
-        try:
-            return TeeRating(
-                course_rating=course_rating,
-                slope_rating=tee.slope_rating,
-                par=tee.par_total if tee.holes else course_par,
-            )
-        except (ValueError, TypeError):
-            # Este es el camino COMUN —25 de los 800 campos importados cambian
-            # de par entre barras—, y tomarlo cambia el course handicap de quien
-            # juegue esa barra. Se sigue anotando: dejarlo en un `pass` mudo
-            # escondia el unico rastro de que un jugador no se valoro contra su
-            # propio par.
-            logger.debug(
-                "Tee %s of golf course %s has an unusable par; rating it against the course par",
-                tee.color.value,
-                golf_course.id,
-            )
+        own_par = tee.par_total if tee.holes else course_par
 
-        try:
-            return TeeRating(
-                course_rating=course_rating,
-                slope_rating=tee.slope_rating,
-                par=course_par,
-            )
-        except (ValueError, TypeError):
-            # Aviso, no debug: generar partidos es puntual —no como el detalle
-            # de una partida rapida, que se pide cada 10 segundos— y con 800
-            # campos importados interesa saber cual se quedo sin valorar.
-            logger.warning(
-                "Golf course %s has a tee (%s) that cannot be rated: "
-                "its players will play off their Handicap Index",
-                golf_course.id,
-                tee.color.value,
-            )
-            return None
+        def _rating(par: int) -> TeeRating | None:
+            try:
+                return TeeRating(
+                    course_rating=course_rating,
+                    slope_rating=tee.slope_rating,
+                    par=par,
+                )
+            except (ValueError, TypeError):
+                return None
+
+        rating = _rating(own_par)
+        if rating is not None:
+            return rating
+
+        # Se reintenta solo si el par del campo es OTRO: con el mismo par el
+        # segundo intento es identico al primero, y lo que falla entonces es el
+        # rating, no el par.
+        if own_par != course_par:
+            rating = _rating(course_par)
+            if rating is not None:
+                # Camino COMUN —25 de los 800 campos importados cambian de par
+                # entre barras—, y tomarlo cambia el course handicap de quien
+                # juegue esa barra: se deja rastro. Se anota AQUI y no antes de
+                # reintentar, porque hasta ahora no se sabia en que acababa.
+                logger.debug(
+                    "Tee %s of golf course %s could not be rated against its own par (%s); "
+                    "using the course par (%s) instead",
+                    tee.color.value,
+                    golf_course.id,
+                    own_par,
+                    course_par,
+                )
+                return rating
+
+        # Aviso, no debug: generar partidos es puntual —no como el detalle de
+        # una partida rapida, que se pide cada 10 segundos— y con 800 campos
+        # importados interesa saber cual se quedo sin valorar. El mensaje dice lo
+        # que pasa AQUI: en competicion la barra ausente no degrada al Handicap
+        # Index, la ronda no se puede generar para quien la juegue.
+        logger.warning(
+            "Golf course %s has a tee (%s, CR %s, SR %s, par %s) that cannot be rated: "
+            "it is left out of the context, and a player enrolled on it will not be able "
+            "to have their round generated",
+            golf_course.id,
+            tee.color.value,
+            course_rating,
+            tee.slope_rating,
+            own_par,
+        )
+        return None
 
     @staticmethod
     def _card_for(tee) -> list[int]:

--- a/src/modules/competition/application/services/tee_context_builder.py
+++ b/src/modules/competition/application/services/tee_context_builder.py
@@ -95,9 +95,18 @@ class TeeContextBuilder:
         Si ese par no sirve —se sale del rango, o la tarjeta viene malformada—
         se cae al del campo, que es lo que se venia usando.
 
-        Y si con el par del campo tampoco vale, devuelve None: la barra se queda
-        fuera del contexto y quien la juegue jugara con su Handicap Index, igual
-        que en partida rapida. Antes ese segundo intento repetia el mismo
+        Y si con el par del campo tampoco vale, devuelve None y la barra se
+        queda fuera del contexto.
+
+        OJO con lo que eso significa AQUI: en partida rapida la barra que falta
+        degrada al Handicap Index, pero en competicion no. Los llamantes
+        (`generate_matches_use_case`, `reassign_match_players_use_case`) tratan
+        la ausencia como `TeeColorNotFoundError`, asi que un jugador inscrito en
+        una barra sin valorar sigue sin poder generar la ronda: lo que cambia es
+        que ahora es un 400 con un mensaje, y no un 500. Llevar la degradacion a
+        competicion es otro cambio, y toca los cinco puntos que hoy lanzan.
+
+        Antes ese segundo intento repetia el mismo
         `course_rating` y el mismo `slope_rating`, asi que cuando lo que se salia
         de rango era el rating y no el par, la reserva lanzaba igual que el
         primer intento: el ValueError subia hasta la API y la ronda se quedaba
@@ -112,7 +121,16 @@ class TeeContextBuilder:
                 par=tee.par_total if tee.holes else course_par,
             )
         except (ValueError, TypeError):
-            pass
+            # Este es el camino COMUN —25 de los 800 campos importados cambian
+            # de par entre barras—, y tomarlo cambia el course handicap de quien
+            # juegue esa barra. Se sigue anotando: dejarlo en un `pass` mudo
+            # escondia el unico rastro de que un jugador no se valoro contra su
+            # propio par.
+            logger.debug(
+                "Tee %s of golf course %s has an unusable par; rating it against the course par",
+                tee.color.value,
+                golf_course.id,
+            )
 
         try:
             return TeeRating(

--- a/src/modules/competition/application/services/tee_context_builder.py
+++ b/src/modules/competition/application/services/tee_context_builder.py
@@ -70,7 +70,12 @@ class TeeContextBuilder:
         for tee in golf_course.tees:
             gender = tee.gender.value if tee.gender else None
             tee_key = (tee.color.value, gender)
-            tee_ratings[tee_key] = TeeContextBuilder._rating_for(tee, course_par, golf_course)
+            # La barra que no se puede valorar se queda FUERA del diccionario en
+            # vez de tumbar la construccion entera: quien la juegue jugara con su
+            # Handicap Index, y el resto del campo sigue funcionando. Ver #219.
+            rating = TeeContextBuilder._rating_for(tee, course_par, golf_course)
+            if rating is not None:
+                tee_ratings[tee_key] = rating
 
             card = TeeContextBuilder._card_for(tee)
             if card:
@@ -83,13 +88,21 @@ class TeeContextBuilder:
         )
 
     @staticmethod
-    def _rating_for(tee, course_par: int, golf_course: GolfCourse) -> TeeRating:
+    def _rating_for(tee, course_par: int, golf_course: GolfCourse) -> TeeRating | None:
         """
         Valoracion de una barra, contra SU par cuando trae tarjeta propia.
 
-        Si ese par no sirve —se sale del rango WHS, o la tarjeta viene
-        malformada— se cae al del campo, que es lo que se venia usando, en vez de
-        dejar la ronda sin poder generar partidos.
+        Si ese par no sirve —se sale del rango, o la tarjeta viene malformada—
+        se cae al del campo, que es lo que se venia usando.
+
+        Y si con el par del campo tampoco vale, devuelve None: la barra se queda
+        fuera del contexto y quien la juegue jugara con su Handicap Index, igual
+        que en partida rapida. Antes ese segundo intento repetia el mismo
+        `course_rating` y el mismo `slope_rating`, asi que cuando lo que se salia
+        de rango era el rating y no el par, la reserva lanzaba igual que el
+        primer intento: el ValueError subia hasta la API y la ronda se quedaba
+        sin poder generar partidos —justo lo que esta reserva existe para
+        evitar—. Ver RyderCupAm#219.
         """
         course_rating = Decimal(str(tee.course_rating))
         try:
@@ -99,16 +112,25 @@ class TeeContextBuilder:
                 par=tee.par_total if tee.holes else course_par,
             )
         except (ValueError, TypeError):
-            logger.debug(
-                "Tee %s of golf course %s has an unusable par; rating it against the course par",
-                tee.color.value,
-                golf_course.id,
-            )
+            pass
+
+        try:
             return TeeRating(
                 course_rating=course_rating,
                 slope_rating=tee.slope_rating,
                 par=course_par,
             )
+        except (ValueError, TypeError):
+            # Aviso, no debug: generar partidos es puntual —no como el detalle
+            # de una partida rapida, que se pide cada 10 segundos— y con 800
+            # campos importados interesa saber cual se quedo sin valorar.
+            logger.warning(
+                "Golf course %s has a tee (%s) that cannot be rated: "
+                "its players will play off their Handicap Index",
+                golf_course.id,
+                tee.color.value,
+            )
+            return None
 
     @staticmethod
     def _card_for(tee) -> list[int]:

--- a/src/modules/competition/domain/services/playing_handicap_calculator.py
+++ b/src/modules/competition/domain/services/playing_handicap_calculator.py
@@ -21,13 +21,28 @@ from src.modules.competition.domain.value_objects.handicap_mode import HandicapM
 # Slope Rating neutral (valor estándar del sistema WHS)
 NEUTRAL_SLOPE = 113
 
-# Límites válidos para ratings de tees según WHS
-MIN_COURSE_RATING = 55
-MAX_COURSE_RATING = 85
-MIN_SLOPE_RATING = 55
-MAX_SLOPE_RATING = 155
-MIN_PAR = 66
-MAX_PAR = 76
+# Rangos absolutos, unión de los de todos los tipos de campo: aquí solo se
+# descarta lo que no puede ser válido en ninguno. Son los mismos que valida la
+# entidad `Tee` (golf_course), y el rango estricto que corresponde a cada tipo
+# lo comprueba `GolfCourse._validate_tee_ratings`, que es quien conoce el
+# `course_type`. Este dominio no puede conocerlo sin depender de `golf_course`.
+#
+# Antes eran los de un campo de 18 hoyos (CR 55-85, SR 55-155, par 66-76) y no
+# los de todos los tipos, así que rechazaban lo que la propia entidad `Tee`
+# admite: en el catálogo federado hay 468 salidas en 227 campos con CR por
+# debajo de 55, y 642 con par por debajo de 66 —los pitch & putt y los
+# ejecutivos, que el sistema no valora en la misma escala—. Un campo entero se
+# quedaba sin poder alojar competición, y en partida rápida sus jugadores
+# jugaban con el Handicap Index a pelo: un 18 recibía 18 golpes donde le tocan
+# 11. Ver RyderCupAm#206 y RyderCupAm#219.
+MIN_COURSE_RATING = 45
+MAX_COURSE_RATING = 90
+MIN_SLOPE_RATING = 40
+MAX_SLOPE_RATING = 160
+# El catálogo federado va de 54 (pitch & putt) a 74; el margen deja sitio a un
+# recorrido más corto sin llegar a admitir un par imposible.
+MIN_PAR = 50
+MAX_PAR = 80
 
 
 @dataclass(frozen=True)

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -7,6 +7,8 @@ PRIMERA barra. De los 800 campos federados importados con mas de una barra con
 tarjeta, 25 tienen par distinto entre barras y 56 stroke index distinto.
 """
 
+from decimal import Decimal
+
 from src.modules.competition.application.services.tee_context_builder import TeeContextBuilder
 from src.modules.golf_course.domain.entities.golf_course import GolfCourse
 from src.modules.golf_course.domain.entities.hole import Hole
@@ -138,3 +140,61 @@ class TestFoursomesTeamCard:
         # del campo (que es el de amarillas, la primera barra)
         assert context.holes_for(TeeColor.RED, Gender.FEMALE)[0] == 18
         assert context.holes_by_stroke_index[0] == 1
+class TestUnratableTee:
+    """
+    Una barra que no se puede valorar no debe tumbar la construccion del
+    contexto: antes el ValueError subia hasta la API y la ronda se quedaba sin
+    poder generar partidos, con un 500. Ver RyderCupAm#219.
+    """
+
+    def test_a_pitch_and_putt_tee_is_now_rated(self):
+        """
+        Given un pitch & putt federado (par 58, CR 54.9, SR 91)
+        When se construye el contexto
+        Then su barra se valora, en vez de quedarse fuera
+        """
+        par_58 = _card(list(range(1, 19)), pars=[3] * 14 + [4] * 4)
+        course = GolfCourse.create(
+            name="Corto",
+            country_code=CountryCode("ES"),
+            course_type=CourseType.PITCH_AND_PUTT,
+            creator_id=UserId.generate(),
+            tees=[
+                Tee(color=TeeColor.ORANGE, gender=Gender.MALE, course_rating=54.9,
+                    slope_rating=91, holes=par_58),
+            ],
+            holes=par_58,
+        )
+        course.approve()
+
+        context = TeeContextBuilder.build(course)
+
+        assert context.tee_ratings[("ORANGE", "MALE")].par == 58
+        assert context.tee_ratings[("ORANGE", "MALE")].course_rating == Decimal("54.9")
+
+    def test_an_unratable_tee_is_left_out_instead_of_raising(self):
+        """
+        Given una barra cuyo rating no cabe ni en el rango mas ancho
+        When se construye el contexto
+        Then esa barra se queda fuera y las demas siguen valoradas
+
+        El caso no se da con el catalogo federado —que entra entero en los
+        rangos—, pero la reserva tiene que existir: es la que antes lanzaba dos
+        veces el mismo error y acababa en un 500.
+        """
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140),
+                Tee(color=TeeColor.WHITE, gender=Gender.MALE, course_rating=71.0,
+                    slope_rating=130),
+            ]
+        )
+        # Se fuerza sobre la entidad ya construida: `Tee` no deja crear una
+        # barra asi, y es justo lo que hace que este camino sea una reserva
+        object.__setattr__(course.tees[0], "course_rating", 30.0)
+
+        context = TeeContextBuilder.build(course)
+
+        assert ("YELLOW", "MALE") not in context.tee_ratings
+        assert ("WHITE", "MALE") in context.tee_ratings

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -7,6 +7,7 @@ PRIMERA barra. De los 800 campos federados importados con mas de una barra con
 tarjeta, 25 tienen par distinto entre barras y 56 stroke index distinto.
 """
 
+import logging
 from decimal import Decimal
 
 from src.modules.competition.application.services.tee_context_builder import TeeContextBuilder
@@ -200,3 +201,26 @@ class TestUnratableTee:
 
         assert ("YELLOW", "MALE") not in context.tee_ratings
         assert ("WHITE", "MALE") in context.tee_ratings
+    def test_the_warning_says_the_round_cannot_be_generated(self, caplog):
+        """
+        El aviso decia que los jugadores de esa barra jugarian con su Handicap
+        Index, que es lo que pasa en partida rapida y NO aqui. Se corrigio el
+        docstring y el aviso de al lado se quedo diciendolo. Ver RyderCupAm#219.
+        """
+        course = _course(
+            [
+                Tee(color=TeeColor.YELLOW, gender=Gender.MALE, course_rating=73.1,
+                    slope_rating=140),
+                Tee(color=TeeColor.WHITE, gender=Gender.MALE, course_rating=71.0,
+                    slope_rating=130),
+            ]
+        )
+        object.__setattr__(course.tees[0], "course_rating", 30.0)
+
+        with caplog.at_level(logging.WARNING):
+            TeeContextBuilder.build(course)
+
+        assert "cannot be rated" in caplog.text
+        assert "will not be able to have their round generated" in caplog.text
+        # Lo que NO debe decir: eso es lo que hace partida rapida, no esta
+        assert "Handicap Index" not in caplog.text

--- a/tests/unit/modules/competition/application/services/test_tee_context_builder.py
+++ b/tests/unit/modules/competition/application/services/test_tee_context_builder.py
@@ -140,6 +140,8 @@ class TestFoursomesTeamCard:
         # del campo (que es el de amarillas, la primera barra)
         assert context.holes_for(TeeColor.RED, Gender.FEMALE)[0] == 18
         assert context.holes_by_stroke_index[0] == 1
+
+
 class TestUnratableTee:
     """
     Una barra que no se puede valorar no debe tumbar la construccion del

--- a/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
+++ b/tests/unit/modules/competition/domain/services/test_playing_handicap_calculator.py
@@ -28,34 +28,52 @@ class TestTeeRating:
         assert rating.par == 72
 
     def test_course_rating_below_min_raises(self):
-        """Error si course_rating < 55."""
+        """Error si course_rating < 45."""
         with pytest.raises(ValueError, match="course_rating must be between"):
-            TeeRating(course_rating=Decimal("54.0"), slope_rating=113, par=72)
+            TeeRating(course_rating=Decimal("44.0"), slope_rating=113, par=72)
 
     def test_course_rating_above_max_raises(self):
-        """Error si course_rating > 85."""
+        """Error si course_rating > 90."""
         with pytest.raises(ValueError, match="course_rating must be between"):
-            TeeRating(course_rating=Decimal("86.0"), slope_rating=113, par=72)
+            TeeRating(course_rating=Decimal("91.0"), slope_rating=113, par=72)
 
     def test_slope_rating_below_min_raises(self):
-        """Error si slope_rating < 55."""
+        """Error si slope_rating < 40."""
         with pytest.raises(ValueError, match="slope_rating must be between"):
-            TeeRating(course_rating=Decimal("72.0"), slope_rating=54, par=72)
+            TeeRating(course_rating=Decimal("72.0"), slope_rating=39, par=72)
 
     def test_slope_rating_above_max_raises(self):
-        """Error si slope_rating > 155."""
+        """Error si slope_rating > 160."""
         with pytest.raises(ValueError, match="slope_rating must be between"):
-            TeeRating(course_rating=Decimal("72.0"), slope_rating=156, par=72)
+            TeeRating(course_rating=Decimal("72.0"), slope_rating=161, par=72)
 
     def test_par_below_min_raises(self):
-        """Error si par < 66."""
+        """Error si par < 50."""
         with pytest.raises(ValueError, match="par must be between"):
-            TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=65)
+            TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=49)
 
     def test_par_above_max_raises(self):
-        """Error si par > 76."""
+        """Error si par > 80."""
         with pytest.raises(ValueError, match="par must be between"):
-            TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=77)
+            TeeRating(course_rating=Decimal("72.0"), slope_rating=113, par=81)
+
+    def test_admite_un_pitch_and_putt_federado(self):
+        """
+        Los rangos son la union de todos los tipos de campo, no los de un 18
+        hoyos: con los de antes (CR 55-85, par 66-76) un pitch & putt federado
+        no se podia valorar, y sus jugadores acababan jugando con el Handicap
+        Index a pelo —o, en competicion, sin poder generar los partidos—.
+        Datos reales de Son Parc naranjas. Ver RyderCupAm#206 y RyderCupAm#219.
+        """
+        rating = TeeRating(course_rating=Decimal("54.9"), slope_rating=91, par=58)
+
+        assert rating.course_rating == Decimal("54.9")
+        assert rating.par == 58
+
+    def test_admite_los_extremos_del_catalogo_federado(self):
+        """El catalogo va de CR 46.5 a 84.7 y de SR 46 a 157: todo debe entrar."""
+        TeeRating(course_rating=Decimal("46.5"), slope_rating=46, par=54)
+        TeeRating(course_rating=Decimal("84.7"), slope_rating=157, par=74)
 
     def test_tee_rating_is_frozen(self):
         """TeeRating es inmutable."""


### PR DESCRIPTION
Found while setting up a competition on the local cluster to test the per-tee par work in RyderCupWeb#424.

## What was wrong

`TeeRating` validated the ranges of an 18-hole course:

```python
MIN_COURSE_RATING = 55   MAX_COURSE_RATING = 85
MIN_SLOPE_RATING  = 55   MAX_SLOPE_RATING  = 155
MIN_PAR           = 66   MAX_PAR           = 76
```

The `Tee` entity accepts CR 45–90 and SR 40–160, so we store courses we then refuse to rate. In the versioned RFEG dataset (4304 tees):

| | Real range | `TeeRating` accepted |
|---|---|---|
| Course rating | 46.5 – 84.7 | 55 – 85 |
| Slope rating | 46 – 157 | 55 – 155 |
| Par | 54 – 74 | 66 – 76 |

**468 tees across 227 courses** fall outside on CR, **642 tees** on par.

Two consequences:

**Quick match — silent and wrong.** The tee is skipped and its players play off the raw Handicap Index. On Son Parc's orange tee (par 58, CR 54.9, SR 91) an 18 handicap receives **18 strokes where the WHS gives 11**. Off by the whole handicap, on a short course where that decides everything.

**Competition — a 500.** `TeeContextBuilder.build` rates *every* tee of the course, so one short tee anywhere makes the round impossible to generate. Verified with all four players enrolled on YELLOW, a perfectly valid tee: still 500, because ORANGE exists in the course. Those 227 courses cannot host a competition at all.

## What changed

**The ranges are the union of every course type** — the same ones `Tee` already validates. The strict per-type range stays in `GolfCourse._validate_tee_ratings`, which is the only place that knows the `course_type`:

| | Standard 18 | Executive | Pitch & putt |
|---|---|---|---|
| Slope | 55 – 160 | 40 – 155 | 40 – 155 |
| Rating | 50 – 90 | 45 – 90 | 45 – 90 |

I first considered moving those per-type ranges into `TeeRating`, but this domain cannot import `golf_course` without breaking a separation the code defends explicitly. Keeping the wide range here and the strict one there means the net against a mistyped CR on a standard 18 is not lost — it just lives where the course type is known.

**`_rating_for` no longer raises from its own fallback.** The retry reused the same course rating and slope rating, changing only the par, so a rating out of range raised twice and the ValueError reached the API. It now returns `None`, the tee is left out of the context, and its players fall back to the Handicap Index — which is what the docstring promised. No tee in the current catalogue takes that path; it is a backstop.

**The parity harness covers a short course.** The client derives par from the holes while the backend carries it in the `TeeRating`, so this is exactly where the two implementations can drift. `run` now takes the scenario's own pars and stroke index instead of always emitting Meis'.

## Testing

`pytest tests/unit/ -q`: 2912 passing. ruff and mypy clean (the 6 ruff findings in `main.py` and `test_quick_match_endpoints.py` are pre-existing on `develop`).

New tests: a federated pitch & putt is now rated; the extremes of the catalogue (CR 46.5–84.7, SR 46–157) all fit; and an unratable tee is left out of the context instead of raising. Existing range tests updated to the new bounds.

Regenerating `backendParity.json` is **left to the RyderCupWeb PR**, which is where it is consumed and where `RATED_*` moves in step. Running the generator today already reports the gap that PR will close:

```
AssertionError: hándicap de juego ... en "campo corto": expected 18 to be 11
```

None of the 12 existing parity scenarios changed value.

## Deploying

**Backend first, then the frontend, back to back.** Between the two deploys, quick match on those 227 courses will allocate differently online and offline.

One more thing worth stating: competition playing handicaps are frozen into `matches` when the round is generated, so nothing already played moves. Quick match recomputes on every read, so **a quick match in progress on one of these courses will change allocation mid-round** — from 18 strokes to 11 on the example above. Correct, but visible to someone who did not touch anything.

Closes #206
Closes #219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pitch-and-putt courses and short 18-hole courses with broader par, course-rating, and slope-rating ranges.
  - Unratable tees are now excluded from tee ratings while hole-card information remains available.

- **Bug Fixes**
  - Improved handling of invalid tee and course ratings without interrupting course setup.
  - Preserved fallback behavior when valid course-level ratings are available.

- **Tests**
  - Added coverage for pitch-and-putt ratings, unratable tees, and rating boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->