### PR TITLE
Fix(auth): Derive a name when Google does not send one

### DIFF
--- a/src/modules/user/infrastructure/external/google_oauth_service.py
+++ b/src/modules/user/infrastructure/external/google_oauth_service.py
@@ -89,11 +89,13 @@ class GoogleOAuthService(IGoogleOAuthService):
                 if not google_user_id or not email:
                     raise ValueError("Google user info is missing required fields (sub, email)")
 
+                first_name, last_name = self._resolve_names(userinfo, email)
+
                 return GoogleUserInfo(
                     google_user_id=google_user_id,
                     email=email,
-                    first_name=userinfo.get("given_name", ""),
-                    last_name=userinfo.get("family_name", ""),
+                    first_name=first_name,
+                    last_name=last_name,
                     email_verified=bool(userinfo.get("email_verified", False)),
                     picture_url=userinfo.get("picture"),
                 )
@@ -102,3 +104,39 @@ class GoogleOAuthService(IGoogleOAuthService):
         except (httpx.RequestError, httpx.TimeoutException) as exc:
             logger.warning(f"Google OAuth network error: {exc}")
             raise ValueError(f"Failed to communicate with Google OAuth service: {exc}") from exc
+
+    @staticmethod
+    def _resolve_names(userinfo: dict, email: str) -> tuple[str, str]:
+        """
+        Nombre y apellido de un perfil de Google, que no siempre los trae.
+
+        Google manda `given_name` y `family_name` solo cuando la cuenta tiene
+        el nombre estructurado. Una cuenta con un solo nombre manda `name` y
+        nada más, y antes eso se guardaba como cadena vacía: el registro se
+        cerraba con el nombre en blanco y el cliente rechazaba la respuesta al
+        pintarla, así que la cuenta quedaba creada y **sin poder entrar nunca**
+        —el siguiente intento la encuentra por su cuenta de Google y devuelve
+        el mismo nombre vacío—.
+
+        Se cae primero a `name`, partiéndolo en nombre y apellidos, y en último
+        término a la parte local del email: un dato real del usuario, no uno
+        inventado, y que además va a corregir en el acto, porque un registro
+        nuevo aterriza en «completar perfil».
+        """
+        given = (userinfo.get("given_name") or "").strip()
+        family = (userinfo.get("family_name") or "").strip()
+        if given and family:
+            return given, family
+
+        # "Ada Lovelace King" → nombre "Ada", apellidos "Lovelace King"
+        full_name_parts = (userinfo.get("name") or "").split()
+        if not given and full_name_parts:
+            given = full_name_parts[0]
+        if not family and len(full_name_parts) > 1:
+            family = " ".join(full_name_parts[1:])
+
+        # El email ya viene validado como no vacío, pero un local vacío
+        # ("@dominio") dejaría el mismo hueco que se está cerrando
+        fallback = email.split("@", 1)[0].strip() or "Usuario"
+        return given or fallback, family or fallback
+

--- a/tests/unit/modules/user/infrastructure/external/test_google_oauth_service.py
+++ b/tests/unit/modules/user/infrastructure/external/test_google_oauth_service.py
@@ -157,7 +157,14 @@ class TestGoogleOAuthService:
     async def test_exchange_code_handles_missing_optional_fields(
         self, mock_client_class, service, mock_token_response
     ):
-        """Debe manejar campos opcionales ausentes (given_name, family_name, picture)."""
+        """
+        Sin nombre en el perfil, el nombre sale del email y NUNCA vacío.
+
+        Este test afirmaba que el nombre y el apellido quedaban en `""`, y con
+        eso daba por bueno el defecto: el registro se cerraba con el nombre en
+        blanco, el cliente rechazaba la respuesta al pintarla y la cuenta
+        quedaba creada sin poder entrar nunca. Ver la issue #227.
+        """
         mock_client = AsyncMock()
         mock_client.post.return_value = mock_token_response
 
@@ -178,8 +185,8 @@ class TestGoogleOAuthService:
 
         assert result.google_user_id == "google-minimal"
         assert result.email == "minimal@gmail.com"
-        assert result.first_name == ""
-        assert result.last_name == ""
+        assert result.first_name == "minimal"
+        assert result.last_name == "minimal"
         assert result.picture_url is None
 
     @patch("src.modules.user.infrastructure.external.google_oauth_service.httpx.AsyncClient")
@@ -206,3 +213,56 @@ class TestGoogleOAuthService:
         get_call_args = mock_client.get.call_args
         assert get_call_args[0][0] == GOOGLE_USERINFO_URL
         assert "Bearer ya29.test-access-token" in str(get_call_args)
+
+
+class TestResolveNames:
+    """
+    De dónde sale el nombre cuando Google no lo manda entero (issue #227).
+
+    Google solo manda `given_name` y `family_name` con el nombre estructurado.
+    Lo que se guardaba antes en su lugar —cadena vacía— dejaba la cuenta creada
+    y sin poder entrar nunca, porque el cliente exige los dos campos.
+    """
+
+    def test_uses_the_structured_name_when_google_sends_it(self):
+        assert GoogleOAuthService._resolve_names(
+            {"given_name": "Ada", "family_name": "Lovelace"}, "ada@example.com"
+        ) == ("Ada", "Lovelace")
+
+    def test_splits_the_full_name_when_the_structured_one_is_missing(self):
+        """El primer término es el nombre y el resto los apellidos."""
+        assert GoogleOAuthService._resolve_names(
+            {"name": "Ada Lovelace King"}, "ada@example.com"
+        ) == ("Ada", "Lovelace King")
+
+    def test_falls_back_to_the_email_for_the_surname_of_a_single_name_account(self):
+        """El caso real del reporte: cuenta con un solo nombre y sin apellido."""
+        assert GoogleOAuthService._resolve_names(
+            {"given_name": "Ada", "name": "Ada"}, "lovelace@example.com"
+        ) == ("Ada", "lovelace")
+
+    def test_falls_back_to_the_email_when_there_is_no_name_at_all(self):
+        assert GoogleOAuthService._resolve_names({}, "ada.lovelace@example.com") == (
+            "ada.lovelace",
+            "ada.lovelace",
+        )
+
+    def test_never_returns_an_empty_field(self):
+        """
+        Un email sin parte local dejaría el mismo hueco que se está cerrando.
+        Ninguna combinación puede devolver una cadena vacía: es lo único que
+        el cliente no acepta.
+        """
+        for userinfo, email in [
+            ({}, "@example.com"),
+            ({"given_name": "   ", "family_name": "   "}, "@example.com"),
+            ({"name": "   "}, "@example.com"),
+        ]:
+            first_name, last_name = GoogleOAuthService._resolve_names(userinfo, email)
+            assert first_name and last_name, (userinfo, email)
+
+    def test_ignores_blank_padding_around_the_names(self):
+        assert GoogleOAuthService._resolve_names(
+            {"given_name": "  Ada  ", "family_name": "  Lovelace  "}, "ada@example.com"
+        ) == ("Ada", "Lovelace")
+


### PR DESCRIPTION
Closes #227

## The failure

Signing in with Google died with **"User entity requires id, email, first_name, and last_name"**, reported from production today.

Google sends `given_name` / `family_name` only when the account has a structured name; one with a single name sends `name` and nothing else. The service filled the rest with an empty string, and nothing downstream stopped it — `User.create_from_oauth` does not check for a blank name and `UserResponseDTO` types both as `str`, which Pydantic fills happily with `""`. The API answered 200 with a blank name and the web client rejected it at `User.js:26`, where `!first_name` is true for an empty string.

`id` and `email` were never the problem: `_get_user_info` already validates both, so the only fields that could arrive empty were the name and the surname.

## Why it was P0

The registration is committed **before** the response is rendered, so the account already existed with a blank name when the client blew up. On the next attempt `_resolve_user` finds it by its OAuth account and hands back the same blank name: same error, forever. The user cannot register by email either, because the address is taken. One production account was affected and was fixed by hand.

## The fix

| Google sends | first_name | last_name |
|---|---|---|
| `given_name: Ada`, `family_name: Lovelace` | `Ada` | `Lovelace` |
| `name: Ada Lovelace King` | `Ada` | `Lovelace King` |
| `given_name: Ada`, `name: Ada` (the reported case) | `Ada` | local part of the email |
| nothing | local part of the email | local part of the email |

The email's local part is a real value of the user's rather than an invented surname, and it is corrected immediately: a new registration lands on `/auth/complete-profile` through the existing `is_new_user` flow. No combination can return an empty field — including an address with no local part, which would leave the very hole this closes.

## Tests

`test_exchange_code_handles_missing_optional_fields` asserted `first_name == ""` as the correct outcome and called it "handles missing optional fields". That is what let the defect through, so it now pins the value that keeps the account usable, with a note about why it changed.

Six new tests cover the resolution itself, including the reported single-name case and the invariant that no field ever comes back empty. Reverting the source file alone fails seven of them.

`pytest tests/unit/` 2921 passed · `ruff check` clean · `mypy` no issues.

## Not a regression from v2.10.0

Neither `google_oauth_service.py` nor the frontend `User.js` has been touched since Google OAuth was integrated. The release deployed today is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fYajaCRfCk3JykfF78J7p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google sign-in profile handling when first or last names are missing.
  - Names are now filled using available profile information or the email address, preventing incomplete account details.
  - Added handling for blank and whitespace-only name values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->