### PR TITLE
feat(quick-match): Allow recording a picked-up hole

### DIFF
--- a/alembic/versions/d3c7a5f18e42_allow_null_score_in_quick_match_hole_scores.py
+++ b/alembic/versions/d3c7a5f18e42_allow_null_score_in_quick_match_hole_scores.py
@@ -42,11 +42,25 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Las rayas no caben en el esquema viejo. Volver atras las BORRA, y el hoyo
-    # pasa de "recogido" a "sin anotar": es la unica lectura que el esquema
-    # anterior sabe representar, y es preferible a que el downgrade reviente
-    # contra el NOT NULL con la tabla ya poblada.
-    op.execute("DELETE FROM quick_match_hole_scores WHERE score IS NULL")
+    # Las rayas no caben en el esquema viejo, y volver atras solo puede
+    # perderlas: un hoyo "recogido" pasaria a "sin anotar", que es lo unico que
+    # el esquema anterior sabe representar. Antes que borrar tarjetas ya
+    # jugadas en silencio, el downgrade se planta y obliga a decidir a mano.
+    #
+    # Sin rayas guardadas —el caso normal, un rollback inmediato— no hay nada
+    # que perder y el downgrade sigue adelante.
+    hay_rayas = (
+        op.get_bind()
+        .execute(sa.text("SELECT EXISTS (SELECT 1 FROM quick_match_hole_scores WHERE score IS NULL)"))
+        .scalar_one()
+    )
+    if hay_rayas:
+        raise RuntimeError(
+            "Cannot downgrade: there are recorded picked-up holes (score IS NULL) "
+            "that the previous schema cannot represent. Export or delete them "
+            "explicitly before rolling back."
+        )
+
     op.alter_column(
         "quick_match_hole_scores",
         "score",

--- a/alembic/versions/d3c7a5f18e42_allow_null_score_in_quick_match_hole_scores.py
+++ b/alembic/versions/d3c7a5f18e42_allow_null_score_in_quick_match_hole_scores.py
@@ -1,0 +1,55 @@
+"""allow null score in quick_match_hole_scores
+
+Un hoyo se puede dar por acabado sin haberlo acabado: el jugador recoge la bola.
+En la tarjeta eso es una raya, y hasta ahora la partida rapida no tenia donde
+guardarla — la columna era NOT NULL, asi que el frontend mandaba `score: null`,
+Pydantic lo rechazaba y la pantalla ensenaba "Ese resultado no es valido".
+El modulo de competicion ya lo admitia (`own_score: int | None`), asi que el
+mismo boton funcionaba en un sitio y en el otro no.
+
+La raya es un hoyo ANOTADO, no un hoyo pendiente: la diferencia entre `score`
+nulo y no tener fila es justo esa, y de ella dependen la clasificacion en vivo
+(un hoyo recogido son 0 puntos Stableford, no un hoyo que falta por jugar) y
+poder dar la partida por terminada.
+
+El CHECK `ck_quick_match_hole_score` no se toca: en SQL un CHECK sobre NULL
+evalua a NULL y no se considera violado, asi que sigue acotando 1..15 los
+scores que si son numero.
+
+Revision ID: d3c7a5f18e42
+Revises: b4d7e1a9c25f
+Create Date: 2026-08-21
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d3c7a5f18e42"
+down_revision = "b4d7e1a9c25f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "quick_match_hole_scores",
+        "score",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Las rayas no caben en el esquema viejo. Volver atras las BORRA, y el hoyo
+    # pasa de "recogido" a "sin anotar": es la unica lectura que el esquema
+    # anterior sabe representar, y es preferible a que el downgrade reviente
+    # contra el NOT NULL con la tabla ya poblada.
+    op.execute("DELETE FROM quick_match_hole_scores WHERE score IS NULL")
+    op.alter_column(
+        "quick_match_hole_scores",
+        "score",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -138,12 +138,18 @@ class StartQuickMatchRequestDTO(BaseModel):
 
 
 class SubmitHoleScoreRequestDTO(BaseModel):
-    """DTO para registrar/actualizar el score propio de un hoyo (solo anotadores)."""
+    """
+    DTO para registrar/actualizar el score propio de un hoyo (solo anotadores).
+
+    `score` nulo es la raya: el hoyo queda anotado como recogido. El campo sigue
+    siendo obligatorio en el body —`Field(...)`—, asi que omitirlo no es lo
+    mismo que mandarlo nulo y no se puede borrar un score por descuido.
+    """
 
     quick_match_id: UUID
     player_user_id: UUID
     hole_number: int = Field(..., ge=1, le=18)
-    score: int = Field(..., ge=1, le=15)
+    score: int | None = Field(..., ge=1, le=15)
 
 
 class SubmitProxyHoleScoreRequestDTO(BaseModel):
@@ -153,7 +159,7 @@ class SubmitProxyHoleScoreRequestDTO(BaseModel):
     scorer_user_id: UUID
     target_participant_id: UUID
     hole_number: int = Field(..., ge=1, le=18)
-    score: int = Field(..., ge=1, le=15)
+    score: int | None = Field(..., ge=1, le=15)
 
 
 class QuickMatchParticipantDTO(BaseModel):
@@ -198,11 +204,11 @@ class PaginatedQuickMatchResponseDTO(BaseModel):
 
 
 class HoleScoreResponseDTO(BaseModel):
-    """DTO de un score de hoyo registrado."""
+    """DTO de un score de hoyo registrado. `score` nulo es la raya."""
 
     hole_number: int
     participant_id: UUID
-    score: int
+    score: int | None
     recorded_by_participant_id: UUID
 
 

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -270,11 +270,22 @@ class GetQuickMatchUseCase:
 
     @staticmethod
     def _net(
-        gross_score: int,
+        gross_score: int | None,
         participant_id: ParticipantId,
         hole_number: int,
         strokes_by_participant: dict[ParticipantId, ParticipantStrokes],
-    ) -> int:
+    ) -> int | None:
+        """
+        Score neto del hoyo, o None si el jugador recogio la bola.
+
+        La raya se propaga tal cual en vez de convertirse en un numero: asi
+        `ScoringService.calculate_hole_winner` la ve como bando sin bola y le
+        da el hoyo al rival, que es la regla de match play. Ese servicio ya
+        trabaja con `list[int | None]` porque competicion lo necesitaba, asi
+        que aqui no hay nada que anadirle.
+        """
+        if gross_score is None:
+            return None
         strokes = strokes_by_participant.get(participant_id)
         if strokes is None:
             return gross_score

--- a/src/modules/quick_match/application/use_cases/submit_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_hole_score_use_case.py
@@ -11,6 +11,7 @@ from src.modules.quick_match.application.exceptions import (
 )
 from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidHoleScoreViolation,
     InvalidQuickMatchStatusViolation,
 )
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
@@ -62,6 +63,12 @@ class SubmitQuickMatchHoleScoreUseCase:
                 raise NotAScorerError(
                     "Only a configured scorer can self-report a hole score. "
                     "Ask a scorer to record it for you."
+                )
+
+            if request.score is None and not quick_match.allows_picked_up_holes():
+                raise InvalidHoleScoreViolation(
+                    "A picked-up hole cannot be recorded in a Medal match: "
+                    "stroke play requires holing out on every hole."
                 )
 
             existing = await self._uow.quick_match_hole_scores.find_by_match_hole_and_participant(

--- a/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
+++ b/src/modules/quick_match/application/use_cases/submit_proxy_hole_score_use_case.py
@@ -11,6 +11,7 @@ from src.modules.quick_match.application.exceptions import (
 )
 from src.modules.quick_match.domain.entities.quick_match_hole_score import QuickMatchHoleScore
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidHoleScoreViolation,
     InvalidQuickMatchStatusViolation,
     NotAssignedScorerViolation,
 )
@@ -77,6 +78,12 @@ class SubmitProxyHoleScoreUseCase:
             if target_participant_id not in assignments.get(scorer_participant_id, []):
                 raise NotAssignedScorerViolation(
                     f"{target_participant_id} is not assigned to this scorer."
+                )
+
+            if request.score is None and not quick_match.allows_picked_up_holes():
+                raise InvalidHoleScoreViolation(
+                    "A picked-up hole cannot be recorded in a Medal match: "
+                    "stroke play requires holing out on every hole."
                 )
 
             existing = await self._uow.quick_match_hole_scores.find_by_match_hole_and_participant(

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -299,6 +299,19 @@ class QuickMatch:
         """Si esta partida reparte golpes de handicap (SCRATCH no reparte nada)."""
         return self._play_mode.allows_handicap()
 
+    def allows_picked_up_holes(self) -> bool:
+        """
+        Si en esta partida se puede anotar una raya (hoyo recogido sin acabar).
+
+        En MEDAL no: el stroke play exige embocar en todos los hoyos, y quien no
+        lo hace no entrega tarjeta. Anotar ahi una raya seria dar por buena una
+        vuelta que en un torneo no existe.
+
+        En Stableford si —recoger cuando ya no se puntua es lo normal, y vale
+        cero puntos— y en match play tambien, donde recoger es conceder el hoyo.
+        """
+        return self._scoring_format != ScoringFormat.MEDAL
+
     def get_effective_allowance(self) -> int:
         """
         Porcentaje de allowance efectivo para el Playing Handicap.

--- a/src/modules/quick_match/domain/entities/quick_match_hole_score.py
+++ b/src/modules/quick_match/domain/entities/quick_match_hole_score.py
@@ -27,7 +27,13 @@ class QuickMatchHoleScore:
 
     Invariantes:
     - hole_number entre 1 y 18
-    - score entre 1 y 15 (mismo rango que HoleScore en competition)
+    - score entre 1 y 15 (mismo rango que HoleScore en competition), o None
+
+    `score` nulo es la RAYA: el jugador recogio la bola y el hoyo se da por
+    acabado sin numero. No es lo mismo que no tener fila —eso es un hoyo que
+    falta por jugar—, y de esa diferencia dependen la clasificacion en vivo y
+    poder dar la partida por terminada. Mismo criterio que `HoleScore.own_score`
+    en competition, que ya admitia nulo.
     """
 
     def __init__(
@@ -36,7 +42,7 @@ class QuickMatchHoleScore:
         quick_match_id: QuickMatchId,
         hole_number: int,
         participant_id: ParticipantId,
-        score: int,
+        score: int | None,
         recorded_by_participant_id: ParticipantId,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
@@ -61,7 +67,10 @@ class QuickMatchHoleScore:
             )
 
     @staticmethod
-    def _validate_score(score: int) -> None:
+    def _validate_score(score: int | None) -> None:
+        # None es la raya (bola recogida), no un score fuera de rango
+        if score is None:
+            return
         if not (MIN_SCORE <= score <= MAX_SCORE):
             raise InvalidHoleScoreViolation(f"score debe estar entre {MIN_SCORE} y {MAX_SCORE}.")
 
@@ -76,7 +85,7 @@ class QuickMatchHoleScore:
         quick_match_id: QuickMatchId,
         hole_number: int,
         participant_id: ParticipantId,
-        score: int,
+        score: int | None,
         recorded_by_participant_id: ParticipantId,
     ) -> "QuickMatchHoleScore":
         now = datetime.now()
@@ -98,7 +107,7 @@ class QuickMatchHoleScore:
         quick_match_id: QuickMatchId,
         hole_number: int,
         participant_id: ParticipantId,
-        score: int,
+        score: int | None,
         recorded_by_participant_id: ParticipantId,
         created_at: datetime,
         updated_at: datetime,
@@ -135,7 +144,7 @@ class QuickMatchHoleScore:
         return self._participant_id
 
     @property
-    def score(self) -> int:
+    def score(self) -> int | None:
         return self._score
 
     @property
@@ -154,8 +163,8 @@ class QuickMatchHoleScore:
     # METODOS DE COMANDO
     # ===========================================
 
-    def update_score(self, score: int, recorded_by_participant_id: ParticipantId) -> None:
-        """Actualiza el score (upsert desde el use case)."""
+    def update_score(self, score: int | None, recorded_by_participant_id: ParticipantId) -> None:
+        """Actualiza el score, o lo deja en raya con None (upsert desde el use case)."""
         self._validate_score(score)
         self._score = score
         self._recorded_by_participant_id = recorded_by_participant_id

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -128,11 +128,23 @@ class StablefordCalculator:
         return max(0, 2 - (net_score - par))
 
     @staticmethod
+    def net_double_bogey(par: int, strokes_received: int) -> int:
+        """
+        Golpes de un hoyo no terminado: `par + 2 + golpes recibidos`.
+
+        Es lo que el WHS (Regla 3.1) manda anotar cuando el jugador recoge la
+        bola, y coincide con el tope de `adjusted_gross`: recoger vale
+        exactamente lo mismo que hacer un desastre topado.
+        """
+        return par + NET_DOUBLE_BOGEY_OVER_PAR + strokes_received
+
+    @staticmethod
     def adjusted_gross(gross_score: int, par: int, strokes_received: int) -> int:
         """
         Golpes del hoyo topados en el net double bogey (Regla WHS 3.1).
 
-        Máximo computable: doble bogey neto, o sea `par + 2 + golpes recibidos`.
+        Máximo computable: doble bogey neto, o sea `par + 2 + golpes recibidos`
+        (`net_double_bogey`).
         Sin ese tope, un hoyo desastroso mueve la media de una temporada entera,
         que es justo lo que la regla existe para evitar.
 
@@ -145,7 +157,7 @@ class StablefordCalculator:
         self,
         handicap: float | None,
         holes: list[HoleSetup],
-        scores_by_hole: dict[int, int],
+        scores_by_hole: dict[int, int | None],
         tee_rating: TeeRating | None = None,
         allowance_percentage: int = 100,
         cap_at_net_double_bogey: bool = False,
@@ -154,7 +166,16 @@ class StablefordCalculator:
         Agrega puntos y golpes de un participante sobre los hoyos anotados.
 
         Los hoyos sin score no cuentan: una partida a medias puntúa por lo
-        jugado, no por lo que falta.
+        jugado, no por lo que falta. Lo que sí cuenta es la RAYA —la clave
+        presente con valor None—, que es un hoyo acabado sin número porque el
+        jugador recogió la bola: se computa como doble bogey neto, que es lo que
+        el WHS (Regla 3.1) manda anotar en un hoyo no terminado. En Stableford
+        eso da exactamente los cero puntos que vale recoger, y en el resultado
+        contra el par deja una cifra defendible en vez de un hoyo regalado.
+
+        De ahí que el hoyo sin anotar se distinga por la AUSENCIA de la clave y
+        no por `get(...) is None`: los dos casos son None y significan cosas
+        contrarias.
 
         `cap_at_net_double_bogey` topa cada hoyo en el máximo que el WHS deja
         computar para hándicap. Va apagado por defecto porque el detalle de la
@@ -176,11 +197,17 @@ class StablefordCalculator:
         adjusted_gross_strokes = 0
 
         for hole in holes:
-            score = scores_by_hole.get(hole.hole_number)
-            if score is None:
+            if hole.hole_number not in scores_by_hole:
                 continue
+            score = scores_by_hole[hole.hole_number]
 
             strokes_received = self.allocate_strokes(strokes_basis, hole.stroke_index)
+            # La raya no trae golpes que sumar, así que se cuenta con los que el
+            # WHS le asigna: doble bogey neto. `hole_points` ya devuelve cero
+            # para None, y un doble bogey neto vale cero, así que las dos vías
+            # dan lo mismo sin tener que tocarla.
+            if score is None:
+                score = self.net_double_bogey(hole.par, strokes_received)
             stableford_points += self.hole_points(score, hole.par, strokes_received)
             total_strokes += score
             adjusted = self.adjusted_gross(score, hole.par, strokes_received)

--- a/src/modules/quick_match/domain/services/stableford_calculator.py
+++ b/src/modules/quick_match/domain/services/stableford_calculator.py
@@ -168,10 +168,11 @@ class StablefordCalculator:
         Los hoyos sin score no cuentan: una partida a medias puntúa por lo
         jugado, no por lo que falta. Lo que sí cuenta es la RAYA —la clave
         presente con valor None—, que es un hoyo acabado sin número porque el
-        jugador recogió la bola: se computa como doble bogey neto, que es lo que
-        el WHS (Regla 3.1) manda anotar en un hoyo no terminado. En Stableford
-        eso da exactamente los cero puntos que vale recoger, y en el resultado
-        contra el par deja una cifra defendible en vez de un hoyo regalado.
+        jugador recogió la bola. Cuenta como doble bogey: `par + 2` de bruto, y
+        doble bogey NETO en lo que puntúa, que es lo que el WHS (Regla 3.1)
+        manda anotar en un hoyo no terminado. En Stableford eso da exactamente
+        los cero puntos que vale recoger, y en el resultado contra el par deja
+        una cifra defendible en vez de un hoyo regalado.
 
         De ahí que el hoyo sin anotar se distinga por la AUSENCIA de la clave y
         no por `get(...) is None`: los dos casos son None y significan cosas
@@ -202,12 +203,30 @@ class StablefordCalculator:
             score = scores_by_hole[hole.hole_number]
 
             strokes_received = self.allocate_strokes(strokes_basis, hole.stroke_index)
-            # La raya no trae golpes que sumar, así que se cuenta con los que el
-            # WHS le asigna: doble bogey neto. `hole_points` ya devuelve cero
-            # para None, y un doble bogey neto vale cero, así que las dos vías
-            # dan lo mismo sin tener que tocarla.
+
             if score is None:
-                score = self.net_double_bogey(hole.par, strokes_received)
+                # La raya no trae golpes, así que el bruto y el neto se llevan
+                # por separado en vez de derivar uno del otro:
+                #
+                # - BRUTO: `par + 2`, el doble bogey que se escribe en la
+                #   tarjeta. No lleva golpes recibidos porque un total de golpes
+                #   no puede depender del reparto —la misma vuelta daba 89 o 90
+                #   según el allowance, y eso es un dato objetivo—.
+                # - NETO: doble bogey NETO, que es lo que el WHS (Regla 3.1)
+                #   manda computar en un hoyo no terminado, y lo que hace que
+                #   valga exactamente cero puntos Stableford.
+                #
+                # Derivar el neto restando los golpes al bruto daría `par + 2 -
+                # golpes`, o sea un punto por hoyo recogido a quien recibe
+                # golpe ahí. Recoger no puntúa.
+                gross = hole.par + NET_DOUBLE_BOGEY_OVER_PAR
+                total_strokes += gross
+                adjusted_gross_strokes += self.net_double_bogey(hole.par, strokes_received)
+                net_strokes += hole.par + NET_DOUBLE_BOGEY_OVER_PAR
+                par_played += hole.par
+                holes_played += 1
+                continue
+
             stableford_points += self.hole_points(score, hole.par, strokes_received)
             total_strokes += score
             adjusted = self.adjusted_gross(score, hole.par, strokes_received)

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -222,9 +222,15 @@ class StartQuickMatchBody(BaseModel):
 
 
 class SubmitHoleScoreBody(BaseModel):
-    """Body para registrar el score propio de un hoyo."""
+    """
+    Body para registrar el score de un hoyo.
 
-    score: int = Field(..., ge=1, le=15)
+    `score: null` es la raya (bola recogida): el hoyo queda anotado sin numero,
+    que no es lo mismo que dejarlo sin anotar. Sigue siendo obligatorio estar
+    presente en el body, para que omitirlo no borre un score ya puesto.
+    """
+
+    score: int | None = Field(..., ge=1, le=15)
 
 
 # ======================================================================================

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -350,7 +350,9 @@ quick_match_hole_scores_table = Table(
     Column("hole_number", Integer, nullable=False),
     # participant_id NO tiene FK a `users`: puede ser un invitado sin cuenta.
     Column("participant_id", ParticipantIdType, nullable=False),
-    Column("score", Integer, nullable=False),
+    # Nulo es la raya: hoyo acabado sin numero porque el jugador recogio. No
+    # tener fila es otra cosa —hoyo sin anotar—, y las dos se distinguen.
+    Column("score", Integer, nullable=True),
     Column("recorded_by_participant_id", ParticipantIdType, nullable=False),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),

--- a/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
+++ b/src/modules/social/application/use_cases/publish_round_achievements_use_case.py
@@ -38,6 +38,11 @@ from src.shared.domain.services.countable_round import countable_holes
 # con más historia que esto ya no estrena nada que importe recordar.
 MAX_HISTORY_LOOKUP = 200
 
+# Golpes sobre el par con los que se anota un hoyo que no se termino (la raya):
+# doble bogey, el mismo criterio que el `NET_DOUBLE_BOGEY_OVER_PAR` del
+# StablefordCalculator, aqui a bruto porque el detector juzga contra el par
+DOUBLE_BOGEY_OVER_PAR = 2
+
 
 @dataclass(frozen=True)
 class _RoundToJudge:
@@ -211,7 +216,19 @@ class PublishRoundAchievementsUseCase:
                             PlayedHole(
                                 number=hole.number,
                                 par=hole.par,
-                                strokes=scores_by_hole[hole.number],
+                                # La raya (score nulo: el jugador recogio) va
+                                # como doble bogey, que es lo que se anota en un
+                                # hoyo no terminado. Aqui se mide a bruto contra
+                                # el par, sin golpes recibidos, porque eso es lo
+                                # que juzga el detector. Ningun logro sale de un
+                                # doble bogey, asi que la raya no inventa nada
+                                # — y el birdie de otro hoyo de la misma vuelta
+                                # se sigue pudiendo presumir.
+                                strokes=(
+                                    scores_by_hole[hole.number]
+                                    if scores_by_hole[hole.number] is not None
+                                    else hole.par + DOUBLE_BOGEY_OVER_PAR
+                                ),
                             )
                             for hole in jugados
                         ],

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -230,6 +230,12 @@ class GetPlayerStatsUseCase:
                 scores = await self._quick_match_uow.quick_match_hole_scores.find_by_match(
                     match.id
                 )
+                # El score nulo (la raya: hoyo recogido) NO se filtra, a
+                # diferencia del camino de competicion de mas abajo: en partida
+                # rapida es un hoyo jugado, y el calculador lo computa como
+                # doble bogey neto, que es lo que el WHS manda anotar en un hoyo
+                # sin terminar. Filtrarlo aqui haria que la vuelta entera dejase
+                # de ser computable por un hoyo que si se jugo.
                 scores_by_hole = {
                     score.hole_number: score.score
                     for score in scores

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -338,10 +338,14 @@ class GetPlayerStatsUseCase:
                 if to_par is None:
                     continue
 
+                # Por `own_submitted`, no por si hay número: la raya (hoyo
+                # recogido) está anotada y sin número, y el calculador la cuenta
+                # como doble bogey. Filtrándola, un solo hoyo recogido dejaba
+                # la vuelta entera fuera de la media y del diferencial.
                 scores_by_hole = {
                     hole_score.hole_number: hole_score.own_score
                     for hole_score in hole_scores
-                    if hole_score.own_score is not None
+                    if hole_score.own_submitted
                 }
                 # El diferencial mide los mismos hoyos que la media, no el campo
                 # entero: en media vuelta, los otros nueve no se jugaron
@@ -519,16 +523,25 @@ class GetPlayerStatsUseCase:
         """
         Neto respecto al par de la tarjeta, o None si no forma una vuelta.
 
-        Un hoyo con `own_score` a None no se rellena ni se ignora: invalida la
-        vuelta. Lo que decide es la tarjeta, no en qué hoyo se ganó el partido:
-        un match play resuelto en el 15 cuenta igual que cualquier otra vuelta
-        si los jugadores siguieron anotando hasta el 18. Lo que deja la ronda
-        fuera es dejar de anotar, no cerrar pronto.
+        Lo que decide es la tarjeta, no en qué hoyo se ganó el partido: un match
+        play resuelto en el 15 cuenta igual que cualquier otra vuelta si los
+        jugadores siguieron anotando hasta el 18. Lo que deja la ronda fuera es
+        dejar de anotar, no cerrar pronto.
+
+        Un hoyo RECOGIDO —anotado (`own_submitted`) y sin número— es un hoyo
+        jugado, no un hueco: cuenta como doble bogey neto, que es lo que el WHS
+        (Regla 3.1) manda anotar en un hoyo no terminado. Antes invalidaba la
+        vuelta entera, y eso dejaba a la misma vuelta contando para la media si
+        se jugaba en partida rápida y fuera si se jugaba en competición.
+
+        De ahí que lo anotado se mire por `own_submitted` y no por si hay
+        número: sin número está la raya y está el hoyo que nadie tocó, y
+        significan lo contrario.
         """
         scored = {
             hole_score.hole_number: hole_score
             for hole_score in hole_scores
-            if hole_score.own_score is not None
+            if hole_score.own_submitted
         }
         played = self._computable_holes(scored, hole_card)
         if played is None:
@@ -537,9 +550,14 @@ class GetPlayerStatsUseCase:
         to_par = 0
         for hole in played:
             hole_score = scored[hole.number]
-            computable = self._calculator.adjusted_gross(
-                hole_score.own_score, hole.par, hole_score.strokes_received
-            )
+            if hole_score.own_score is None:
+                computable = self._calculator.net_double_bogey(
+                    hole.par, hole_score.strokes_received
+                )
+            else:
+                computable = self._calculator.adjusted_gross(
+                    hole_score.own_score, hole.par, hole_score.strokes_received
+                )
             to_par += computable - hole_score.strokes_received - hole.par
 
         return self._to_eighteen(to_par, len(played))

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -480,6 +480,12 @@ class GetRecentMatchesUseCase:
                 continue
 
             def net(pid, hole=hole_number, values=scores):
+                # La raya (score nulo) se propaga: `calculate_hole_winner` la lee
+                # como bando que no entrego bola y le da el hoyo al rival, que es
+                # la regla de match play. Convertirla en un numero aqui la haria
+                # competir por el hoyo.
+                if values[pid] is None:
+                    return None
                 allocation = strokes_by_participant.get(pid)
                 if allocation is None:
                     return values[pid]
@@ -544,6 +550,11 @@ class GetRecentMatchesUseCase:
         total_strokes = 0
         holes_played = 0
         for hole_number in range(1, TOTAL_HOLES + 1):
+            # El None deja fuera tanto el hoyo sin anotar como la raya, y aqui
+            # las dos cosas valen lo mismo: un hoyo recogido no tiene golpes que
+            # sumar al total del bando. El resultado del partido no depende de
+            # esto —lo decide `calculate_hole_winner`, que si ve la raya—, solo
+            # los golpes que se ensenan al lado.
             scores = [
                 score
                 for participant_id in side_in_order

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -27,6 +27,7 @@ from src.modules.quick_match.domain.services.hole_completion_service import (
     hole_is_complete,
 )
 from src.modules.quick_match.domain.services.stableford_calculator import (
+    NET_DOUBLE_BOGEY_OVER_PAR,
     HoleSetup,
     StablefordCalculator,
 )
@@ -302,7 +303,7 @@ class GetRecentMatchesUseCase:
         # Leyendo solo lo anotado a nombre de cada uno, el que llevaba la fila
         # salía con una vuelta entera de 72 golpes y su compañero sin nada.
         side_strokes = (
-            self._foursomes_side_strokes(raw)
+            self._foursomes_side_strokes(raw, course)
             if raw.match.match_format == MatchFormat.FOURSOMES
             else None
         )
@@ -524,7 +525,9 @@ class GetRecentMatchesUseCase:
             standing["status"],
         )
 
-    def _foursomes_side_strokes(self, raw: _QuickMatchRaw) -> tuple[int, int] | None:
+    def _foursomes_side_strokes(
+        self, raw: _QuickMatchRaw, course: GolfCourse | None
+    ) -> tuple[int, int] | None:
         """
         Golpes brutos y hoyos del BANDO en foursomes: una bola por hoyo.
 
@@ -534,6 +537,12 @@ class GetRecentMatchesUseCase:
         hoyo: contar aquí una y adjudicar con la otra dejaría la partida con
         unos golpes que no explican su resultado. Lo que nunca se hace es
         sumarlas, porque comparten bola y eso doblaría la vuelta.
+
+        Un hoyo RECOGIDO cuenta: está jugado, y lo decide el resultado del
+        partido igual que cualquier otro. Vale doble bogey BRUTO —`par + 2`, sin
+        golpes recibidos—, porque esta cifra es bruta y meterle un hoyo neto
+        dentro mezclaría dos escalas en el mismo número. Dejarlo fuera daba un
+        total de menos hoyos de los que el partido dice que se jugaron.
 
         Devuelve None si no hay bandos resolubles o el bando no anotó nada.
         """
@@ -546,32 +555,66 @@ class GetRecentMatchesUseCase:
         side_in_order = [
             p.participant_id for p in raw.match.participants if p.participant_id in my_side
         ]
+        par_by_hole = self._side_pars(raw, course, side_in_order)
 
         total_strokes = 0
         holes_played = 0
         for hole_number in range(1, TOTAL_HOLES + 1):
-            # El None deja fuera tanto el hoyo sin anotar como la raya, y aqui
-            # las dos cosas valen lo mismo: un hoyo recogido no tiene golpes que
-            # sumar al total del bando. El resultado del partido no depende de
-            # esto —lo decide `calculate_hole_winner`, que si ve la raya—, solo
-            # los golpes que se ensenan al lado.
-            scores = [
-                score
+            # La CLAVE, no el valor: la raya está presente con valor None y es un
+            # hoyo jugado, mientras que un hoyo sin anotar no tiene entrada.
+            anotaciones = [
+                raw.scores_by_participant[participant_id][hole_number]
                 for participant_id in side_in_order
-                if (score := raw.scores_by_participant.get(participant_id, {}).get(hole_number))
-                is not None
+                if hole_number in raw.scores_by_participant.get(participant_id, {})
             ]
-            if not scores:
+            if not anotaciones:
                 continue
-            # El menor, que es lo que hace `ScoringService._best_ball` al decidir
-            # el hoyo. Normalmente solo hay uno —la bola se guarda a nombre del
-            # primero del bando—, pero si llegan dos que no coinciden, contar
-            # aquí uno y adjudicar el hoyo con el otro dejaría la misma partida
-            # con unos golpes que no explican su resultado.
-            total_strokes += min(scores)
+
+            # El menor de los números, que es lo que hace `ScoringService._best_ball`
+            # al decidir el hoyo. Normalmente solo hay uno —la bola se guarda a
+            # nombre del primero del bando—, pero si llegan dos que no coinciden,
+            # contar aquí uno y adjudicar el hoyo con el otro dejaría la misma
+            # partida con unos golpes que no explican su resultado.
+            numeros = [score for score in anotaciones if score is not None]
+            if numeros:
+                total_strokes += min(numeros)
+                holes_played += 1
+                continue
+
+            # Solo rayas: el bando recogió. Sin el par del hoyo no hay con qué
+            # contarlo, y antes que inventar un número se deja fuera.
+            par = par_by_hole.get(hole_number)
+            if par is None:
+                continue
+            total_strokes += par + NET_DOUBLE_BOGEY_OVER_PAR
             holes_played += 1
 
         return (total_strokes, holes_played) if holes_played else None
+
+    @staticmethod
+    def _side_pars(
+        raw: _QuickMatchRaw, course: GolfCourse | None, side_in_order: list
+    ) -> dict[int, int]:
+        """
+        El par de cada hoyo para la barra del bando, o vacío si no se sabe.
+
+        La barra es la del primer jugador del bando, que es a cuyo nombre se
+        guarda la bola: el par sale de SU tarjeta, no del campo, porque en 25 de
+        los 800 campos federados cambia entre barras.
+        """
+        if course is None or not side_in_order:
+            return {}
+
+        titular = next(
+            (p for p in raw.match.participants if p.participant_id == side_in_order[0]), None
+        )
+        if titular is None:
+            return {}
+
+        return {
+            hole.number: hole.par
+            for hole in course.hole_card_for(titular.tee_color, titular.tee_gender)
+        }
 
     def _participant_totals(
         self,

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -433,6 +433,79 @@ class TestQuickMatchFreePlayFlow:
         assert len(detail["hole_scores"]) == 1
 
 
+class TestQuickMatchPickedUpHole:
+    """
+    La raya de punta a punta: el frontend manda `score: null` y el endpoint la
+    acepta en Stableford y la rechaza en Medal.
+
+    Nace de un defecto de produccion: la columna era NOT NULL y el body exigia
+    un entero, asi que el boton "Raya" —el mismo que ya funcionaba en
+    competicion— devolvia un 422 que la pantalla ensenaba como "Ese resultado
+    no es valido".
+    """
+
+    async def _start_free_play(self, client: AsyncClient, prefix: str, scoring_format: str):
+        admin = await create_admin_user(
+            client, f"qm_admin_{prefix}@test.com", "P@ssw0rd123!", "Admin", "Raya"
+        )
+        creator = await create_authenticated_user(
+            client, f"qm_creator_{prefix}@test.com", "P@ssw0rd123!", "Creator", "Raya"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "scoring_format": scoring_format},
+        )
+        assert create_response.status_code == 201, create_response.text
+        quick_match_id = create_response.json()["id"]
+        creator_participant_id = create_response.json()["participants"][0]["participant_id"]
+
+        start_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator_participant_id]},
+        )
+        assert start_response.status_code == 200, start_response.text
+        return quick_match_id
+
+    @pytest.mark.asyncio
+    async def test_stableford_accepts_a_null_score(self, client: AsyncClient):
+        quick_match_id = await self._start_free_play(client, "raya_ok", "STABLEFORD")
+
+        score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={"score": None}
+        )
+
+        assert score_response.status_code == 200, score_response.text
+        assert score_response.json()["score"] is None
+
+        detail = (await client.get(f"/api/v1/quick-matches/{quick_match_id}")).json()
+        assert len(detail["hole_scores"]) == 1
+        assert detail["hole_scores"][0]["score"] is None
+
+    @pytest.mark.asyncio
+    async def test_medal_rejects_a_null_score(self, client: AsyncClient):
+        quick_match_id = await self._start_free_play(client, "raya_medal", "MEDAL")
+
+        score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={"score": None}
+        )
+
+        assert score_response.status_code == 400, score_response.text
+
+    @pytest.mark.asyncio
+    async def test_the_score_field_is_still_required(self, client: AsyncClient):
+        """Mandar la raya es explicito; omitir el campo sigue siendo un error."""
+        quick_match_id = await self._start_free_play(client, "raya_missing", "STABLEFORD")
+
+        score_response = await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/holes/1/score", json={}
+        )
+
+        assert score_response.status_code == 422, score_response.text
+
+
 class TestQuickMatchFullFlow:
     """Flujo completo: crear, añadir amigo, iniciar, registrar scores, ver detalle."""
 

--- a/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_get_quick_match_use_case.py
@@ -137,6 +137,90 @@ class TestGetQuickMatchUseCase:
         assert detail.standing.leading_team == "A"
         assert detail.standing.status == "1UP"
 
+    async def test_a_raya_loses_the_hole_in_match_play(self, qm_uow, user_uow, golf_course_uow):
+        """
+        Given un hoyo en el que un jugador recoge la bola y el rival la entrega
+        When se calcula el standing
+        Then el hoyo es del rival
+
+        Es la regla de match play: quien no acaba el hoyo lo pierde. La raya se
+        propaga como None hasta `calculate_hole_winner`, que ya sabe leer un
+        bando sin bola porque competicion lo necesitaba.
+        """
+        creator = await create_user(user_uow, "raya-standing@test.com")
+        other = await create_user(user_uow, "raya-standing2@test.com")
+        qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
+
+        submit_uc = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        await submit_uc.execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=creator.id.value,
+                hole_number=1,
+                score=None,
+            )
+        )
+        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
+        await proxy_uc.execute(
+            SubmitProxyHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=other.id.value,
+                hole_number=1,
+                score=7,
+            )
+        )
+
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
+        detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.hole_scores[0].score is None
+        assert detail.standing is not None
+        assert detail.standing.holes_played == 1
+        assert detail.standing.leading_team == "B"
+        assert detail.standing.status == "1UP"
+
+    async def test_two_rayas_halve_the_hole(self, qm_uow, user_uow, golf_course_uow):
+        """
+        Given un hoyo que recogen los dos
+        When se calcula el standing
+        Then el hoyo queda empatado, no sin jugar
+        """
+        creator = await create_user(user_uow, "raya-halved@test.com")
+        other = await create_user(user_uow, "raya-halved2@test.com")
+        qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
+
+        submit_uc = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        await submit_uc.execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=creator.id.value,
+                hole_number=1,
+                score=None,
+            )
+        )
+        proxy_uc = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
+        await proxy_uc.execute(
+            SubmitProxyHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=other.id.value,
+                hole_number=1,
+                score=None,
+            )
+        )
+
+        get_uc = GetQuickMatchUseCase(
+            qm_uow, user_uow, ScoringService(), ScoringCoverageService(), golf_course_uow
+        )
+        detail = await get_uc.execute(str(qm.id.value), str(creator.id.value))
+
+        assert detail.standing is not None
+        assert detail.standing.holes_played == 1
+        assert detail.standing.leading_team is None
+
     async def test_registered_participant_handicap_comes_from_user_profile(self, qm_uow, user_uow, golf_course_uow):
         creator = await create_user(user_uow, "creator-hcp@test.com", handicap=12.4)
         other = await create_user(user_uow, "other-hcp@test.com", handicap=None)

--- a/tests/unit/modules/quick_match/application/use_cases/test_submit_hole_score_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_submit_hole_score_use_case.py
@@ -17,12 +17,14 @@ from src.modules.quick_match.application.use_cases.submit_hole_score_use_case im
 )
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidHoleScoreViolation,
     InvalidQuickMatchStatusViolation,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
 )
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
 from src.modules.user.domain.value_objects.user_id import UserId
 from tests.unit.modules.quick_match.conftest import create_user
 
@@ -151,3 +153,116 @@ class TestSubmitQuickMatchHoleScoreUseCase:
                     score=4,
                 )
             )
+
+
+class TestSubmitQuickMatchHoleScorePickedUp:
+    """La raya: hoyo anotado sin numero porque el jugador recogio la bola."""
+
+    async def test_submit_raya_succeeds(self, qm_uow, user_uow):
+        """
+        Given un jugador que recoge la bola en un hoyo
+        When lo anota con score nulo
+        Then queda registrado como raya, no rechazado
+
+        Es el defecto que trajo esto: el frontend mandaba `score: null` y el
+        endpoint lo tumbaba con un 422, que la pantalla traducia a "Ese
+        resultado no es valido".
+        """
+        creator = await create_user(user_uow, "raya-creator@test.com")
+        other = await create_user(user_uow, "raya-other@test.com")
+        qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
+
+        use_case = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        response = await use_case.execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=creator.id.value,
+                hole_number=1,
+                score=None,
+            )
+        )
+
+        assert response.score is None
+        assert response.recorded_by_participant_id == creator.id.value
+
+    async def test_a_scored_hole_can_be_corrected_to_a_raya(self, qm_uow, user_uow):
+        """
+        Given un hoyo ya anotado con golpes
+        When se rectifica a raya
+        Then el score guardado queda nulo, sin crear una fila nueva
+        """
+        creator = await create_user(user_uow, "raya-fix@test.com")
+        other = await create_user(user_uow, "raya-fix2@test.com")
+        qm = await _create_in_progress_match(qm_uow, creator.id, other.id)
+
+        use_case = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        dto = SubmitHoleScoreRequestDTO(
+            quick_match_id=qm.id.value,
+            player_user_id=creator.id.value,
+            hole_number=1,
+            score=6,
+        )
+        await use_case.execute(dto)
+        response = await use_case.execute(dto.model_copy(update={"score": None}))
+
+        assert response.score is None
+        async with qm_uow:
+            stored = await qm_uow.quick_match_hole_scores.find_by_match(qm.id)
+        assert len(stored) == 1
+        assert stored[0].score is None
+
+
+class TestMedalRejectsPickedUpHoles:
+    """En Medal se emboca en todos los hoyos: la raya no es anotable."""
+
+    async def _create_medal_match(self, qm_uow, creator_id, other_id):
+        qm = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=creator_id,
+            golf_course_id=GolfCourseId(uuid4()),
+            scoring_format=ScoringFormat.MEDAL,
+        )
+        qm.add_participant(QuickMatchParticipant.for_user(other_id))
+        qm.start([qm.creator_participant_id])
+        async with qm_uow:
+            await qm_uow.quick_matches.add(qm)
+        return qm
+
+    async def test_a_raya_is_rejected_in_medal(self, qm_uow, user_uow):
+        """
+        Given una partida libre en Medal
+        When alguien intenta anotar un hoyo con score nulo
+        Then se rechaza, porque en stroke play no vale recoger
+        """
+        creator = await create_user(user_uow, "medal-raya@test.com")
+        other = await create_user(user_uow, "medal-raya2@test.com")
+        qm = await self._create_medal_match(qm_uow, creator.id, other.id)
+
+        use_case = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        with pytest.raises(InvalidHoleScoreViolation):
+            await use_case.execute(
+                SubmitHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    player_user_id=creator.id.value,
+                    hole_number=1,
+                    score=None,
+                )
+            )
+
+    async def test_a_number_is_still_accepted_in_medal(self, qm_uow, user_uow):
+        """El rechazo es de la raya, no de anotar en Medal."""
+        creator = await create_user(user_uow, "medal-ok@test.com")
+        other = await create_user(user_uow, "medal-ok2@test.com")
+        qm = await self._create_medal_match(qm_uow, creator.id, other.id)
+
+        use_case = SubmitQuickMatchHoleScoreUseCase(qm_uow)
+        response = await use_case.execute(
+            SubmitHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                player_user_id=creator.id.value,
+                hole_number=1,
+                score=5,
+            )
+        )
+
+        assert response.score == 5

--- a/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_submit_proxy_hole_score_use_case.py
@@ -18,6 +18,7 @@ from src.modules.quick_match.application.use_cases.submit_proxy_hole_score_use_c
 )
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
 from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidHoleScoreViolation,
     NotAssignedScorerViolation,
 )
 from src.modules.quick_match.domain.services.scoring_coverage_service import (
@@ -27,6 +28,7 @@ from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMat
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
 )
+from src.modules.quick_match.domain.value_objects.scoring_format import ScoringFormat
 from tests.unit.modules.quick_match.conftest import create_user
 
 pytestmark = pytest.mark.asyncio
@@ -143,5 +145,69 @@ class TestSubmitProxyHoleScoreUseCase:
                     target_participant_id=not_assigned_to_other.participant_id.value,
                     hole_number=1,
                     score=5,
+                )
+            )
+
+
+class TestSubmitProxyHoleScorePickedUp:
+    async def test_scorer_can_record_a_raya_for_someone_else(self, qm_uow, user_uow):
+        """
+        Given un invitado que recoge la bola
+        When su anotador lo registra con score nulo
+        Then queda anotado como raya
+
+        Quien recoge la bola suele ser justo el invitado al que anota otro, asi
+        que el camino delegado importa tanto como el propio.
+        """
+        creator = await create_user(user_uow, "raya-proxy@test.com")
+        qm, guest = await _create_in_progress_match_with_guest(qm_uow, creator.id)
+
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
+        response = await use_case.execute(
+            SubmitProxyHoleScoreRequestDTO(
+                quick_match_id=qm.id.value,
+                scorer_user_id=creator.id.value,
+                target_participant_id=guest.participant_id.value,
+                hole_number=1,
+                score=None,
+            )
+        )
+
+        assert response.score is None
+        assert response.participant_id == guest.participant_id.value
+
+
+class TestMedalRejectsPickedUpHolesByProxy:
+    async def test_a_raya_by_proxy_is_rejected_in_medal(self, qm_uow, user_uow):
+        """
+        Given una partida libre en Medal con un invitado
+        When su anotador intenta ponerle raya
+        Then se rechaza igual que si se la pusiera a si mismo
+
+        La regla es de la partida, no de quien anota: dejarla solo en el camino
+        propio la dejaria abierta justo por donde mas se usa.
+        """
+        creator = await create_user(user_uow, "medal-proxy-raya@test.com")
+        qm = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=creator.id,
+            golf_course_id=GolfCourseId(uuid4()),
+            scoring_format=ScoringFormat.MEDAL,
+        )
+        guest = QuickMatchParticipant.for_guest(first_name="Guest", last_name="Medal")
+        qm.add_participant(guest)
+        qm.start([qm.creator_participant_id])
+        async with qm_uow:
+            await qm_uow.quick_matches.add(qm)
+
+        use_case = SubmitProxyHoleScoreUseCase(qm_uow, ScoringCoverageService())
+        with pytest.raises(InvalidHoleScoreViolation):
+            await use_case.execute(
+                SubmitProxyHoleScoreRequestDTO(
+                    quick_match_id=qm.id.value,
+                    scorer_user_id=creator.id.value,
+                    target_participant_id=guest.participant_id.value,
+                    hole_number=1,
+                    score=None,
                 )
             )

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -659,3 +659,42 @@ class TestQuickMatchAllowance:
     def test_rejects_allowance_out_of_range(self):
         with pytest.raises(InvalidAllowanceViolation):
             _make_quick_match(allowance_percentage=45)
+
+
+class TestAllowsPickedUpHoles:
+    """
+    Donde vale la raya y donde no.
+
+    En Medal no se puede recoger: el stroke play exige embocar en todos los
+    hoyos y quien no lo hace no entrega tarjeta. En Stableford y en match play
+    si, que es donde recoger forma parte del juego.
+    """
+
+    def _free_play(self, scoring_format):
+        return QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=UserId.generate(),
+            golf_course_id=GolfCourseId(uuid4()),
+            scoring_format=scoring_format,
+        )
+
+    def test_medal_does_not_allow_a_raya(self):
+        assert self._free_play(ScoringFormat.MEDAL).allows_picked_up_holes() is False
+
+    def test_stableford_allows_a_raya(self):
+        assert self._free_play(ScoringFormat.STABLEFORD).allows_picked_up_holes() is True
+
+    @pytest.mark.parametrize(
+        "match_format",
+        [MatchFormat.SINGLES, MatchFormat.FOURBALL, MatchFormat.FOURSOMES],
+    )
+    def test_match_play_allows_a_raya(self, match_format):
+        """Recoger en match play es conceder el hoyo, que es jugada legitima."""
+        qm = QuickMatch.create(
+            id=QuickMatchId.generate(),
+            creator_id=UserId.generate(),
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=match_format,
+        )
+
+        assert qm.allows_picked_up_holes() is True

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match_hole_score.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match_hole_score.py
@@ -60,3 +60,50 @@ class TestQuickMatchHoleScoreUpdate:
         hs = _make_hole_score()
         with pytest.raises(InvalidHoleScoreViolation):
             hs.update_score(20, recorded_by_participant_id=ParticipantId.generate())
+
+
+class TestQuickMatchHoleScorePickedUp:
+    """
+    La raya: hoyo acabado sin numero porque el jugador recogio la bola.
+
+    Se guarda como `score=None`, que NO es lo mismo que no tener fila: sin fila
+    el hoyo esta por jugar, y con fila y raya esta jugado. De esa diferencia
+    dependen la clasificacion en vivo y poder dar la partida por terminada.
+    """
+
+    def test_create_accepts_a_picked_up_hole(self):
+        """
+        Given un hoyo que el jugador no termino
+        When se anota con score None
+        Then la entidad lo acepta como raya, no como score fuera de rango
+        """
+        hs = _make_hole_score(score=None)
+
+        assert hs.score is None
+        assert hs.hole_number == 1
+
+    def test_update_score_can_turn_a_number_into_a_raya(self):
+        """
+        Given un hoyo ya anotado con golpes
+        When el anotador rectifica y pone raya
+        Then el score queda en None y consta quien lo rectifico
+        """
+        hs = _make_hole_score(score=6)
+        corrector = ParticipantId.generate()
+
+        hs.update_score(None, recorded_by_participant_id=corrector)
+
+        assert hs.score is None
+        assert hs.recorded_by_participant_id == corrector
+
+    def test_update_score_can_turn_a_raya_back_into_a_number(self):
+        """
+        Given un hoyo anotado con raya por error
+        When se corrige con los golpes reales
+        Then vuelve a tener numero
+        """
+        hs = _make_hole_score(score=None)
+
+        hs.update_score(5, recorded_by_participant_id=ParticipantId.generate())
+
+        assert hs.score == 5

--- a/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
@@ -340,3 +340,149 @@ class TestParityWithTheFrontend:
         assert totals.total_strokes == gross
         assert totals.net_strokes == net
         assert totals.to_par == to_par
+
+    @pytest.mark.parametrize(
+        ("handicap", "points", "gross", "net", "to_par"),
+        [
+            # El hoyo 1 es par 4 y su score real era 5. Con raya pasa a valer su
+            # doble bogey neto: 6 a scratch (un golpe mas que lo jugado, y un
+            # punto menos), y 7 con 12.4, que recibe un golpe ahi.
+            (0, 19, 89, 89, 17),
+            (12.4, 30, 90, 78, 6),
+        ],
+    )
+    def test_a_picked_up_hole_matches_the_frontend_too(
+        self, handicap, points, gross, net, to_par
+    ):
+        """
+        La raya es la parte mas facil de que los dos motores se separen: no hay
+        numero anotado del que tirar, asi que cada lado tiene que inventar el
+        mismo. Los valores salen de la misma vuelta de arriba con el hoyo 1
+        recogido.
+        """
+        calculator = StablefordCalculator()
+        scores: dict[int, int | None] = dict(self.SCORES)
+        scores[1] = None
+
+        totals = calculator.compute_participant_totals(
+            handicap=handicap, holes=self._holes(), scores_by_hole=scores
+        )
+
+        assert totals.stableford_points == points
+        assert totals.total_strokes == gross
+        assert totals.net_strokes == net
+        assert totals.to_par == to_par
+
+
+class TestPickedUpHole:
+    """
+    La raya: el jugador recogio la bola y el hoyo se acabo sin numero.
+
+    Se computa como doble bogey neto (Regla WHS 3.1), que es lo que manda
+    anotar un hoyo no terminado. La distincion que sostiene todo esto es entre
+    la clave AUSENTE —hoyo por jugar, no cuenta— y la clave presente con valor
+    None —hoyo jugado y recogido, cuenta y vale cero puntos—.
+    """
+
+    def test_a_raya_counts_as_a_played_hole(self):
+        """
+        Given un hoyo anotado con raya
+        When se agregan los totales
+        Then el hoyo cuenta como jugado, con su par
+        """
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: 4, 2: None}
+        )
+
+        assert totals.holes_played == 2
+        assert totals.par_played == 8
+
+    def test_a_raya_is_worth_no_points(self):
+        """
+        Given un hoyo recogido
+        When se cuentan los puntos
+        Then aporta cero, que es lo que vale recoger en Stableford
+        """
+        calculator = StablefordCalculator()
+
+        con_raya = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: 4, 2: None}
+        )
+        solo_el_bueno = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: 4}
+        )
+
+        assert con_raya.stableford_points == solo_el_bueno.stableford_points
+
+    def test_a_raya_is_charged_as_net_double_bogey(self):
+        """
+        Given un par 4 recogido sin recibir golpes
+        When se suman los golpes
+        Then cuenta 6, el doble bogey neto, y no cero
+        """
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: None}
+        )
+
+        assert totals.total_strokes == 6
+        assert totals.net_strokes == 6
+
+    def test_the_charge_grows_with_the_strokes_received(self):
+        """
+        Given un jugador que recibe un golpe en ese hoyo
+        When recoge la bola
+        Then el hoyo le cuesta un golpe mas de bruto, y sigue valiendo cero neto
+
+        Es la misma cuenta que `adjusted_gross`: recoger vale exactamente lo
+        mismo que hacer un desastre topado.
+        """
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=18, holes=_course(), scores_by_hole={1: None}
+        )
+
+        assert totals.total_strokes == 7
+        assert totals.net_strokes == 6
+        assert totals.stableford_points == 0
+
+    def test_a_missing_hole_still_does_not_count(self):
+        """
+        Given una tarjeta a la que le falta el hoyo 2
+        When se agregan los totales
+        Then ese hoyo no cuenta, a diferencia de uno con raya
+
+        Es la trampa del cambio: `scores_by_hole.get(2)` devuelve None en los
+        dos casos y significan lo contrario.
+        """
+        calculator = StablefordCalculator()
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: 4}
+        )
+
+        assert totals.holes_played == 1
+        assert totals.par_played == 4
+
+    def test_a_raya_feeds_the_adjusted_gross_score(self):
+        """
+        Given una vuelta con un hoyo recogido
+        When se calcula el Adjusted Gross Score del WHS
+        Then el hoyo entra topado en su doble bogey neto
+
+        Sin esto la vuelta con raya daria un diferencial mejor de lo jugado,
+        que es justo lo que la Regla 3.1 evita.
+        """
+        calculator = StablefordCalculator()
+        scores: dict[int, int | None] = dict.fromkeys(range(1, 19), 4)
+        scores[1] = None
+
+        totals = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole=scores, cap_at_net_double_bogey=True
+        )
+
+        assert totals.adjusted_gross_strokes == 4 * 17 + 6

--- a/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
+++ b/tests/unit/modules/quick_match/domain/services/test_stableford_calculator.py
@@ -344,11 +344,12 @@ class TestParityWithTheFrontend:
     @pytest.mark.parametrize(
         ("handicap", "points", "gross", "net", "to_par"),
         [
-            # El hoyo 1 es par 4 y su score real era 5. Con raya pasa a valer su
-            # doble bogey neto: 6 a scratch (un golpe mas que lo jugado, y un
-            # punto menos), y 7 con 12.4, que recibe un golpe ahi.
+            # El hoyo 1 es par 4 y su score real era 5. Con raya pasa a valer un
+            # doble bogey: 6 de BRUTO en los dos casos —el bruto no depende del
+            # reparto— y doble bogey NETO en lo que puntua, que es lo que le
+            # quita el punto que el 5 daba.
             (0, 19, 89, 89, 17),
-            (12.4, 30, 90, 78, 6),
+            (12.4, 30, 89, 78, 6),
         ],
     )
     def test_a_picked_up_hole_matches_the_frontend_too(
@@ -431,24 +432,29 @@ class TestPickedUpHole:
         assert totals.total_strokes == 6
         assert totals.net_strokes == 6
 
-    def test_the_charge_grows_with_the_strokes_received(self):
+    def test_the_gross_charge_does_not_depend_on_the_strokes_received(self):
         """
-        Given un jugador que recibe un golpe en ese hoyo
-        When recoge la bola
-        Then el hoyo le cuesta un golpe mas de bruto, y sigue valiendo cero neto
+        Given la misma raya con y sin golpes recibidos
+        When se miran los golpes brutos
+        Then valen lo mismo: el bruto es un dato objetivo
 
-        Es la misma cuenta que `adjusted_gross`: recoger vale exactamente lo
-        mismo que hacer un desastre topado.
+        El neto si baja con los golpes —de ahi que siga siendo doble bogey neto
+        y cero puntos—, pero el total de golpes no puede moverse con el
+        allowance: la misma vuelta llegaba a dar 89 o 90 segun con que reparto
+        se mirara.
         """
         calculator = StablefordCalculator()
 
-        totals = calculator.compute_participant_totals(
+        scratch = calculator.compute_participant_totals(
+            handicap=0, holes=_course(), scores_by_hole={1: None}
+        )
+        con_golpe = calculator.compute_participant_totals(
             handicap=18, holes=_course(), scores_by_hole={1: None}
         )
 
-        assert totals.total_strokes == 7
-        assert totals.net_strokes == 6
-        assert totals.stableford_points == 0
+        assert scratch.total_strokes == con_golpe.total_strokes == 6
+        assert scratch.net_strokes == con_golpe.net_strokes == 6
+        assert con_golpe.stableford_points == 0
 
     def test_a_missing_hole_still_does_not_count(self):
         """

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -212,6 +212,7 @@ async def _played_competition_match(
     strokes_received_per_hole: int = 0,
     holes_played: int = 18,
     unscored_holes: list[int] | None = None,
+    picked_up_holes: list[int] | None = None,
     decided_early: bool = False,
     round_date: date = date(2026, 6, 1),
     match_format: MatchFormat = MatchFormat.SINGLES,
@@ -222,6 +223,8 @@ async def _played_competition_match(
     `strokes_per_hole=None` deja la tarjeta entera sin anotar; `holes_played`
     la corta antes del 18 (partido cerrado antes de tiempo) y `unscored_holes`
     deja huecos sueltos, que es como queda un hoyo concedido en match play.
+    `picked_up_holes` los deja ANOTADOS y sin número, que es la raya: el
+    jugador recogió la bola, y eso es un hoyo jugado, no un hueco.
     """
     competition = Competition.create(
         id=CompetitionId(uuid4()),
@@ -274,7 +277,9 @@ async def _played_competition_match(
                 team="A",
                 strokes_received=strokes_received_per_hole,
             )
-            if strokes_per_hole is not None and hole_number not in (unscored_holes or []):
+            if hole_number in (picked_up_holes or []):
+                hole_score.set_own_score(None)
+            elif strokes_per_hole is not None and hole_number not in (unscored_holes or []):
                 hole_score.set_own_score(strokes_per_hole)
             await competition_uow.hole_scores.add(hole_score)
         await competition_uow.commit()
@@ -736,6 +741,64 @@ class TestCompetitionScorecards:
 
         assert stats.rounds_played == 0
         assert stats.scoring_avg is None
+
+    async def test_a_picked_up_hole_does_not_invalidate_the_card(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Given una vuelta de competicion con un hoyo recogido
+        When se calculan las estadisticas
+        Then la vuelta computa, con ese hoyo a doble bogey neto
+
+        Es la diferencia con el hoyo SIN anotar de arriba: recoger es acabar el
+        hoyo sin numero, y el WHS (Regla 3.1) manda anotarlo como doble bogey
+        neto. Antes se filtraba por si habia numero, asi que la raya invalidaba
+        la vuelta entera — y la misma vuelta contaba para la media si se jugaba
+        en partida rapida y no si se jugaba en competicion.
+        """
+        player = await create_user(user_uow, unique_email("pickedup"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await _played_competition_match(
+            competition_uow, course, player, rival, strokes_per_hole=5, picked_up_holes=[7]
+        )
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        # Campo de par 4: 17 bogeys (+1 cada uno) y el hoyo recogido a doble
+        # bogey neto (+2)
+        assert stats.rounds_played == 1
+        assert stats.scoring_avg == 19
+
+    async def test_a_picked_up_hole_counts_the_same_as_a_double_bogey(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Given la misma vuelta con el hoyo 7 recogido o firmado con un 6
+        When se comparan las medias
+        Then salen iguales: recoger vale lo que un doble bogey, ni mas ni menos
+        """
+        recoge = await create_user(user_uow, unique_email("dash"), handicap=0)
+        firma = await create_user(user_uow, unique_email("six"), handicap=0)
+        rival = await create_user(user_uow, unique_email("rival"), handicap=0)
+        course = await create_golf_course(golf_course_uow, recoge.id)
+        await _played_competition_match(
+            competition_uow, course, recoge, rival, strokes_per_hole=5, picked_up_holes=[7]
+        )
+        await _played_competition_match(
+            competition_uow, course, firma, rival, strokes_per_hole=5
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+        con_raya = await use_case.execute(recoge.id)
+        sin_raya = await use_case.execute(firma.id)
+
+        # La vuelta sin raya son 18 bogeys (+18); la de la raya cambia ese hoyo
+        # por un doble bogey (+2 en vez de +1)
+        assert sin_raya.scoring_avg == 18
+        assert con_raya.scoring_avg == sin_raya.scoring_avg + 1
 
     async def test_a_match_without_a_single_hole_scored_does_not_count(
         self, user_uow, competition_uow, qm_uow, golf_course_uow

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -540,6 +540,84 @@ class TestTeamQuickMatch:
         assert holder.stableford_points is None
         assert mate.stableford_points is None
 
+    async def test_a_picked_up_hole_counts_in_the_side_strokes(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Given un foursomes en el que el bando recogio la bola en todos los hoyos
+        When se lee el historial
+        Then el bando suma su doble bogey bruto por hoyo, y los 18 cuentan
+
+        Un hoyo recogido esta JUGADO —el resultado del partido lo cuenta como
+        cualquier otro—, asi que dejarlo fuera del total daba unos golpes de
+        menos hoyos de los que el propio partido dice que se jugaron. El campo
+        de pruebas es todo par 4, asi que cada raya vale 6.
+        """
+        creator = await create_user(user_uow, "Picked", handicap=0)
+        partner = await create_user(user_uow, "Up", handicap=0)
+        rival_one = await create_user(user_uow, "Foe", handicap=0)
+        rival_two = await create_user(user_uow, "Mate", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            scoring_participant_indexes={0, 2},
+            strokes_by_participant_index={0: None, 2: 5},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        holder = (await use_case.execute(creator.id)).matches[0]
+        mate = (await use_case.execute(partner.id)).matches[0]
+
+        assert holder.total_strokes == mate.total_strokes == 18 * 6
+        assert holder.holes_played == mate.holes_played == 18
+
+    async def test_a_number_beats_a_picked_up_hole_in_the_side_strokes(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Given un hoyo del bando con raya en una fila y golpes en la otra
+        When se suman los golpes del bando
+        Then manda el numero
+
+        Es con el numero con el que `_best_ball` adjudica el hoyo, asi que
+        contar aqui la raya dejaria unos golpes que no explican el resultado.
+        """
+        creator = await create_user(user_uow, "Dash", handicap=0)
+        partner = await create_user(user_uow, "Number", handicap=0)
+        rival_one = await create_user(user_uow, "Rival", handicap=0)
+        rival_two = await create_user(user_uow, "Other", handicap=0)
+        course = await create_golf_course(golf_course_uow, creator.id)
+        await played_quick_match(
+            qm_uow,
+            course,
+            creator,
+            scoring_format=None,
+            match_format=MatchFormat.FOURSOMES,
+            others=[
+                QuickMatchParticipant.for_user(partner.id, team="A"),
+                QuickMatchParticipant.for_user(rival_one.id, team="B"),
+                QuickMatchParticipant.for_user(rival_two.id, team="B"),
+            ],
+            scoring_participant_indexes={0, 1, 2},
+            strokes_by_participant_index={0: None, 1: 4, 2: 6},
+        )
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        holder = (await use_case.execute(creator.id)).matches[0]
+
+        assert holder.total_strokes == 18 * 4
+
     async def test_the_side_strokes_never_add_both_partners(
         self, user_uow, competition_uow, qm_uow, golf_course_uow
     ):


### PR DESCRIPTION
## What

A player who picks up their ball finishes the hole without a number — on the scorecard, a dash. Quick matches had nowhere to store it: the `score` column was `NOT NULL` and `SubmitHoleScoreBody` demanded an integer, so the frontend's "Raya" button sent `score: null`, Pydantic answered **422**, and the scoring screen showed *"Ese resultado no es válido"*. The competition module already accepted it (`own_score: int | None`), so the same button worked in one screen and not in the other.

Reported from production, with a screenshot of the failing screen.

## The distinction that matters

A picked-up hole is a **recorded** hole, not a pending one. Key present with a null value vs. no row at all — that is what the live standings and being able to finish the match hang on. `compute_participant_totals` now tells them apart by key presence instead of `get(...) is None`, because both cases were `None` and mean the opposite.

## How a dash counts

| Context | Rule |
|---|---|
| Stableford / stroke totals | Net double bogey (`par + 2 + strokes received`), per WHS Rule 3.1 for a hole not holed out. Yields exactly the zero points picking up is worth. |
| Match play | The null propagates to `calculate_hole_winner`, which reads a side with no ball and gives the hole to the opponent. That service already took `list[int \| None]`, so nothing changed there. |
| **Medal** | **Not allowed.** Stroke play requires holing out on every hole, so `QuickMatch.allows_picked_up_holes()` is false and both scoring use cases reject a null score with a **400**. |
| Achievements | Judged as a plain double bogey against par. No achievement comes out of a double bogey, so a legitimate birdie elsewhere in the round can still be shared. |

## Migration

`d3c7a5f18e42` drops the `NOT NULL` on `quick_match_hole_scores.score`. Instant, no table rewrite, and **backward compatible** — the current API never writes a null. The CHECK constraint is untouched: a CHECK over NULL evaluates to NULL and is not considered violated, so real scores are still bounded to 1..15. The downgrade deletes rows with a null score, since they cannot be represented in the old schema.

## Verified

- `pytest tests/unit/` — 2951 passed
- `pytest tests/integration/` — 438 passed, 1 skipped
- `ruff check .` / `mypy src/` — clean (the 6 pre-existing ruff findings on `develop` are untouched)
- **Against the live local cluster**, not only in tests: image rebuilt, migration applied on boot, then a real Stableford match recorded a dash (200, `score: null`, returned as null in the detail) and a Medal match rejected it (400) while still accepting a number (200).

## Deploy order

**FRONTEND FIRST**, and both in a row — the opposite of the usual order here, and worth reading before deploying.

With the backend first, the installed app (v2.14.0) still offers the picked-up button in every format, and its `score: null` submissions would start being **stored**. That version draws a dash exactly like an unscored hole, leaves the hole selector amber forever (`hs.score != null`) and skips the hole in its Stableford while the backend counts it — bad data written by a client that cannot read it back.

With the frontend first there is no window: the old backend keeps answering 422, which is today's behaviour, and the new screen already maps 400 and 422 to the same copy.

## Also in this PR

Competition rounds now count a picked-up hole too (net double bogey), instead of throwing the whole card out of the average and the WHS differential. Without it the same round counted for your average if it was a quick match and not if it was a competition — and that split applied to future rounds, not just old ones. **This recomputes averages and differentials for rounds already played**, which was agreed before making the change.

Frontend: agustinEDev/RyderCupWeb#431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording picked-up holes with an explicit `null` score in eligible quick match formats.
  * Stableford scoring now treats picked-up holes as net double bogeys with zero Stableford points.
  * Match-play results correctly award holes when one player picks up, while halving holes when both do.
  * Picked-up holes can be corrected to numeric scores and vice versa.

* **Bug Fixes**
  * Medal matches now reject picked-up hole submissions.
  * Round statistics and achievements remain accurate when picked-up holes are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
