### PR TITLE
Fix(avatar): Accept the HEIC photos an iPhone actually stores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -184,6 +184,12 @@ python-multipart==0.0.32
 # comprimir a JPEG) antes de guardar la foto de avatar subida por el usuario en BD
 Pillow==12.3.0
 
+# pillow-heif - Lector de HEIC/HEIF para Pillow, que no lo trae. Es el formato en
+# el que un iPhone guarda TODAS las fotos de su fototeca, así que sin esto la
+# única forma de poner un avatar desde un iPhone era hacer una foto nueva: la
+# cámara del navegador entrega JPEG y la fototeca entrega HEIC (BE #232)
+pillow-heif==1.5.0
+
 
 # ================================
 # TESTING Y DESARROLLO

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -81,7 +81,7 @@ PHOTO_CACHE_CONTROL = "private, max-age=31536000, immutable"
 @limiter.limit("30/hour")
 async def upload_my_photo(
     request: Request,  # noqa: ARG001 - Required by SlowAPI for rate limiting
-    file: UploadFile = File(..., description="Image file (JPEG, PNG or WEBP)"),
+    file: UploadFile = File(..., description="Image file (HEIC, JPEG, PNG or WEBP)"),
     caption: str | None = Form(None, max_length=280),
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: UploadProfilePhotoUseCase = Depends(get_upload_profile_photo_use_case),

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -81,7 +81,7 @@ PHOTO_CACHE_CONTROL = "private, max-age=31536000, immutable"
 @limiter.limit("30/hour")
 async def upload_my_photo(
     request: Request,  # noqa: ARG001 - Required by SlowAPI for rate limiting
-    file: UploadFile = File(..., description="Image file (HEIC, JPEG, PNG or WEBP)"),
+    file: UploadFile = File(..., description="Image file (HEIC/HEIF, JPEG, PNG or WEBP)"),
     caption: str | None = Form(None, max_length=280),
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: UploadProfilePhotoUseCase = Depends(get_upload_profile_photo_use_case),

--- a/src/modules/user/infrastructure/api/v1/avatar_routes.py
+++ b/src/modules/user/infrastructure/api/v1/avatar_routes.py
@@ -190,7 +190,7 @@ async def set_avatar_preset(
     status_code=status.HTTP_201_CREATED,
     summary="Upload a new avatar photo",
     description=(
-        "Uploads a new photo to use as avatar (max 10MB, JPEG/PNG/WEBP). "
+        "Uploads a new photo to use as avatar (max 10MB, HEIC/JPEG/PNG/WEBP). "
         "The server resizes/compresses it to 512x512 JPEG before storing. "
         "Rate limited to 10 per hour. Keeps a history of up to 5 uploads per user "
         "(oldest is pruned automatically)."

--- a/src/modules/user/infrastructure/api/v1/avatar_routes.py
+++ b/src/modules/user/infrastructure/api/v1/avatar_routes.py
@@ -190,7 +190,7 @@ async def set_avatar_preset(
     status_code=status.HTTP_201_CREATED,
     summary="Upload a new avatar photo",
     description=(
-        "Uploads a new photo to use as avatar (max 10MB, HEIC/JPEG/PNG/WEBP). "
+        "Uploads a new photo to use as avatar (max 10MB, HEIC/HEIF/JPEG/PNG/WEBP). "
         "The server resizes/compresses it to 512x512 JPEG before storing. "
         "Rate limited to 10 per hour. Keeps a history of up to 5 uploads per user "
         "(oldest is pruned automatically)."

--- a/src/modules/user/infrastructure/external/pillow_image_processor.py
+++ b/src/modules/user/infrastructure/external/pillow_image_processor.py
@@ -8,12 +8,21 @@ redimensiona y comprime la imagen de avatar antes de guardarla en BD.
 import io
 
 from PIL import Image, ImageOps, UnidentifiedImageError
+from pillow_heif import register_heif_opener
 
 from src.modules.user.application.ports.image_processor_interface import IImageProcessor
 from src.modules.user.domain.errors.user_errors import InvalidAvatarImageError
 
-# Formatos de imagen de entrada aceptados (Pillow los normaliza todos a JPEG de salida)
-ALLOWED_INPUT_FORMATS = {"JPEG", "PNG", "WEBP"}
+# Pillow no lee HEIC por su cuenta. Se registra al importar el módulo, una sola
+# vez, para que `Image.open` lo reconozca igual que a los demás formatos.
+register_heif_opener()
+
+# Formatos de imagen de entrada aceptados (Pillow los normaliza todos a JPEG de salida).
+# HEIF es el formato en el que un iPhone guarda las fotos de su fototeca: sin él, la
+# única forma de poner avatar desde un iPhone era hacer una foto nueva, porque la
+# cámara del navegador entrega JPEG y la fototeca entrega el HEIC original (BE #232).
+# Ojo, Pillow lo identifica como "HEIF", no como "HEIC".
+ALLOWED_INPUT_FORMATS = {"HEIF", "JPEG", "PNG", "WEBP"}
 
 # Dimensión final (cuadrada) del avatar
 AVATAR_TARGET_SIZE = 512
@@ -115,7 +124,9 @@ class PillowImageProcessor(IImageProcessor):
             raise InvalidAvatarImageError("El archivo subido no es una imagen válida") from exc
 
         # Corrige la orientación según el tag EXIF antes de nada más: si no, las
-        # fotos tomadas en vertical con el móvil se guardarían giradas.
+        # fotos tomadas en vertical con el móvil se guardarían giradas. Un HEIC
+        # no pasa por aquí dos veces: pillow-heif ya lo entrega girado y con el
+        # tag puesto a 1, así que `exif_transpose` lo deja como está.
         transposed = ImageOps.exif_transpose(image)
         if transposed is not None:
             image = transposed

--- a/tests/unit/modules/user/infrastructure/external/test_pillow_image_processor.py
+++ b/tests/unit/modules/user/infrastructure/external/test_pillow_image_processor.py
@@ -93,3 +93,88 @@ class TestPillowImageProcessor:
 
         with pytest.raises(InvalidAvatarImageError):
             processor.process_avatar_image(raw_bytes)
+
+
+class TestHeicFromAnIPhonePhotoLibrary:
+    """
+    Las fotos de la fototeca de un iPhone son HEIC (BE #232).
+
+    Pillow no lo lee por su cuenta, así que la subida moría con «no es una
+    imagen válida» y desde un iPhone solo se podía poner avatar haciendo una
+    foto nueva: la cámara del navegador entrega JPEG y la fototeca entrega el
+    HEIC original.
+    """
+
+    @staticmethod
+    def _heic_bytes(width: int, height: int, exif: Image.Exif | None = None) -> bytes:
+        image = Image.new("RGB", (width, height), color=(10, 200, 50))
+        buffer = io.BytesIO()
+        image.save(buffer, "HEIF", exif=exif.tobytes() if exif else None)
+        return buffer.getvalue()
+
+    def test_processes_a_heic_photo_to_square_jpeg(self):
+        """
+        Given una foto HEIC como las que guarda un iPhone
+        When se procesa como avatar
+        Then sale el mismo JPEG cuadrado que con cualquier otro formato
+        """
+        processor = PillowImageProcessor()
+
+        result = processor.process_avatar_image(self._heic_bytes(800, 400))
+
+        output_image = Image.open(io.BytesIO(result))
+        assert output_image.format == "JPEG"
+        assert output_image.size == (AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE)
+
+    def test_processes_a_heic_photo_for_the_gallery(self):
+        """La subida de foto de perfil comparte la validación, así que también entra."""
+        processor = PillowImageProcessor()
+
+        result = processor.process_gallery_image(self._heic_bytes(400, 300))
+
+        assert Image.open(io.BytesIO(result)).format == "JPEG"
+
+    def test_pillow_identifies_heic_as_heif(self):
+        """
+        El nombre del formato es lo que decide si se acepta, y Pillow llama
+        «HEIF» a un HEIC. Poner «HEIC» en la lista no habría servido de nada.
+        """
+        assert Image.open(io.BytesIO(self._heic_bytes(60, 60))).format == "HEIF"
+
+    def test_does_not_rotate_a_heic_twice(self):
+        """
+        pillow-heif ya entrega la imagen girada y con el tag EXIF a 1, así que
+        `exif_transpose` no debe volver a girarla. Si alguna versión futura
+        cambiara eso, las fotos verticales de iPhone saldrían tumbadas.
+        """
+        exif = Image.Exif()
+        exif[274] = 6  # girar 90º
+        raw = self._heic_bytes(400, 300, exif=exif)
+
+        decoded = Image.open(io.BytesIO(raw))
+
+        assert decoded.size == (300, 400), "pillow-heif debería entregarla ya girada"
+        assert decoded.getexif().get(274) in (None, 1), "y con la orientación ya consumida"
+
+    def test_still_rejects_a_format_that_is_not_allowed(self):
+        """Aceptar HEIC no abre la puerta a cualquier cosa."""
+        processor = PillowImageProcessor()
+        buffer = io.BytesIO()
+        Image.new("RGB", (100, 100)).save(buffer, "BMP")
+
+        with pytest.raises(InvalidAvatarImageError):
+            processor.process_avatar_image(buffer.getvalue())
+
+    def test_still_rejects_a_heic_over_the_pixel_limit(self, monkeypatch):
+        """
+        El tope de píxeles protege de una bomba de descompresión y tiene que
+        seguir aplicando al formato nuevo, no solo a los de antes.
+        """
+        from src.modules.user.infrastructure.external import pillow_image_processor
+
+        monkeypatch.setattr(pillow_image_processor, "MAX_INPUT_PIXELS", 100)
+        processor = PillowImageProcessor()
+
+        with pytest.raises(InvalidAvatarImageError, match="demasiado grande"):
+            processor.process_avatar_image(self._heic_bytes(200, 200))
+


### PR DESCRIPTION
Closes #232

## The failure

Picking an existing photo from the iOS library to use as a profile picture came back **"Ese archivo no es una imagen válida (JPEG, PNG o WEBP)"**. Taking a new photo in the same dialog worked.

That difference was the whole diagnosis. An iPhone stores its library in **HEIC**, while a capture taken through the browser is handed over as JPEG — so the upload failed for the only format the phone actually saves in. In practice, the sole way to set an avatar from an iPhone was to take a new picture, never to use one you already had.

Pillow does not read HEIC on its own. Verified against the pinned version: no HEIC/HEIF extension registered, so `Image.open` raised before the format check ever ran and the processor answered `InvalidAvatarImageError`.

## The fix

`pillow-heif` registers the reader and `HEIF` joins `ALLOWED_INPUT_FORMATS`. Nothing downstream changes: `_decode_and_validate` already re-encodes whatever comes in to JPEG, corrects EXIF orientation and guards the pixel ceiling.

Two things found while testing, both pinned by tests because both would break silently:

- **Pillow identifies a HEIC as `HEIF`**, not "HEIC". Listing `"HEIC"` would have done nothing at all while reading as correct in review.
- **pillow-heif consumes the EXIF orientation itself**, handing the image over already rotated with the tag at 1, so `exif_transpose` leaves it alone. There is no double rotation today; if a future version changed that, portrait iPhone photos would come out on their side.

## Scope

`social`'s profile photo upload shares this processor through `process_gallery_image`, so it is fixed too — the issue flagged it as worth checking and it was. Both API descriptions that listed the accepted formats have been updated so the docs stop lying.

## The guards still hold

Accepting HEIC does not loosen anything: a BMP is still rejected, and the pixel ceiling that protects against decompression bombs applies to the new format as well. Both have their own test.

## Verified end to end

The dependency ships its own libheif binaries, so the Dockerfile needed no change — checked by building the image and decoding a HEIC inside the container, which is the real risk with this kind of package.

Then against the local cluster, with that image deployed: uploading a 1200×900 HEIC carrying EXIF orientation 6 returns **201** where it used to return 400, and what comes back out is a **JPEG 512×512 RGB**, identical to any other photo.

`pytest tests/unit/` 2927 passed · `ruff check` clean on the touched files · `mypy src/` no issues. Reverting only the format list fails three of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fYajaCRfCk3JykfF78J7p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading HEIC/HEIF images as profile photos and avatars.
  * HEIC images are automatically processed and converted to JPEG for avatars and gallery images.
  * Existing image validation, including format and pixel-size limits, remains in place.
* **Documentation**
  * Updated upload descriptions to list HEIC among supported image formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->