### PR TITLE
chore(release): Prepare v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-08-22
+
+### Added
+
+- **Ocultar una partida rápida y dejarla fuera de tus estadísticas dejan de ser lo mismo.** `hidden_by_participant_ids` hacía las dos cosas a la vez: la partida desaparecía del historial **y** dejaba de contar, con un único botón, sin aviso y sin vuelta atrás desde la aplicación. Lo destapó un usuario que ocultó una partida y se quedó sin manera de recuperarla. Ahora son dos marcas independientes:
+
+  - `hidden_by_participant_ids` — igual que antes: fuera de mi lista, definitivo.
+  - `stats_excluded_by_participant_ids` — nueva: no cuenta en mis estadísticas, pero la partida **sigue en la lista** y la marca se puede quitar.
+
+  ```
+  POST   /api/v1/quick-matches/{id}/stats-exclusion
+  DELETE /api/v1/quick-matches/{id}/stats-exclusion
+  ```
+
+  Solo se puede marcar una partida **terminada** (**409** en otro caso): una que sigue en juego no cuenta todavía en ningún sitio. Quitar la marca no exige estado alguno, porque la migración puede dejarla puesta sobre una partida sin terminar. El par de endpoints es propio del que pide, como el de ocultar: el usuario sale del JWT y nunca del cuerpo, y a un desconocido se le responde **404** en vez de 403 para no confirmarle que la partida existe.
+
+  La migración `f1a4c86d2e59` añade la columna y **traspasa las filas existentes de la marca vieja a la nueva**, no al revés. Quien pulsó aquella papelera no pudo pedir nada permanente —no había aviso ni forma de deshacerlo—, y lo único que aquella acción quería con seguridad es que la partida no contara, que es justo la marca nueva y esa sí se puede levantar. **Consecuencia visible al desplegar: las partidas ocultadas hasta hoy reaparecen en el historial, marcadas como que no cuentan.** Sus estadísticas no cambian. La vuelta atrás junta las dos marcas en una, así que una partida marcada con el ojo después del despliegue quedaría oculta —exactamente lo que esa marca promete que no pasa—; queda escrito en la propia migración.
+
+### Changed
+
+- **Las estadísticas dejan de apoyarse en el filtro del historial.** Se calculaban sobre `list_for_user`, que descartaba las ocultas; esa lista tiene que devolver ahora las excluidas —para eso se quedan a la vista—, así que seguir compartiendo consulta habría hecho contar en silencio partidas que el usuario dejó fuera. El cálculo usa `list_for_stats`, una consulta propia que descarta **las dos** marcas y no acepta un tope por defecto, porque un límite invisible recortaría la media de alguien sin que nada lo dijera.
+
+  Que la papelera siga sacando de las estadísticas además de sacar de la lista **es deliberado**: una partida que has quitado de tu historial no debería seguir moviendo tu media. El aviso de la papelera lo dice con todas las letras antes de confirmar.
+
 ## [2.11.0] - 2026-08-21
 
 ### Added

--- a/alembic/versions/f1a4c86d2e59_split_quick_match_hiding_from_stats_exclusion.py
+++ b/alembic/versions/f1a4c86d2e59_split_quick_match_hiding_from_stats_exclusion.py
@@ -1,0 +1,92 @@
+"""split quick match hiding from stats exclusion
+
+Hasta ahora `hidden_by_participant_ids` hacia dos cosas a la vez: la partida
+desaparecia del historial del usuario Y dejaba de contar en sus estadisticas.
+Un unico boton —una papelera, sin aviso y sin vuelta atras desde la app— para
+dos efectos distintos. Se separan (BE #242):
+
+- `hidden_by_participant_ids` se queda como esta: fuera de mi lista, definitivo.
+- `stats_excluded_by_participant_ids`, nueva: no cuenta en mis estadisticas,
+  pero la partida se sigue viendo en la lista y la marca se puede quitar.
+
+Las filas existentes se MIGRAN de la primera a la segunda, y no al reves.
+Quien pulso aquella papelera no pudo pedir nada permanente: no habia aviso ni
+manera de deshacerlo, y de hecho el caso que destapo esto fue un usuario que
+oculto una partida y se quedo sin forma de recuperarla. Lo unico que aquella
+accion queria con seguridad es que la partida no contara, que es exactamente
+la marca nueva, y esa si es reversible. Dejarlas en la papelera nueva las
+condenaria a no volver, por un clic que nunca dijo eso.
+
+Consecuencia visible al desplegar: las partidas ocultadas hasta hoy reaparecen
+en el historial, marcadas como que no cuentan. Sus estadisticas no cambian.
+
+Revision ID: f1a4c86d2e59
+Revises: d3c7a5f18e42
+Create Date: 2026-08-21
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a4c86d2e59"
+down_revision = "d3c7a5f18e42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Se crea con default de servidor para que las filas existentes queden con
+    # lista vacia y la columna pueda ser NOT NULL desde el principio.
+    op.add_column(
+        "quick_matches",
+        sa.Column(
+            "stats_excluded_by_participant_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+    # Traspaso: lo que estaba oculto pasa a "no cuenta", y deja de estar oculto.
+    op.execute(
+        """
+        UPDATE quick_matches
+        SET stats_excluded_by_participant_ids = hidden_by_participant_ids,
+            hidden_by_participant_ids = '[]'::jsonb
+        WHERE jsonb_array_length(hidden_by_participant_ids) > 0
+        """
+    )
+
+
+def downgrade() -> None:
+    # AVISO: esto no es simetrico, y no puede serlo. Al volver atras solo queda
+    # una columna, asi que las partidas marcadas con el ojo despues del
+    # despliegue —que el usuario dejo fuera de sus estadisticas contando con que
+    # seguirian en su lista— pasan a estar OCULTAS, justo lo que esa marca
+    # prometia que no pasaria. No hay forma de distinguirlas de las que ya
+    # venian ocultas de antes: la informacion de cual era cual se pierde al
+    # fusionar las dos marcas en una.
+    #
+    # Lo que si se conserva es A QUIEN afecta cada marca. Las dos listas se
+    # UNEN, no se elige una: en una misma partida, A puede haberla ocultado y B
+    # haberla dejado fuera de sus estadisticas, y quedarse solo con la de A
+    # borraria la de B en silencio —su partida volveria a contar sin que el
+    # hiciera nada—. Se deduplica porque un mismo participante puede estar en
+    # las dos listas.
+    op.execute(
+        """
+        UPDATE quick_matches
+        SET hidden_by_participant_ids = (
+            SELECT COALESCE(jsonb_agg(DISTINCT elemento), '[]'::jsonb)
+            FROM jsonb_array_elements(
+                hidden_by_participant_ids || stats_excluded_by_participant_ids
+            ) AS elementos(elemento)
+        )
+        WHERE jsonb_array_length(stats_excluded_by_participant_ids) > 0
+        """
+    )
+    op.drop_column("quick_matches", "stats_excluded_by_participant_ids")

--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -220,11 +220,17 @@ from src.modules.quick_match.application.use_cases.complete_quick_match_use_case
 from src.modules.quick_match.application.use_cases.create_quick_match_use_case import (
     CreateQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.exclude_quick_match_from_stats_use_case import (
+    ExcludeQuickMatchFromStatsUseCase,
+)
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
 from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
     HideQuickMatchUseCase,
+)
+from src.modules.quick_match.application.use_cases.include_quick_match_in_stats_use_case import (
+    IncludeQuickMatchInStatsUseCase,
 )
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
@@ -1335,6 +1341,22 @@ def get_unhide_quick_match_use_case(
 ) -> UnhideQuickMatchUseCase:
     """Proveedor del caso de uso UnhideQuickMatchUseCase."""
     return UnhideQuickMatchUseCase(uow, user_uow)
+
+
+def get_exclude_quick_match_from_stats_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> ExcludeQuickMatchFromStatsUseCase:
+    """Proveedor del caso de uso ExcludeQuickMatchFromStatsUseCase."""
+    return ExcludeQuickMatchFromStatsUseCase(uow, user_uow)
+
+
+def get_include_quick_match_in_stats_use_case(
+    uow: QuickMatchUnitOfWorkInterface = Depends(get_quick_match_uow),
+    user_uow: UserUnitOfWorkInterface = Depends(get_uow),
+) -> IncludeQuickMatchInStatsUseCase:
+    """Proveedor del caso de uso IncludeQuickMatchInStatsUseCase."""
+    return IncludeQuickMatchInStatsUseCase(uow, user_uow)
 
 
 def get_set_quick_match_participant_handicap_use_case(

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -10,7 +10,7 @@ una release ha llegado realmente a produccion.
 
 import os
 
-APP_VERSION = "2.11.0"
+APP_VERSION = "2.12.0"
 
 
 def get_deployed_commit() -> str:

--- a/src/modules/quick_match/application/dto/quick_match_dto.py
+++ b/src/modules/quick_match/application/dto/quick_match_dto.py
@@ -190,6 +190,14 @@ class QuickMatchResponseDTO(BaseModel):
     play_mode: str = "HANDICAP"
     participants: list[QuickMatchParticipantDTO]
     scorer_ids: list[UUID]
+    excluded_from_stats: bool = Field(
+        default=False,
+        description=(
+            "True si QUIEN PREGUNTA ha dejado esta partida fuera de sus estadisticas. "
+            "La partida se sigue viendo en su historial, marcada. Es por usuario: "
+            "la misma partida puede contar para un participante y no para otro."
+        ),
+    )
     created_at: datetime
     updated_at: datetime
 

--- a/src/modules/quick_match/application/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/application/mappers/quick_match_mapper.py
@@ -5,6 +5,7 @@ from src.modules.quick_match.application.dto.quick_match_dto import (
     QuickMatchResponseDTO,
 )
 from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.user.domain.entities.user import User
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
@@ -20,6 +21,8 @@ class QuickMatchDTOMapper:
         quick_match: QuickMatch,
         user_uow: UserUnitOfWorkInterface,
         users_by_id: dict[UserId, User] | None = None,
+        *,
+        requester_id: UserId,
     ) -> QuickMatchResponseDTO:
         """
         Convierte una QuickMatch a su DTO de respuesta.
@@ -28,6 +31,13 @@ class QuickMatchDTOMapper:
         p.ej. al listar varias partidas), se evita una query por participante.
         Los invitados (`is_guest=True`) no tienen `user_id` y se resuelven
         directamente desde sus datos manuales, sin tocar `users_by_id`.
+
+        `requester_id` resuelve `excluded_from_stats`, que es una marca POR
+        USUARIO: sin saber quien pregunta no hay respuesta posible. Es
+        obligatorio y va como keyword a proposito. Con un valor por defecto,
+        olvidarlo devolvia "esta partida cuenta" para una que no cuenta —una
+        respuesta equivocada en silencio, que el cliente cachea y pinta— en vez
+        de un error al arrancar.
         """
         if users_by_id is None:
             registered_ids = [p.user_id for p in quick_match.participants if p.user_id is not None]
@@ -76,6 +86,9 @@ class QuickMatchDTOMapper:
             play_mode=quick_match.play_mode.value,
             participants=participants_dto,
             scorer_ids=[sid.value for sid in quick_match.scorer_ids],
+            excluded_from_stats=quick_match.is_stats_excluded_for(
+                ParticipantId(requester_id.value)
+            ),
             created_at=quick_match.created_at,
             updated_at=quick_match.updated_at,
         )

--- a/src/modules/quick_match/application/use_cases/add_friend_to_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/add_friend_to_quick_match_use_case.py
@@ -102,4 +102,6 @@ class AddFriendToQuickMatchUseCase:
             quick_match.add_participant(participant)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/add_guest_to_quick_match_use_case.py
@@ -85,4 +85,6 @@ class AddGuestToQuickMatchUseCase:
             quick_match.add_participant(participant)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/cancel_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/cancel_quick_match_use_case.py
@@ -41,4 +41,6 @@ class CancelQuickMatchUseCase:
             quick_match.cancel()
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/complete_quick_match_use_case.py
@@ -77,7 +77,9 @@ class CompleteQuickMatchUseCase:
 
         await self._publicar_logros(quick_match_id_raw, marca_previa)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )
 
     async def _marca_previa(self, jugadores: list[UserId]) -> dict[str, float | None]:
         """El mejor diferencial de cada jugador con cuenta, antes de cerrar."""

--- a/src/modules/quick_match/application/use_cases/create_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/create_quick_match_use_case.py
@@ -84,4 +84,6 @@ class CreateQuickMatchUseCase:
         async with self._uow:
             await self._uow.quick_matches.add(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=UserId(request.creator_id)
+        )

--- a/src/modules/quick_match/application/use_cases/exclude_quick_match_from_stats_use_case.py
+++ b/src/modules/quick_match/application/use_cases/exclude_quick_match_from_stats_use_case.py
@@ -1,13 +1,10 @@
-"""Caso de Uso: Editar el handicap de un participante antes de iniciar la partida."""
+"""Caso de Uso: dejar una partida rapida fuera de las estadisticas propias."""
 
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
     QuickMatchResponseDTO,
-    SetParticipantHandicapRequestDTO,
 )
-from src.modules.quick_match.application.exceptions import (
-    NotQuickMatchCreatorError,
-    QuickMatchNotFoundError,
-)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
 from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -20,22 +17,24 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
-class SetParticipantHandicapUseCase:
+class ExcludeQuickMatchFromStatsUseCase:
     """
-    Edita el handicap de un participante (manual para invitados, override para
-    registrados) mientras la partida esta PENDING — pensado para el resumen
-    previo a `start()`.
+    Marca una partida para que no cuente en las estadisticas del solicitante.
 
-    Solo el creador puede editarlo.
+    A diferencia de ocultarla, la partida SIGUE en su historial: se enseña
+    marcada y la marca se puede quitar. Es self-scoped como ocultar: cualquier
+    participante puede hacerlo para si mismo y no afecta al resto.
+
+    Solo en partidas terminadas; la entidad lo exige y la ruta lo traduce a 409.
     """
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
         self._uow = uow
         self._user_uow = user_uow
 
-    async def execute(self, request: SetParticipantHandicapRequestDTO) -> QuickMatchResponseDTO:
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
         requester_id = UserId(request.requester_id)
-        target_participant_id = ParticipantId(request.target_participant_id)
+        requester_participant_id = ParticipantId(requester_id.value)
 
         async with self._uow:
             quick_match = await self._uow.quick_matches.find_by_id_for_update(
@@ -44,12 +43,7 @@ class SetParticipantHandicapUseCase:
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 
-            if quick_match.creator_id != requester_id:
-                raise NotQuickMatchCreatorError(
-                    "Only the quick match creator can edit a participant's handicap."
-                )
-
-            quick_match.set_participant_handicap(target_participant_id, request.handicap)
+            quick_match.exclude_from_stats_for(requester_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
         return await QuickMatchDTOMapper.to_response_dto(

--- a/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/get_quick_match_use_case.py
@@ -89,7 +89,10 @@ class GetQuickMatchUseCase:
                     users_by_id[user_id] = user
 
         base_dto = await QuickMatchDTOMapper.to_response_dto(
-            quick_match, self._user_uow, users_by_id=users_by_id
+            quick_match,
+            self._user_uow,
+            users_by_id=users_by_id,
+            requester_id=UserId(current_user_id_raw),
         )
 
         hole_scores_dto = [

--- a/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/hide_quick_match_use_case.py
@@ -44,4 +44,6 @@ class HideQuickMatchUseCase:
             quick_match.hide_for(requester_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/include_quick_match_in_stats_use_case.py
+++ b/src/modules/quick_match/application/use_cases/include_quick_match_in_stats_use_case.py
@@ -1,13 +1,10 @@
-"""Caso de Uso: Editar el handicap de un participante antes de iniciar la partida."""
+"""Caso de Uso: volver a contar una partida rapida en las estadisticas propias."""
 
 from src.modules.quick_match.application.dto.quick_match_dto import (
+    HideQuickMatchRequestDTO,
     QuickMatchResponseDTO,
-    SetParticipantHandicapRequestDTO,
 )
-from src.modules.quick_match.application.exceptions import (
-    NotQuickMatchCreatorError,
-    QuickMatchNotFoundError,
-)
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
 from src.modules.quick_match.application.mappers.quick_match_mapper import QuickMatchDTOMapper
 from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interface import (
     QuickMatchUnitOfWorkInterface,
@@ -20,22 +17,23 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 from src.modules.user.domain.value_objects.user_id import UserId
 
 
-class SetParticipantHandicapUseCase:
+class IncludeQuickMatchInStatsUseCase:
     """
-    Edita el handicap de un participante (manual para invitados, override para
-    registrados) mientras la partida esta PENDING — pensado para el resumen
-    previo a `start()`.
+    Contrario de ExcludeQuickMatchFromStatsUseCase: la partida vuelve a contar
+    en las estadisticas del solicitante. Self-scoped e idempotente.
 
-    Solo el creador puede editarlo.
+    Aqui no se exige que la partida este terminada: quitar una marca siempre es
+    seguro, y la migracion que separo ocultar de excluir pudo dejar alguna en
+    una partida sin terminar.
     """
 
     def __init__(self, uow: QuickMatchUnitOfWorkInterface, user_uow: UserUnitOfWorkInterface):
         self._uow = uow
         self._user_uow = user_uow
 
-    async def execute(self, request: SetParticipantHandicapRequestDTO) -> QuickMatchResponseDTO:
+    async def execute(self, request: HideQuickMatchRequestDTO) -> QuickMatchResponseDTO:
         requester_id = UserId(request.requester_id)
-        target_participant_id = ParticipantId(request.target_participant_id)
+        requester_participant_id = ParticipantId(requester_id.value)
 
         async with self._uow:
             quick_match = await self._uow.quick_matches.find_by_id_for_update(
@@ -44,12 +42,7 @@ class SetParticipantHandicapUseCase:
             if not quick_match:
                 raise QuickMatchNotFoundError(f"Quick match not found: {request.quick_match_id}")
 
-            if quick_match.creator_id != requester_id:
-                raise NotQuickMatchCreatorError(
-                    "Only the quick match creator can edit a participant's handicap."
-                )
-
-            quick_match.set_participant_handicap(target_participant_id, request.handicap)
+            quick_match.include_in_stats_for(requester_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
         return await QuickMatchDTOMapper.to_response_dto(

--- a/src/modules/quick_match/application/use_cases/list_my_quick_matches_use_case.py
+++ b/src/modules/quick_match/application/use_cases/list_my_quick_matches_use_case.py
@@ -45,7 +45,9 @@ class ListMyQuickMatchesUseCase:
             }
 
         items = [
-            await QuickMatchDTOMapper.to_response_dto(qm, self._user_uow, users_by_id=users_by_id)
+            await QuickMatchDTOMapper.to_response_dto(
+                qm, self._user_uow, users_by_id=users_by_id, requester_id=user_id
+            )
             for qm in quick_matches
         ]
 

--- a/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
+++ b/src/modules/quick_match/application/use_cases/remove_participant_use_case.py
@@ -54,4 +54,6 @@ class RemoveParticipantUseCase:
             quick_match.remove_participant(target_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/start_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/start_quick_match_use_case.py
@@ -51,4 +51,6 @@ class StartQuickMatchUseCase:
             quick_match.start(scorer_ids)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
+++ b/src/modules/quick_match/application/use_cases/unhide_quick_match_use_case.py
@@ -38,4 +38,6 @@ class UnhideQuickMatchUseCase:
             quick_match.unhide_for(requester_participant_id)
             await self._uow.quick_matches.update(quick_match)
 
-        return await QuickMatchDTOMapper.to_response_dto(quick_match, self._user_uow)
+        return await QuickMatchDTOMapper.to_response_dto(
+            quick_match, self._user_uow, requester_id=requester_id
+        )

--- a/src/modules/quick_match/domain/entities/quick_match.py
+++ b/src/modules/quick_match/domain/entities/quick_match.py
@@ -26,6 +26,8 @@ from ..events.quick_match_participant_handicap_updated_event import (
 )
 from ..events.quick_match_participant_removed_event import QuickMatchParticipantRemovedEvent
 from ..events.quick_match_started_event import QuickMatchStartedEvent
+from ..events.quick_match_stats_excluded_event import QuickMatchStatsExcludedEvent
+from ..events.quick_match_stats_included_event import QuickMatchStatsIncludedEvent
 from ..events.quick_match_unhidden_event import QuickMatchUnhiddenEvent
 from ..exceptions.quick_match_violations import (
     CreatorCannotBeRemovedViolation,
@@ -88,6 +90,7 @@ class QuickMatch:
         play_mode: PlayMode = PlayMode.HANDICAP,
         scorer_ids: list[ParticipantId] | None = None,
         hidden_by_participant_ids: list[ParticipantId] | None = None,
+        stats_excluded_by_participant_ids: list[ParticipantId] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
@@ -107,6 +110,9 @@ class QuickMatch:
         self._scorer_ids = list(scorer_ids) if scorer_ids else []
         self._hidden_by_participant_ids = (
             list(hidden_by_participant_ids) if hidden_by_participant_ids else []
+        )
+        self._stats_excluded_by_participant_ids = (
+            list(stats_excluded_by_participant_ids) if stats_excluded_by_participant_ids else []
         )
         self._created_at = created_at or datetime.now()
         self._updated_at = updated_at or datetime.now()
@@ -353,6 +359,17 @@ class QuickMatch:
         return list(self._hidden_by_participant_ids)
 
     @property
+    def stats_excluded_by_participant_ids(self) -> list[ParticipantId]:
+        """
+        Participantes que han dejado esta partida fuera de SUS estadisticas.
+
+        Distinto de `hidden_by_participant_ids`: la partida se sigue viendo en
+        su historial, solo que no cuenta. Antes las dos cosas eran una sola
+        marca y el mismo boton hacia ambas (BE #242).
+        """
+        return list(self._stats_excluded_by_participant_ids)
+
+    @property
     def created_at(self) -> datetime:
         return self._created_at
 
@@ -378,6 +395,9 @@ class QuickMatch:
 
     def is_hidden_for(self, participant_id: ParticipantId) -> bool:
         return participant_id in self._hidden_by_participant_ids
+
+    def is_stats_excluded_for(self, participant_id: ParticipantId) -> bool:
+        return participant_id in self._stats_excluded_by_participant_ids
 
     def capacity(self) -> int:
         """Numero maximo de jugadores admitidos por el formato."""
@@ -585,6 +605,73 @@ class QuickMatch:
 
         self.add_domain_event(
             QuickMatchUnhiddenEvent(
+                quick_match_id=str(self._id), participant_id=str(participant_id)
+            )
+        )
+
+    def exclude_from_stats_for(self, participant_id: ParticipantId) -> None:
+        """
+        Deja la partida fuera de las estadisticas de un participante, sin
+        sacarla de su historial: la sigue viendo, atenuada, y puede volver
+        atras cuando quiera (BE #242).
+
+        Solo en partidas TERMINADAS. Una que aun se esta jugando todavia no
+        cuenta en ninguna estadistica, asi que la marca no diria nada: seria
+        una promesa sobre el futuro que ni la pantalla ni el calculo miran.
+
+        Es personal: no afecta a los demas participantes ni borra nada.
+        Idempotente.
+        """
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if self._status != QuickMatchStatus.COMPLETED:
+            raise InvalidQuickMatchStatusViolation(
+                "Only a completed quick match can be left out of the statistics "
+                f"(this one is {self._status.value})."
+            )
+
+        if participant_id in self._stats_excluded_by_participant_ids:
+            return
+
+        self._stats_excluded_by_participant_ids = [
+            *self._stats_excluded_by_participant_ids,
+            participant_id,
+        ]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchStatsExcludedEvent(
+                quick_match_id=str(self._id), participant_id=str(participant_id)
+            )
+        )
+
+    def include_in_stats_for(self, participant_id: ParticipantId) -> None:
+        """
+        Contrario de exclude_from_stats_for. Idempotente.
+
+        Aqui NO se exige que la partida este terminada, al reves que al
+        excluir: quitar una marca es siempre seguro, y la migracion que separo
+        las dos marcas pudo dejar alguna en una partida sin terminar. Exigirlo
+        dejaria esa marca sin forma de quitarse.
+        """
+        if not self.is_participant(participant_id):
+            raise NotQuickMatchParticipantViolation(
+                f"{participant_id} is not a participant of this quick match."
+            )
+
+        if participant_id not in self._stats_excluded_by_participant_ids:
+            return
+
+        self._stats_excluded_by_participant_ids = [
+            pid for pid in self._stats_excluded_by_participant_ids if pid != participant_id
+        ]
+        self._updated_at = datetime.now()
+
+        self.add_domain_event(
+            QuickMatchStatsIncludedEvent(
                 quick_match_id=str(self._id), participant_id=str(participant_id)
             )
         )

--- a/src/modules/quick_match/domain/events/quick_match_stats_excluded_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_stats_excluded_event.py
@@ -1,0 +1,16 @@
+"""QuickMatchStatsExcludedEvent - Un participante deja esta partida fuera de sus estadisticas."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchStatsExcludedEvent(DomainEvent):
+    """
+    Emitido cuando un participante marca la partida para que no cuente en sus
+    estadisticas. No la saca de su historial: eso es QuickMatchHiddenEvent.
+    """
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/events/quick_match_stats_included_event.py
+++ b/src/modules/quick_match/domain/events/quick_match_stats_included_event.py
@@ -1,0 +1,13 @@
+"""QuickMatchStatsIncludedEvent - Un participante vuelve a contar esta partida en sus estadisticas."""
+
+from dataclasses import dataclass
+
+from src.shared.domain.events.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class QuickMatchStatsIncludedEvent(DomainEvent):
+    """Contrario de QuickMatchStatsExcludedEvent."""
+
+    quick_match_id: str
+    participant_id: str

--- a/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
+++ b/src/modules/quick_match/domain/repositories/quick_match_repository_interface.py
@@ -48,6 +48,19 @@ class QuickMatchRepositoryInterface(ABC):
         pass
 
     @abstractmethod
+    async def list_for_stats(
+        self,
+        user_id: UserId,
+        status: QuickMatchStatus | None = None,
+        limit: int | None = None,
+    ) -> list[QuickMatch]:
+        """
+        Partidas que cuentan en las estadisticas del usuario: descarta tanto las
+        que oculto de su historial como las que dejo fuera de sus estadisticas.
+        """
+        pass
+
+    @abstractmethod
     async def count_for_user(
         self, user_id: UserId, status: QuickMatchStatus | None = None
     ) -> int:

--- a/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
+++ b/src/modules/quick_match/infrastructure/api/v1/quick_match_routes.py
@@ -18,8 +18,10 @@ from src.config.dependencies import (
     get_complete_quick_match_use_case,
     get_create_quick_match_use_case,
     get_current_user,
+    get_exclude_quick_match_from_stats_use_case,
     get_get_quick_match_use_case,
     get_hide_quick_match_use_case,
+    get_include_quick_match_in_stats_use_case,
     get_list_my_quick_matches_use_case,
     get_remove_quick_match_participant_use_case,
     get_set_quick_match_participant_handicap_use_case,
@@ -77,11 +79,17 @@ from src.modules.quick_match.application.use_cases.complete_quick_match_use_case
 from src.modules.quick_match.application.use_cases.create_quick_match_use_case import (
     CreateQuickMatchUseCase,
 )
+from src.modules.quick_match.application.use_cases.exclude_quick_match_from_stats_use_case import (
+    ExcludeQuickMatchFromStatsUseCase,
+)
 from src.modules.quick_match.application.use_cases.get_quick_match_use_case import (
     GetQuickMatchUseCase,
 )
 from src.modules.quick_match.application.use_cases.hide_quick_match_use_case import (
     HideQuickMatchUseCase,
+)
+from src.modules.quick_match.application.use_cases.include_quick_match_in_stats_use_case import (
+    IncludeQuickMatchInStatsUseCase,
 )
 from src.modules.quick_match.application.use_cases.list_my_quick_matches_use_case import (
     ListMyQuickMatchesUseCase,
@@ -432,6 +440,71 @@ async def unhide_quick_match(
     quick_match_id: UUID,
     current_user: UserResponseDTO = Depends(get_current_user),
     use_case: UnhideQuickMatchUseCase = Depends(get_unhide_quick_match_use_case),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.post(
+    "/quick-matches/{quick_match_id}/stats-exclusion",
+    response_model=QuickMatchResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Leave this match out of my statistics",
+    description=(
+        "The match stops counting towards the caller's statistics but STAYS in their "
+        "history, flagged, and the flag can be lifted again (DELETE on the same path). "
+        "Different from hiding it, which removes it from the list for good. "
+        "Self-scoped: any participant can flag it for themselves and it does not affect "
+        "the others. Only on a completed match; anything else returns 409. Idempotent."
+    ),
+    tags=["Quick Matches"],
+)
+async def exclude_quick_match_from_stats(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: ExcludeQuickMatchFromStatsUseCase = Depends(
+        get_exclude_quick_match_from_stats_use_case
+    ),
+):
+    try:
+        request_dto = HideQuickMatchRequestDTO(
+            quick_match_id=quick_match_id,
+            requester_id=current_user.id,
+        )
+        return await use_case.execute(request_dto)
+
+    except QuickMatchNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except NotQuickMatchParticipantViolation as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except InvalidQuickMatchStatusViolation as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.delete(
+    "/quick-matches/{quick_match_id}/stats-exclusion",
+    response_model=QuickMatchResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Count this match towards my statistics again",
+    description=(
+        "Reverses the exclusion: the match counts again for the caller. Idempotent, and "
+        "allowed in any status — lifting a flag is always safe."
+    ),
+    tags=["Quick Matches"],
+)
+async def include_quick_match_in_stats(
+    quick_match_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: IncludeQuickMatchInStatsUseCase = Depends(get_include_quick_match_in_stats_use_case),
 ):
     try:
         request_dto = HideQuickMatchRequestDTO(

--- a/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/in_memory/in_memory_quick_match_repository.py
@@ -39,6 +39,33 @@ class InMemoryQuickMatchRepository(QuickMatchRepositoryInterface):
             and (status is None or qm.status == status)
         )
 
+    async def list_for_stats(
+        self,
+        user_id: UserId,
+        status: QuickMatchStatus | None = None,
+        limit: int | None = None,
+    ) -> list[QuickMatch]:
+        """
+        Las que cuentan: ni ocultas del historial ni excluidas de estadisticas.
+
+        Se apoya en `_matches_user` en vez de repetir su condicion: si cambia la
+        regla de "oculta", esto la hereda. Reescrita a mano, la copia vieja se
+        quedaria aqui y los tests unitarios —que corren contra este repositorio—
+        seguirian en verde mientras el SQL dice otra cosa.
+        """
+        participant_id = ParticipantId(user_id.value)
+        results = sorted(
+            [
+                qm
+                for qm in self._quick_matches.values()
+                if self._matches_user(qm, user_id, status)
+                and not qm.is_stats_excluded_for(participant_id)
+            ],
+            key=lambda qm: qm.created_at,
+            reverse=True,
+        )
+        return results[:limit] if limit is not None else results
+
     async def list_for_user(
         self,
         user_id: UserId,

--- a/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
+++ b/src/modules/quick_match/infrastructure/persistence/mappers/quick_match_mapper.py
@@ -277,8 +277,8 @@ class ScorerIdsJsonType(sqlalchemy.types.TypeDecorator[list]):
     """
     TypeDecorator para serializar list[ParticipantId] a/desde JSONB.
 
-    Generico: se reutiliza tanto para `scorer_ids` como para
-    `hidden_by_participant_ids` (misma forma, listas de ParticipantId).
+    Generico: se reutiliza para `scorer_ids`, `hidden_by_participant_ids` y
+    `stats_excluded_by_participant_ids` (misma forma, listas de ParticipantId).
     """
 
     impl = JSONB
@@ -324,6 +324,10 @@ quick_matches_table = Table(
     Column("participants", QuickMatchParticipantsJsonType, nullable=False),
     Column("scorer_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("hidden_by_participant_ids", ScorerIdsJsonType, nullable=False, default=list),
+    # Quien deja la partida fuera de SUS estadisticas sin sacarla del historial:
+    # la sigue viendo, marcada, y puede volver atras. Antes esto y ocultarla
+    # eran la misma marca y el mismo boton (BE #242).
+    Column("stats_excluded_by_participant_ids", ScorerIdsJsonType, nullable=False, default=list),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
     CheckConstraint(
@@ -382,6 +386,9 @@ def start_quick_match_mappers() -> None:
                 "_participants": quick_matches_table.c.participants,
                 "_scorer_ids": quick_matches_table.c.scorer_ids,
                 "_hidden_by_participant_ids": quick_matches_table.c.hidden_by_participant_ids,
+                "_stats_excluded_by_participant_ids": (
+                    quick_matches_table.c.stats_excluded_by_participant_ids
+                ),
                 "_created_at": quick_matches_table.c.created_at,
                 "_updated_at": quick_matches_table.c.updated_at,
             },

--- a/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
+++ b/src/modules/quick_match/infrastructure/persistence/sqlalchemy/quick_match_repository.py
@@ -54,6 +54,17 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
             cast([str(user_id.value)], JSONB)
         )
 
+    def _counts_for_stats_filter(self, user_id: UserId):
+        """
+        Excluye las que el usuario ha dejado fuera de sus estadisticas.
+
+        Es una marca DISTINTA de ocultar: estas si salen en el historial, solo
+        que no cuentan (ver exclude_from_stats_for()).
+        """
+        return ~quick_matches_table.c.stats_excluded_by_participant_ids.op("@>")(
+            cast([str(user_id.value)], JSONB)
+        )
+
     async def list_for_user(
         self,
         user_id: UserId,
@@ -72,6 +83,48 @@ class SQLAlchemyQuickMatchRepository(QuickMatchRepositoryInterface):
             .limit(limit)
             .offset(offset)
         )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_for_stats(
+        self,
+        user_id: UserId,
+        status: QuickMatchStatus | None = None,
+        limit: int | None = None,
+    ) -> list[QuickMatch]:
+        """
+        Partidas que SI cuentan en las estadisticas del usuario.
+
+        Metodo propio y no un parametro de `list_for_user` a proposito: las dos
+        consultas responden a preguntas distintas —«que enseno en su historial»
+        frente a «que entra en sus numeros»— y separarlas evita el fallo que
+        tuvo esto antes de existir la marca nueva, cuando las estadisticas se
+        apoyaban en el filtro del historial y bastaba con relajarlo para que
+        empezaran a contar partidas que el usuario habia excluido, en silencio.
+
+        `limit` sin valor trae el historial entero: quien calcula decide
+        cuantas vueltas agrega, y un tope por defecto aqui recortaria la media
+        de alguien sin que nada lo dijera.
+
+        Descarta LAS DOS marcas a proposito, y eso significa que la papelera
+        sigue sacando de las estadisticas ademas de sacar de la lista. La
+        separacion de BE #242 es de una sola direccion: el ojo no oculta, pero
+        ocultar si deja de contar. Es defendible —una partida que has quitado de
+        tu historial no deberia seguir moviendo tu media—, pero es una decision,
+        no un descuido, y el aviso de la papelera en la aplicacion lo dice con
+        todas las letras antes de confirmar.
+        """
+        conditions = [
+            self._participant_filter(user_id),
+            self._not_hidden_filter(user_id),
+            self._counts_for_stats_filter(user_id),
+        ]
+        if status is not None:
+            conditions.append(QuickMatch._status == status)
+
+        stmt = select(QuickMatch).where(and_(*conditions)).order_by(QuickMatch._created_at.desc())
+        if limit is not None:
+            stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -134,6 +134,17 @@ class RecentMatchDTO(BaseModel):
     )
     partners: list[str] = Field(default_factory=list)
     opponents: list[str] = Field(default_factory=list)
+    excluded_from_stats: bool = Field(
+        default=False,
+        description=(
+            "True si el jugador ha dejado esta partida fuera de sus estadisticas. "
+            "El historial la sigue enseñando —por eso viaja aqui la marca— pero el "
+            "resumen de arriba no la cuenta: sin este campo, la pantalla enseñaria "
+            "una vuelta que el resumen ignora y las dos cifras se contradirian sin "
+            "explicacion. Los partidos de torneo son siempre False: la marca es solo "
+            "de partidas rapidas."
+        ),
+    )
 
 
 class RecentMatchesResponseDTO(BaseModel):

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -193,9 +193,14 @@ class GetPlayerStatsUseCase:
         medias no se puede comparar con una completa, y con el campo borrado no
         hay ni pares contra los que medirla.
 
-        `list_for_user` ya descarta las que el propio usuario ocultó (#127), y
-        lo hace por participante: una partida que A ocultó sigue contando para
-        B. Esa regla se hereda tal cual en lugar de reimplementarse aquí.
+        `list_for_stats` descarta dos cosas distintas, ambas por participante
+        —una partida que A excluyó sigue contando para B—: las que el usuario
+        ocultó de su historial (#127) y las que dejó fuera de sus estadísticas
+        con el ojo (BE #242). Esas reglas se heredan del repositorio en vez de
+        reimplementarse aquí, y por eso esto NO puede volver a `list_for_user`:
+        ese método sí devuelve las excluidas, porque el historial las enseña
+        marcadas, y usarlo aquí las metería otra vez en la media sin que nada
+        fallara.
 
         FOURSOMES se queda fuera: la pareja juega UNA bola a golpes alternos,
         así que ninguno de los dos ha jugado esa vuelta entera y no dice a qué
@@ -208,7 +213,7 @@ class GetPlayerStatsUseCase:
         results: list[_ComputableRound] = []
 
         async with self._quick_match_uow, self._golf_course_uow:
-            matches = await self._quick_match_uow.quick_matches.list_for_user(
+            matches = await self._quick_match_uow.quick_matches.list_for_stats(
                 user_id, status=QuickMatchStatus.COMPLETED, limit=MAX_ROUNDS_AGGREGATED
             )
 

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -34,6 +34,7 @@ from src.modules.quick_match.domain.services.stableford_calculator import (
 from src.modules.quick_match.domain.services.stroke_allocation_service import (
     StrokeAllocationService,
 )
+from src.modules.quick_match.domain.value_objects.participant_id import ParticipantId
 from src.modules.quick_match.domain.value_objects.quick_match_participant import (
     QuickMatchParticipant,
 )
@@ -137,7 +138,7 @@ class GetRecentMatchesUseCase:
         profile_handicap = float(player.handicap.value) if player and player.handicap else None
 
         entries = [
-            self._to_quick_match_dto(raw, users_by_id, courses_by_id, profile_handicap)
+            self._to_quick_match_dto(raw, users_by_id, courses_by_id, profile_handicap, user_id)
             for raw in quick_raws
         ] + [
             self._to_competition_match_dto(raw, user_id, users_by_id, courses_by_id)
@@ -156,6 +157,12 @@ class GetRecentMatchesUseCase:
 
         `list_for_user` ya descarta las que este jugador ocultó (#127), y solo
         para él: una partida que A ocultó sigue en el historial de B.
+
+        Aquí NO se usa `list_for_stats`, al revés que el resumen: esta lista es
+        el historial y tiene que enseñar también las que el jugador dejó fuera
+        de sus estadísticas (BE #242). Viajan con `excluded_from_stats` puesto
+        para que la pantalla las marque; si no, el resumen diría cero vueltas
+        mientras justo debajo se lista una, sin nada que explique la diferencia.
         """
         raws: list[_QuickMatchRaw] = []
 
@@ -286,6 +293,7 @@ class GetRecentMatchesUseCase:
         users_by_id: dict[UserId, User],
         courses_by_id: dict[GolfCourseId, GolfCourse],
         profile_handicap: float | None,
+        user_id: UserId,
     ) -> RecentMatchDTO:
         match = raw.match
         course = courses_by_id.get(match.golf_course_id)
@@ -318,6 +326,7 @@ class GetRecentMatchesUseCase:
 
         return RecentMatchDTO(
             id=str(match.id.value),
+            excluded_from_stats=match.is_stats_excluded_for(ParticipantId(user_id.value)),
             # Una partida rápida no guarda cuándo se jugó, solo cuándo se creó:
             # se juegan del tirón, así que la fecha de creación es la del juego
             date=match.created_at.date(),

--- a/tests/integration/api/v1/test_quick_match_endpoints.py
+++ b/tests/integration/api/v1/test_quick_match_endpoints.py
@@ -1125,3 +1125,145 @@ class TestQuickMatchHideFromHistory:
         )
 
         assert response.status_code == 404
+
+
+class TestQuickMatchStatsExclusion:
+    """
+    Tests para POST/DELETE /api/v1/quick-matches/{id}/stats-exclusion (BE #242).
+
+    El ojo: la partida deja de contar en las estadisticas de quien lo pulsa,
+    pero SIGUE en su historial. Es la otra mitad de la separacion que hizo la
+    papelera (`/hide`) exclusivamente "quitar de mi lista".
+    """
+
+    async def _create_completed_match(
+        self, client: AsyncClient, suffix: str
+    ) -> tuple[dict, dict, str]:
+        admin = await create_admin_user(
+            client, f"qm_admin_stats{suffix}@test.com", "P@ssw0rd123!", "Admin", "Stats"
+        )
+        creator = await create_authenticated_user(
+            client, f"qm_creator_stats{suffix}@test.com", "P@ssw0rd123!", "Creator", "Stats"
+        )
+        friend = await create_authenticated_user(
+            client, f"qm_friend_stats{suffix}@test.com", "P@ssw0rd123!", "Friend", "Stats"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"], friend["user"]["id"]]},
+        )
+        await client.post(f"/api/v1/quick-matches/{quick_match_id}/complete")
+
+        return creator, friend, quick_match_id
+
+    @pytest.mark.asyncio
+    async def test_excluded_match_stays_in_my_list_flagged(self, client: AsyncClient):
+        """La diferencia con la papelera: sigue estando, marcada."""
+        creator, _friend, quick_match_id = await self._create_completed_match(client, "1")
+
+        set_auth_cookies(client, creator["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["excluded_from_stats"] is True
+
+        my_matches = await client.get("/api/v1/quick-matches/me")
+        listed = {m["id"]: m for m in my_matches.json()["quick_matches"]}
+        assert quick_match_id in listed
+        assert listed[quick_match_id]["excluded_from_stats"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_flag_belongs_to_whoever_asks(self, client: AsyncClient):
+        """El otro participante ve la misma partida sin marcar."""
+        creator, friend, quick_match_id = await self._create_completed_match(client, "2")
+
+        set_auth_cookies(client, creator["cookies"])
+        await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        set_auth_cookies(client, friend["cookies"])
+        friend_matches = await client.get("/api/v1/quick-matches/me")
+        listed = {m["id"]: m for m in friend_matches.json()["quick_matches"]}
+        assert listed[quick_match_id]["excluded_from_stats"] is False
+
+    @pytest.mark.asyncio
+    async def test_delete_brings_it_back_into_the_stats(self, client: AsyncClient):
+        creator, _friend, quick_match_id = await self._create_completed_match(client, "3")
+
+        set_auth_cookies(client, creator["cookies"])
+        await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+        response = await client.delete(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["excluded_from_stats"] is False
+
+    @pytest.mark.asyncio
+    async def test_excluding_a_match_in_progress_returns_409(self, client: AsyncClient):
+        """Una partida a medias todavia no cuenta en ninguna estadistica."""
+        admin = await create_admin_user(
+            client, "qm_admin_stats4@test.com", "P@ssw0rd123!", "Admin", "Stats"
+        )
+        creator = await create_authenticated_user(
+            client, "qm_creator_stats4@test.com", "P@ssw0rd123!", "Creator", "Stats"
+        )
+        friend = await create_authenticated_user(
+            client, "qm_friend_stats4@test.com", "P@ssw0rd123!", "Friend", "Stats"
+        )
+        golf_course_id = await _create_approved_golf_course(client, admin, creator)
+        await _make_friends(client, creator, friend)
+
+        set_auth_cookies(client, creator["cookies"])
+        create_response = await client.post(
+            "/api/v1/quick-matches",
+            json={"golf_course_id": golf_course_id, "match_format": "SINGLES"},
+        )
+        quick_match_id = create_response.json()["id"]
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/participants",
+            json={"friend_user_id": friend["user"]["id"]},
+        )
+        await client.post(
+            f"/api/v1/quick-matches/{quick_match_id}/start",
+            json={"scorer_ids": [creator["user"]["id"], friend["user"]["id"]]},
+        )
+
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        assert response.status_code == 409, response.text
+
+    @pytest.mark.asyncio
+    async def test_a_stranger_gets_404(self, client: AsyncClient):
+        """
+        Ni toca la partida ni se entera de que existe: se responde lo mismo que
+        para un id inventado, igual que hace la papelera.
+        """
+        _creator, _friend, quick_match_id = await self._create_completed_match(client, "5")
+        outsider = await create_authenticated_user(
+            client, "qm_outsider_stats5@test.com", "P@ssw0rd123!", "Outsider", "Stats"
+        )
+
+        set_auth_cookies(client, outsider["cookies"])
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self, client: AsyncClient):
+        _creator, _friend, quick_match_id = await self._create_completed_match(client, "6")
+
+        client.cookies.clear()
+        response = await client.post(f"/api/v1/quick-matches/{quick_match_id}/stats-exclusion")
+
+        assert response.status_code == 401

--- a/tests/unit/modules/quick_match/application/use_cases/test_quick_match_stats_exclusion_use_cases.py
+++ b/tests/unit/modules/quick_match/application/use_cases/test_quick_match_stats_exclusion_use_cases.py
@@ -1,0 +1,185 @@
+"""Tests para ExcludeQuickMatchFromStatsUseCase e IncludeQuickMatchInStatsUseCase."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.modules.competition.domain.value_objects.match_format import MatchFormat
+from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCourseId
+from src.modules.quick_match.application.dto.quick_match_dto import HideQuickMatchRequestDTO
+from src.modules.quick_match.application.exceptions import QuickMatchNotFoundError
+from src.modules.quick_match.application.use_cases.exclude_quick_match_from_stats_use_case import (
+    ExcludeQuickMatchFromStatsUseCase,
+)
+from src.modules.quick_match.application.use_cases.include_quick_match_in_stats_use_case import (
+    IncludeQuickMatchInStatsUseCase,
+)
+from src.modules.quick_match.domain.entities.quick_match import QuickMatch
+from src.modules.quick_match.domain.exceptions.quick_match_violations import (
+    InvalidQuickMatchStatusViolation,
+    NotQuickMatchParticipantViolation,
+)
+from src.modules.quick_match.domain.value_objects.quick_match_id import QuickMatchId
+from src.modules.quick_match.domain.value_objects.quick_match_participant import (
+    QuickMatchParticipant,
+)
+from src.modules.user.domain.value_objects.user_id import UserId
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_completed_match(qm_uow, creator_id):
+    """Partida terminada con dos jugadores registrados."""
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    other = QuickMatchParticipant.for_user(UserId(uuid4()))
+    qm.add_participant(other)
+    qm.start([qm.creator_participant_id])
+    qm.complete()
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm, other
+
+
+async def _create_in_progress_match(qm_uow, creator_id):
+    qm = QuickMatch.create(
+        id=QuickMatchId.generate(),
+        creator_id=creator_id,
+        golf_course_id=GolfCourseId(uuid4()),
+        match_format=MatchFormat.SINGLES,
+    )
+    qm.add_participant(QuickMatchParticipant.for_user(UserId(uuid4())))
+    qm.start([qm.creator_participant_id])
+    async with qm_uow:
+        await qm_uow.quick_matches.add(qm)
+    return qm
+
+
+class TestExcludeQuickMatchFromStatsUseCase:
+    async def test_creator_can_exclude_a_completed_match(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_stats_excluded_for(qm.creator_participant_id)
+
+    async def test_excluding_does_not_hide_the_match(self, qm_uow, user_uow):
+        """Lo que separa esta marca de ocultar: la partida sigue en el historial."""
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert not stored.is_hidden_for(qm.creator_participant_id)
+        listed = await qm_uow.quick_matches.list_for_user(creator)
+        assert [m.id for m in listed] == [qm.id]
+
+    async def test_any_participant_can_exclude_for_themselves(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, other = await _create_completed_match(qm_uow, creator)
+
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=other.user_id.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert stored.is_stats_excluded_for(other.participant_id)
+        assert not stored.is_stats_excluded_for(qm.creator_participant_id)
+
+    async def test_response_reports_the_flag_for_the_caller_only(self, qm_uow, user_uow):
+        """`excluded_from_stats` responde a QUIEN pregunta, no al estado global."""
+        creator = UserId(uuid4())
+        qm, other = await _create_completed_match(qm_uow, creator)
+
+        exclude = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        response = await exclude.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=other.user_id.value)
+        )
+
+        assert response.excluded_from_stats is True
+
+    async def test_excluding_a_match_in_progress_raises(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm = await _create_in_progress_match(qm_uow, creator)
+
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        with pytest.raises(InvalidQuickMatchStatusViolation):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+            )
+
+    async def test_non_participant_raises(self, qm_uow, user_uow):
+        """
+        Un extraño no puede tocar una partida ajena. Se distingue de "no existe"
+        en el dominio; la ruta traduce las dos a 404 para no confirmar que la
+        partida existe a quien no tiene nada que ver con ella.
+        """
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=uuid4())
+            )
+
+    async def test_not_found_raises(self, qm_uow, user_uow):
+        use_case = ExcludeQuickMatchFromStatsUseCase(qm_uow, user_uow)
+        with pytest.raises(QuickMatchNotFoundError):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=uuid4(), requester_id=uuid4())
+            )
+
+
+class TestIncludeQuickMatchInStatsUseCase:
+    async def test_reverses_a_previous_exclusion(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+        async with qm_uow:
+            await qm_uow.quick_matches.update(qm)
+
+        use_case = IncludeQuickMatchInStatsUseCase(qm_uow, user_uow)
+        response = await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert not stored.is_stats_excluded_for(qm.creator_participant_id)
+        assert response.excluded_from_stats is False
+
+    async def test_is_idempotent(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+
+        use_case = IncludeQuickMatchInStatsUseCase(qm_uow, user_uow)
+        await use_case.execute(
+            HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=creator.value)
+        )
+
+        stored = await qm_uow.quick_matches.find_by_id(qm.id)
+        assert not stored.is_stats_excluded_for(qm.creator_participant_id)
+
+    async def test_non_participant_raises(self, qm_uow, user_uow):
+        creator = UserId(uuid4())
+        qm, _other = await _create_completed_match(qm_uow, creator)
+
+        use_case = IncludeQuickMatchInStatsUseCase(qm_uow, user_uow)
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            await use_case.execute(
+                HideQuickMatchRequestDTO(quick_match_id=qm.id.value, requester_id=uuid4())
+            )

--- a/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
+++ b/tests/unit/modules/quick_match/domain/entities/test_quick_match.py
@@ -31,6 +31,12 @@ from src.modules.quick_match.domain.events.quick_match_participant_removed_event
 from src.modules.quick_match.domain.events.quick_match_started_event import (
     QuickMatchStartedEvent,
 )
+from src.modules.quick_match.domain.events.quick_match_stats_excluded_event import (
+    QuickMatchStatsExcludedEvent,
+)
+from src.modules.quick_match.domain.events.quick_match_stats_included_event import (
+    QuickMatchStatsIncludedEvent,
+)
 from src.modules.quick_match.domain.events.quick_match_unhidden_event import (
     QuickMatchUnhiddenEvent,
 )
@@ -272,6 +278,140 @@ class TestQuickMatchRemoveParticipant:
         qm.start([qm.creator_participant_id])
         with pytest.raises(InvalidQuickMatchStatusViolation):
             qm.remove_participant(other.participant_id)
+
+
+def _completed_quick_match():
+    """Partida terminada con dos jugadores: el estado que exige el ojo."""
+    qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+    other = _registered()
+    qm.add_participant(other)
+    qm.start([qm.creator_participant_id])
+    qm.complete()
+    return qm, other
+
+
+class TestQuickMatchStatsExclusion:
+    """
+    El ojo: la partida no cuenta en MIS estadisticas pero sigue en mi historial.
+
+    Es otra marca distinta de ocultar, que si la saca de la lista y es
+    definitiva. Antes las dos cosas eran una sola (BE #242).
+    """
+
+    def test_exclude_from_stats_succeeds_on_a_completed_match(self):
+        qm, _ = _completed_quick_match()
+        qm.clear_domain_events()
+
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+
+        assert qm.is_stats_excluded_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchStatsExcludedEvent)
+
+    def test_exclude_from_stats_does_not_hide_the_match(self):
+        """Lo que distingue esta marca de ocultar: la partida se sigue viendo."""
+        qm, _ = _completed_quick_match()
+
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+
+        assert not qm.is_hidden_for(qm.creator_participant_id)
+
+    def test_exclude_from_stats_is_personal(self):
+        """Una partida que A excluye sigue contando para B."""
+        qm, other = _completed_quick_match()
+
+        qm.exclude_from_stats_for(other.participant_id)
+
+        assert qm.is_stats_excluded_for(other.participant_id)
+        assert not qm.is_stats_excluded_for(qm.creator_participant_id)
+
+    def test_exclude_from_stats_requires_a_completed_match(self):
+        """
+        Una partida a medias todavia no cuenta en ninguna estadistica, asi que
+        la marca no diria nada: seria una promesa sobre el futuro.
+        """
+        qm = _make_quick_match(match_format=MatchFormat.SINGLES)
+        qm.add_participant(_registered())
+        qm.start([qm.creator_participant_id])
+
+        with pytest.raises(InvalidQuickMatchStatusViolation):
+            qm.exclude_from_stats_for(qm.creator_participant_id)
+
+    def test_exclude_from_stats_for_non_participant_raises(self):
+        qm, _ = _completed_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.exclude_from_stats_for(ParticipantId.generate())
+
+    def test_exclude_from_stats_is_idempotent(self):
+        qm, _ = _completed_quick_match()
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+
+        assert qm.is_stats_excluded_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_include_in_stats_reverses_the_exclusion(self):
+        qm, _ = _completed_quick_match()
+        qm.exclude_from_stats_for(qm.creator_participant_id)
+        qm.clear_domain_events()
+
+        qm.include_in_stats_for(qm.creator_participant_id)
+
+        assert not qm.is_stats_excluded_for(qm.creator_participant_id)
+        events = qm.get_domain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], QuickMatchStatsIncludedEvent)
+
+    def test_include_in_stats_does_not_require_a_completed_match(self):
+        """
+        Quitar la marca siempre es seguro, y la migracion que separo ocultar de
+        excluir pudo dejar alguna en una partida sin terminar: exigir COMPLETED
+        aqui la dejaria sin forma de quitarse.
+        """
+        # Se construye la entidad con la marca puesta y la partida sin
+        # terminar, que es justo la fila que puede dejar la migracion: la
+        # marca vieja se traspaso sin mirar el estado.
+        creator = _registered()
+        qm = QuickMatch(
+            id=QuickMatchId.generate(),
+            creator_id=UserId(creator.participant_id.value),
+            golf_course_id=GolfCourseId(uuid4()),
+            match_format=MatchFormat.SINGLES,
+            status=QuickMatchStatus.IN_PROGRESS,
+            participants=[creator],
+            stats_excluded_by_participant_ids=[creator.participant_id],
+        )
+        assert qm.is_stats_excluded_for(creator.participant_id)
+
+        qm.include_in_stats_for(creator.participant_id)
+
+        assert not qm.is_stats_excluded_for(creator.participant_id)
+
+    def test_include_in_stats_for_non_participant_raises(self):
+        qm, _ = _completed_quick_match()
+        with pytest.raises(NotQuickMatchParticipantViolation):
+            qm.include_in_stats_for(ParticipantId.generate())
+
+    def test_include_in_stats_is_idempotent(self):
+        qm, _ = _completed_quick_match()
+        qm.clear_domain_events()
+
+        qm.include_in_stats_for(qm.creator_participant_id)
+
+        assert not qm.is_stats_excluded_for(qm.creator_participant_id)
+        assert qm.get_domain_events() == []
+
+    def test_hiding_and_excluding_are_independent_marks(self):
+        """La prueba de que se han separado de verdad."""
+        qm, _ = _completed_quick_match()
+
+        qm.hide_for(qm.creator_participant_id)
+
+        assert qm.is_hidden_for(qm.creator_participant_id)
+        assert not qm.is_stats_excluded_for(qm.creator_participant_id)
 
 
 class TestQuickMatchHideForHistory:

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -911,6 +911,81 @@ class TestHiddenMatches:
         assert (await use_case.execute(other.id)).rounds_played == 1
 
 
+@pytest.mark.asyncio
+class TestMatchesLeftOutOfStats:
+    """
+    El ojo (BE #242): la partida sigue en el historial pero no cuenta aqui.
+
+    Estas pruebas son la red del cambio que separo ocultar de excluir. Antes,
+    las estadisticas se apoyaban en que el listado del historial ya descartaba
+    lo oculto; al hacer que ese listado devuelva las excluidas —para poder
+    pintarlas marcadas— bastaba con no tocar nada mas para que volvieran a
+    contar en la media, sin que fallara ni un test ni saltara ningun error.
+    """
+
+    async def test_a_match_left_out_by_the_caller_does_not_count_for_them(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("excluder"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        match = await _played_quick_match(qm_uow, course, user)
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.exclude_from_stats_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        stats = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            user.id
+        )
+
+        assert stats.rounds_played == 0
+        assert stats.scoring_avg is None
+        assert stats.best_differential is None
+
+    async def test_the_match_is_still_in_the_history(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """La diferencia con ocultar: no cuenta, pero se sigue viendo."""
+        user = await create_user(user_uow, unique_email("excluder"), handicap=0)
+        course = await create_golf_course(golf_course_uow, user.id)
+        match = await _played_quick_match(qm_uow, course, user)
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.exclude_from_stats_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+            listed = await qm_uow.quick_matches.list_for_user(user.id)
+
+        assert [m.id for m in listed] == [match.id]
+
+    async def test_it_still_counts_for_the_other_participant(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Es una marca personal: nadie puede alterar las estadisticas ajenas."""
+        excluder = await create_user(user_uow, unique_email("excluder"), handicap=0)
+        other = await create_user(user_uow, unique_email("other"), handicap=0)
+        course = await create_golf_course(golf_course_uow, excluder.id)
+        other_participant = QuickMatchParticipant.for_user(other.id)
+        match = await _played_quick_match(
+            qm_uow, course, excluder, others=[other_participant]
+        )
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.exclude_from_stats_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        assert (await use_case.execute(excluder.id)).rounds_played == 0
+        assert (await use_case.execute(other.id)).rounds_played == 1
+
+
 class TestScoreDifferentials:
     """
     Score Differentials y el índice estimado (BE #167).

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -994,6 +994,72 @@ class TestHiddenMatches:
 
 
 @pytest.mark.asyncio
+class TestMatchesLeftOutOfStats:
+    """
+    El ojo (BE #242): fuera de las estadisticas, pero DENTRO del historial.
+
+    Justo lo contrario que ocultar. Si esta lista se limitara a no enseñarlas,
+    el resumen de arriba diria cero vueltas y debajo no habria nada que
+    explicara por que; y si las enseñara sin marca, la contradiccion seria peor
+    todavia: una vuelta a la vista que el resumen no cuenta.
+    """
+
+    async def test_the_match_stays_in_the_feed_flagged(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Excluder", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        match = await played_quick_match(qm_uow, course, player)
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.exclude_from_stats_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert len(feed.matches) == 1
+        assert feed.matches[0].excluded_from_stats is True
+
+    async def test_a_match_that_counts_is_not_flagged(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Counter", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_quick_match(qm_uow, course, player)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].excluded_from_stats is False
+
+    async def test_the_flag_is_personal(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        excluder = await create_user(user_uow, "Excluder", handicap=0)
+        other = await create_user(user_uow, "Other", handicap=0)
+        course = await create_golf_course(golf_course_uow, excluder.id)
+        match = await played_quick_match(
+            qm_uow, course, excluder, others=[QuickMatchParticipant.for_user(other.id)]
+        )
+
+        async with qm_uow:
+            stored = await qm_uow.quick_matches.find_by_id(match.id)
+            stored.exclude_from_stats_for(stored.participants[0].participant_id)
+            await qm_uow.quick_matches.update(stored)
+            await qm_uow.commit()
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+
+        assert (await use_case.execute(excluder.id)).matches[0].excluded_from_stats is True
+        assert (await use_case.execute(other.id)).matches[0].excluded_from_stats is False
+
+
+@pytest.mark.asyncio
 class TestComparableFigures:
     """
     Golpes, hoyos y puntos Stableford en cualquier formato (FE #306).


### PR DESCRIPTION
Release v2.12.0 del backend.

## Qué sale

**El ojo de las partidas rápidas** (BE #242, PR #243): ocultar una partida y dejarla fuera de tus estadísticas pasan a ser dos marcas independientes. La papelera sigue siendo definitiva; la marca nueva deja la partida en la lista y se puede levantar.

## Orden de despliegue

**Este backend va PRIMERO**, y el frontend (FE v2.16.0) inmediatamente después, sin nada en medio. La migración `f1a4c86d2e59` hace **reaparecer en el historial las partidas ocultadas con la papelera vieja**, marcadas como que no cuentan; el frontend actual todavía no sabe pintar esa marca, así que durante esa ventana las mostraría sin distintivo alguno.

## Verificación

El contenido ya se revisó en la PR #243 y se comprobó en navegador contra el clúster local, junto al frontend que lo consume: marca y desmarca con las estadísticas moviéndose de ida y vuelta, la partida quedándose en la lista, y la papelera con su aviso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7E5pEDXHoUiJZL72B6AZx