### PR TITLE
chore(release): Prepare v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.10.2] - 2026-08-20
+
+### Fixed
+
+- **Una foto de la fototeca de un iPhone se rechazaba como «no es una imagen válida».** Un iPhone guarda **todas** las fotos de su galería en HEIC, y Pillow no lee ese formato por su cuenta, así que `Image.open` fallaba antes incluso de llegar a la comprobación de formato. Hacer una foto nueva sí funcionaba —la cámara del navegador entrega JPEG—, de modo que la única manera de ponerse avatar desde un iPhone era hacerse una foto en ese momento, nunca usar una que ya se tuviera. `pillow-heif` registra el lector y HEIF entra en los formatos admitidos; el resto del procesado no cambia, porque ya reconvertía a JPEG cualquier cosa que entrara. Dos detalles que salieron al probarlo y que quedan fijados por tests: Pillow identifica un HEIC como **«HEIF»**, así que poner «HEIC» en la lista no habría servido de nada, y pillow-heif **ya consume la orientación EXIF** —entrega la imagen girada y con el tag a 1—, así que no hay doble rotación; si eso cambiara, las fotos verticales saldrían tumbadas. La subida de foto de perfil comparte el mismo procesador, así que también queda arreglada. Verificado contra el clúster: un HEIC de 1200x900 con orientación 6 sube con 201 y se guarda como JPEG de 512x512. Reportado desde producción. Cierra la issue #232.
+
 ## [2.10.1] - 2026-08-20
 
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,6 +184,12 @@ python-multipart==0.0.32
 # comprimir a JPEG) antes de guardar la foto de avatar subida por el usuario en BD
 Pillow==12.3.0
 
+# pillow-heif - Lector de HEIC/HEIF para Pillow, que no lo trae. Es el formato en
+# el que un iPhone guarda TODAS las fotos de su fototeca, así que sin esto la
+# única forma de poner un avatar desde un iPhone era hacer una foto nueva: la
+# cámara del navegador entrega JPEG y la fototeca entrega HEIC (BE #232)
+pillow-heif==1.5.0
+
 
 # ================================
 # TESTING Y DESARROLLO

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -10,7 +10,7 @@ una release ha llegado realmente a produccion.
 
 import os
 
-APP_VERSION = "2.10.1"
+APP_VERSION = "2.10.2"
 
 
 def get_deployed_commit() -> str:

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -81,7 +81,7 @@ PHOTO_CACHE_CONTROL = "private, max-age=31536000, immutable"
 @limiter.limit("30/hour")
 async def upload_my_photo(
     request: Request,  # noqa: ARG001 - Required by SlowAPI for rate limiting
-    file: UploadFile = File(..., description="Image file (JPEG, PNG or WEBP)"),
+    file: UploadFile = File(..., description="Image file (HEIC, JPEG, PNG or WEBP)"),
     caption: str | None = Form(None, max_length=280),
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: UploadProfilePhotoUseCase = Depends(get_upload_profile_photo_use_case),

--- a/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
+++ b/src/modules/social/infrastructure/api/v1/profile_photo_routes.py
@@ -81,7 +81,7 @@ PHOTO_CACHE_CONTROL = "private, max-age=31536000, immutable"
 @limiter.limit("30/hour")
 async def upload_my_photo(
     request: Request,  # noqa: ARG001 - Required by SlowAPI for rate limiting
-    file: UploadFile = File(..., description="Image file (HEIC, JPEG, PNG or WEBP)"),
+    file: UploadFile = File(..., description="Image file (HEIC/HEIF, JPEG, PNG or WEBP)"),
     caption: str | None = Form(None, max_length=280),
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: UploadProfilePhotoUseCase = Depends(get_upload_profile_photo_use_case),

--- a/src/modules/user/infrastructure/api/v1/avatar_routes.py
+++ b/src/modules/user/infrastructure/api/v1/avatar_routes.py
@@ -190,7 +190,7 @@ async def set_avatar_preset(
     status_code=status.HTTP_201_CREATED,
     summary="Upload a new avatar photo",
     description=(
-        "Uploads a new photo to use as avatar (max 10MB, JPEG/PNG/WEBP). "
+        "Uploads a new photo to use as avatar (max 10MB, HEIC/JPEG/PNG/WEBP). "
         "The server resizes/compresses it to 512x512 JPEG before storing. "
         "Rate limited to 10 per hour. Keeps a history of up to 5 uploads per user "
         "(oldest is pruned automatically)."

--- a/src/modules/user/infrastructure/api/v1/avatar_routes.py
+++ b/src/modules/user/infrastructure/api/v1/avatar_routes.py
@@ -190,7 +190,7 @@ async def set_avatar_preset(
     status_code=status.HTTP_201_CREATED,
     summary="Upload a new avatar photo",
     description=(
-        "Uploads a new photo to use as avatar (max 10MB, HEIC/JPEG/PNG/WEBP). "
+        "Uploads a new photo to use as avatar (max 10MB, HEIC/HEIF/JPEG/PNG/WEBP). "
         "The server resizes/compresses it to 512x512 JPEG before storing. "
         "Rate limited to 10 per hour. Keeps a history of up to 5 uploads per user "
         "(oldest is pruned automatically)."

--- a/src/modules/user/infrastructure/external/pillow_image_processor.py
+++ b/src/modules/user/infrastructure/external/pillow_image_processor.py
@@ -8,12 +8,21 @@ redimensiona y comprime la imagen de avatar antes de guardarla en BD.
 import io
 
 from PIL import Image, ImageOps, UnidentifiedImageError
+from pillow_heif import register_heif_opener
 
 from src.modules.user.application.ports.image_processor_interface import IImageProcessor
 from src.modules.user.domain.errors.user_errors import InvalidAvatarImageError
 
-# Formatos de imagen de entrada aceptados (Pillow los normaliza todos a JPEG de salida)
-ALLOWED_INPUT_FORMATS = {"JPEG", "PNG", "WEBP"}
+# Pillow no lee HEIC por su cuenta. Se registra al importar el módulo, una sola
+# vez, para que `Image.open` lo reconozca igual que a los demás formatos.
+register_heif_opener()
+
+# Formatos de imagen de entrada aceptados (Pillow los normaliza todos a JPEG de salida).
+# HEIF es el formato en el que un iPhone guarda las fotos de su fototeca: sin él, la
+# única forma de poner avatar desde un iPhone era hacer una foto nueva, porque la
+# cámara del navegador entrega JPEG y la fototeca entrega el HEIC original (BE #232).
+# Ojo, Pillow lo identifica como "HEIF", no como "HEIC".
+ALLOWED_INPUT_FORMATS = {"HEIF", "JPEG", "PNG", "WEBP"}
 
 # Dimensión final (cuadrada) del avatar
 AVATAR_TARGET_SIZE = 512
@@ -115,7 +124,9 @@ class PillowImageProcessor(IImageProcessor):
             raise InvalidAvatarImageError("El archivo subido no es una imagen válida") from exc
 
         # Corrige la orientación según el tag EXIF antes de nada más: si no, las
-        # fotos tomadas en vertical con el móvil se guardarían giradas.
+        # fotos tomadas en vertical con el móvil se guardarían giradas. Un HEIC
+        # no pasa por aquí dos veces: pillow-heif ya lo entrega girado y con el
+        # tag puesto a 1, así que `exif_transpose` lo deja como está.
         transposed = ImageOps.exif_transpose(image)
         if transposed is not None:
             image = transposed

--- a/tests/unit/modules/user/infrastructure/external/test_pillow_image_processor.py
+++ b/tests/unit/modules/user/infrastructure/external/test_pillow_image_processor.py
@@ -93,3 +93,88 @@ class TestPillowImageProcessor:
 
         with pytest.raises(InvalidAvatarImageError):
             processor.process_avatar_image(raw_bytes)
+
+
+class TestHeicFromAnIPhonePhotoLibrary:
+    """
+    Las fotos de la fototeca de un iPhone son HEIC (BE #232).
+
+    Pillow no lo lee por su cuenta, así que la subida moría con «no es una
+    imagen válida» y desde un iPhone solo se podía poner avatar haciendo una
+    foto nueva: la cámara del navegador entrega JPEG y la fototeca entrega el
+    HEIC original.
+    """
+
+    @staticmethod
+    def _heic_bytes(width: int, height: int, exif: Image.Exif | None = None) -> bytes:
+        image = Image.new("RGB", (width, height), color=(10, 200, 50))
+        buffer = io.BytesIO()
+        image.save(buffer, "HEIF", exif=exif.tobytes() if exif else None)
+        return buffer.getvalue()
+
+    def test_processes_a_heic_photo_to_square_jpeg(self):
+        """
+        Given una foto HEIC como las que guarda un iPhone
+        When se procesa como avatar
+        Then sale el mismo JPEG cuadrado que con cualquier otro formato
+        """
+        processor = PillowImageProcessor()
+
+        result = processor.process_avatar_image(self._heic_bytes(800, 400))
+
+        output_image = Image.open(io.BytesIO(result))
+        assert output_image.format == "JPEG"
+        assert output_image.size == (AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE)
+
+    def test_processes_a_heic_photo_for_the_gallery(self):
+        """La subida de foto de perfil comparte la validación, así que también entra."""
+        processor = PillowImageProcessor()
+
+        result = processor.process_gallery_image(self._heic_bytes(400, 300))
+
+        assert Image.open(io.BytesIO(result)).format == "JPEG"
+
+    def test_pillow_identifies_heic_as_heif(self):
+        """
+        El nombre del formato es lo que decide si se acepta, y Pillow llama
+        «HEIF» a un HEIC. Poner «HEIC» en la lista no habría servido de nada.
+        """
+        assert Image.open(io.BytesIO(self._heic_bytes(60, 60))).format == "HEIF"
+
+    def test_does_not_rotate_a_heic_twice(self):
+        """
+        pillow-heif ya entrega la imagen girada y con el tag EXIF a 1, así que
+        `exif_transpose` no debe volver a girarla. Si alguna versión futura
+        cambiara eso, las fotos verticales de iPhone saldrían tumbadas.
+        """
+        exif = Image.Exif()
+        exif[274] = 6  # girar 90º
+        raw = self._heic_bytes(400, 300, exif=exif)
+
+        decoded = Image.open(io.BytesIO(raw))
+
+        assert decoded.size == (300, 400), "pillow-heif debería entregarla ya girada"
+        assert decoded.getexif().get(274) in (None, 1), "y con la orientación ya consumida"
+
+    def test_still_rejects_a_format_that_is_not_allowed(self):
+        """Aceptar HEIC no abre la puerta a cualquier cosa."""
+        processor = PillowImageProcessor()
+        buffer = io.BytesIO()
+        Image.new("RGB", (100, 100)).save(buffer, "BMP")
+
+        with pytest.raises(InvalidAvatarImageError):
+            processor.process_avatar_image(buffer.getvalue())
+
+    def test_still_rejects_a_heic_over_the_pixel_limit(self, monkeypatch):
+        """
+        El tope de píxeles protege de una bomba de descompresión y tiene que
+        seguir aplicando al formato nuevo, no solo a los de antes.
+        """
+        from src.modules.user.infrastructure.external import pillow_image_processor
+
+        monkeypatch.setattr(pillow_image_processor, "MAX_INPUT_PIXELS", 100)
+        processor = PillowImageProcessor()
+
+        with pytest.raises(InvalidAvatarImageError, match="demasiado grande"):
+            processor.process_avatar_image(self._heic_bytes(200, 200))
+


### PR DESCRIPTION
Patch release for the production HEIC upload failure reported today.

## What ships

| PR | |
|---|---|
| #233 | HEIC photos from an iPhone's library upload like any other image (closes #232) |

Nothing else: `develop` carried only this fix.

## Why it could not wait

An iPhone stores **every** photo in its library as HEIC, so the only way to set an avatar from one was to take a new picture on the spot — never to use a photo you already had. The profile photo upload shares the same processor and was equally affected.

## New dependency

`pillow-heif==1.5.0`, which ships its own libheif binaries: the Dockerfile needed no change. Verified by building the image and decoding a HEIC inside the container before opening the PR, and again by the CI's own Docker build. Snyk and Trivy cleared it.

## Verified against the local cluster

With that image deployed: a 1200×900 HEIC carrying EXIF orientation 6 uploads with **201** where it used to return 400, and comes back out as a **JPEG 512×512 RGB**.

`pytest tests/unit/` 2927 passed · `ruff check` clean on the touched files · `mypy src/` no issues.

CodeRabbit reviewed #233; its one note — naming both HEIC and HEIF in the public descriptions, since the processor accepts any HEIF — was applied. It does not review release PRs, which target `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fYajaCRfCk3JykfF78J7p