### PR TITLE
Fix(history): Leave foursomes tournament cards without Stableford points

### DIFF
--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -372,6 +372,12 @@ class GetRecentMatchesUseCase:
             else course.reference_card
         )
         total_strokes, holes_played, points = self._scorecard_totals(raw, hole_card)
+        # En foursomes la pareja juega UNA bola, así que la tarjeta no es la
+        # vuelta de ninguno de los dos por separado y no lleva puntos Stableford.
+        # Los golpes del bando sí se enseñan, y son los mismos para los dos
+        # compañeros. Es la misma regla que en partida rápida, donde vive en
+        # `_to_quick_match_dto`: aquí se había quedado sin aplicar.
+        is_foursomes = raw.round_.match_format == MatchFormat.FOURSOMES
 
         return RecentMatchDTO(
             id=str(match.id.value),
@@ -385,7 +391,7 @@ class GetRecentMatchesUseCase:
             tournament_name=raw.tournament_name,
             result=self._result_for_team(match.get_winner(), "A" if in_team_a else "B"),
             score=match.result.get("score") if match.result else None,
-            stableford_points=points,
+            stableford_points=None if is_foursomes else points,
             total_strokes=total_strokes,
             holes_played=holes_played,
             partners=partners,

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import pytest
 
 from src.modules.competition.domain.entities.competition import Competition
+from src.modules.competition.domain.entities.hole_score import HoleScore
 from src.modules.competition.domain.entities.match import Match
 from src.modules.competition.domain.entities.round import Round
 from src.modules.competition.domain.value_objects.competition_id import CompetitionId
@@ -213,8 +214,15 @@ async def played_competition_match(
     round_date: date,
     result: dict,
     match_format: MatchFormat = MatchFormat.SINGLES,
+    own_scores_by_user_id: dict | None = None,
 ):
-    """Un partido de torneo terminado, con su ronda y su competición."""
+    """
+    Un partido de torneo terminado, con su ronda y su competición.
+
+    `own_scores_by_user_id` siembra la tarjeta de cada jugador —un golpe por
+    hoyo, empezando por el 1—. Sin ella el partido guarda quién ganó pero no
+    cómo jugó nadie, que es justo lo que hace falta para mirar los puntos.
+    """
     creator_id = team_a_user_ids[0]
     competition = Competition.create(
         id=CompetitionId(uuid4()),
@@ -253,10 +261,26 @@ async def played_competition_match(
     match.start()
     match.complete(result)
 
+    hole_scores = []
+    for user_id, own_scores in (own_scores_by_user_id or {}).items():
+        team = "A" if user_id in team_a_user_ids else "B"
+        for hole_number, own_score in enumerate(own_scores, start=1):
+            hole_score = HoleScore.create(
+                match_id=match.id,
+                hole_number=hole_number,
+                player_user_id=user_id,
+                team=team,
+                strokes_received=0,
+            )
+            hole_score.set_own_score(own_score)
+            hole_scores.append(hole_score)
+
     async with competition_uow:
         await competition_uow.competitions.add(competition)
         await competition_uow.rounds.add(round_)
         await competition_uow.matches.add(match)
+        if hole_scores:
+            await competition_uow.hole_scores.add_many(hole_scores)
         await competition_uow.commit()
 
     return match
@@ -712,6 +736,72 @@ class TestCompetitionMatch:
 
         assert feed.matches[0].scoring_format is None
         assert feed.matches[0].stableford_points is None
+
+    async def test_a_scored_tournament_card_carries_its_stableford_points(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Con tarjeta anotada sí hay puntos: nueve pares en un campo de par 4 son
+        18 puntos. Fija el caso normal contra el que se recorta FOURSOMES.
+        """
+        player = await create_user(user_uow, "Home")
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+            own_scores_by_user_id={player.id: [4] * 9},
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].stableford_points == 18
+        assert feed.matches[0].total_strokes == 36
+        assert feed.matches[0].holes_played == 9
+
+    async def test_a_foursomes_card_has_no_stableford_points(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        La pareja juega UNA bola, así que la tarjeta no es la vuelta de ninguno
+        de los dos y no lleva puntos —los golpes del bando sí se enseñan—. La
+        regla ya estaba en la partida rápida y el torneo se la había saltado:
+        el mismo partido salía con 18 puntos para cada compañero.
+        """
+        player = await create_user(user_uow, "Home")
+        partner = await create_user(user_uow, "Partner")
+        rival_one = await create_user(user_uow, "Rivalone")
+        rival_two = await create_user(user_uow, "Rivaltwo")
+        course = await create_golf_course(golf_course_uow, player.id)
+        # La bola del bando se guarda igual a nombre de los dos compañeros
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id, partner.id],
+            team_b_user_ids=[rival_one.id, rival_two.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+            match_format=MatchFormat.FOURSOMES,
+            own_scores_by_user_id={player.id: [4] * 9, partner.id: [4] * 9},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        scorer = (await use_case.execute(player.id)).matches[0]
+        companion = (await use_case.execute(partner.id)).matches[0]
+
+        assert scorer.stableford_points is None
+        assert companion.stableford_points is None
+        # Los golpes del bando sí, y los mismos para los dos
+        assert scorer.total_strokes == companion.total_strokes == 36
+        assert scorer.holes_played == companion.holes_played == 9
+        assert scorer.score == companion.score == "2UP"
 
     async def test_separates_partners_from_opponents_in_fourball(
         self, user_uow, competition_uow, qm_uow, golf_course_uow


### PR DESCRIPTION
Closes #223

## What

In foursomes the pair plays **one ball**, so the card is not either partner's own round and carries **no Stableford points** — the history shows the side's gross strokes and the match result instead.

`_to_quick_match_dto` already applies that rule. `_to_competition_match_dto` passed the points straight through, so a tournament foursomes was listed as **23 pts** for the winning side and **7 pts** for the losing one.

```diff
-            stableford_points=points,
+            stableford_points=None if is_foursomes else points,
```

Player stats were never affected: `get_player_stats_use_case` already skips FOURSOMES on both paths, so the match stays out of the average, the WHS differential and the round count. This was only the history line.

## Why the web client needs no change

`RecentMatches.jsx:75` already falls back to the match result when `stableford_points` is null — that is exactly why quick match foursomes looked right and tournament ones did not. Once the API stops sending points, the entry reads `9&7` like its quick match sibling. No coordinated deploy needed.

## Tests

`played_competition_match` can now seed a scorecard per player, which is what makes the new tests meaningful — the existing tournament tests had no card at all, so their `stableford_points is None` said nothing about the format:

- `test_a_scored_tournament_card_carries_its_stableford_points` — nine pars on a par 4 course are 18 points in SINGLES. Fixes the normal case the foursomes rule is carved out of.
- `test_a_foursomes_card_has_no_stableford_points` — the same nine pars in FOURSOMES: no points for either partner, and both read the side's 36 strokes and the same result.

Reverting the one-line fix makes the second test fail with `18 == None`, so it does not bless the bug.

`pytest tests/unit/` 2915 passed · `ruff check` clean on the touched files · `mypy src/` no issues.

## How it was found

Playing a full competition foursomes in the browser against the local cluster on 2026-08-20 (match `a6a8ba1a`, "Torneo Par Por Barra", Son Parc Par 71): the finished match showed up in "Todas tus partidas" with points, two lines above quick match foursomes that correctly showed `9UP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fYajaCRfCk3JykfF78J7p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recent match history now correctly handles foursomes rounds.
  * Foursomes matches display shared-side stroke and hole totals without individual Stableford points.
  * Scored tournament matches now accurately report strokes, holes played, and Stableford points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->