### PR TITLE
feat(user): Add a unique public alias to the profile

### DIFF
--- a/alembic/versions/c8e1d5b73f92_add_alias_to_users.py
+++ b/alembic/versions/c8e1d5b73f92_add_alias_to_users.py
@@ -1,0 +1,50 @@
+"""add alias to users
+
+El alias es el apodo publico con el que la aplicacion pinta a una persona en
+lugar de su nombre real (BE #239). Es opcional: sin alias se sigue enseñando
+el nombre completo.
+
+Es UNICO entre todos los usuarios ignorando mayusculas, que es una decision de
+producto: dos cuentas llamadas «Chuchi» harian inutil el alias para encontrar
+gente y trivial hacerse pasar por otro.
+
+El indice es funcional —sobre LOWER(alias)— y parcial —solo donde hay alias—.
+Lo segundo hace falta porque en Postgres los NULL no colisionan entre si en un
+indice unico, pero un indice funcional sobre LOWER(NULL) tampoco aporta nada:
+se deja fuera para que no ocupe ni se recorra.
+
+No hay relleno de datos: las cuentas existentes se quedan con alias NULL, que
+significa «usa mi nombre real».
+
+Revision ID: c8e1d5b73f92
+Revises: f1a4c86d2e59
+Create Date: 2026-08-31
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8e1d5b73f92"
+down_revision = "f1a4c86d2e59"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("alias", sa.String(length=20), nullable=True))
+
+    op.create_index(
+        "ix_users_alias_lower",
+        "users",
+        [sa.text("LOWER(alias)")],
+        unique=True,
+        postgresql_where=sa.text("alias IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_alias_lower", table_name="users")
+    op.drop_column("users", "alias")

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -405,9 +405,11 @@ class UpdateProfileRequestDTO(BaseModel):
     )
     alias: str | None = Field(
         None,
+        max_length=FieldLimits.ALIAS_MAX_LENGTH,
         description=(
             "Nuevo alias público. Enviar cadena vacía lo borra y devuelve al "
-            "usuario a su nombre real. Omitir el campo lo deja como está."
+            "usuario a su nombre real. Omitir el campo —o mandarlo a null— lo "
+            "deja como está."
         ),
     )
 
@@ -426,19 +428,21 @@ class UpdateProfileRequestDTO(BaseModel):
         if v.strip() == "":
             return ""
 
-        sanitized = sanitize_html(v)
-        if not sanitized:
-            raise ValueError("alias no puede estar vacío")
+        # El formato se valida ANTES de sanear, y sobre lo que la persona
+        # escribió. Al revés, `Chuchi & Co` salía de `sanitize_html` como
+        # `Chuchi &amp; Co` y se rechazaba con un «no puede contener HTML» que
+        # no era verdad: lo que sobra ahí es el `&`, y eso ya lo dice el
+        # mensaje de los caracteres permitidos
+        validated = AliasValidator.validate(v, field_name="alias")
 
-        # Al contrario que en el nombre, aquí NO vale con sanear y seguir. El
-        # alias es único y es lo que otra gente teclea para encontrarte: si
-        # `Chu<b>chi` se guardara en silencio como `Chuchi`, quien lo pidió
-        # acabaría con un alias que no es el que escribió. Si el saneado ha
-        # cambiado algo, se dice
-        if sanitized != " ".join(v.split()):
+        # Cinturón: la lista de caracteres permitidos ya deja fuera `<`, `>` y
+        # `&`, así que esto no deberia disparar nunca. Si algun dia se ampliara
+        # esa lista, mejor un rechazo que guardar en silencio algo distinto de
+        # lo que se pidió: el alias es único y es lo que otros teclean
+        if sanitize_html(validated) != validated:
             raise ValueError("alias no puede contener HTML")
 
-        return AliasValidator.validate(sanitized, field_name="alias")
+        return validated
 
     @field_validator("first_name", "last_name")
     @classmethod
@@ -459,8 +463,13 @@ class UpdateProfileRequestDTO(BaseModel):
         """Valida que se proporcione al menos un campo."""
         # El alias se mira por si VINO en la petición, no por su valor: mandar
         # `alias: ""` es una petición legítima —«quítame el alias»— y con la
-        # comprobación por valor se leía como «no has mandado nada»
-        alias_provided = "alias" in self.model_fields_set
+        # comprobación por valor se leía como «no has mandado nada».
+        #
+        # `null` NO cuenta, igual que en el resto de campos de este endpoint,
+        # donde `"last_name": null` significa «no lo toques». Sin esto,
+        # `{"alias": null}` a secas pasaba el DTO y reventaba mas adentro, en
+        # la entidad, con un 400 y un mensaje en ingles
+        alias_provided = "alias" in self.model_fields_set and self.alias is not None
         if (
             not self.first_name
             and not self.last_name

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 from src.shared.application.validation import (
+    AliasValidator,
     FieldLimits,
     NameValidator,
     sanitize_html,
@@ -179,6 +180,13 @@ class UserResponseDTO(BaseModel):
     email: EmailStr = Field(..., description=EMAIL_DESCRIPTION)
     first_name: str = Field(..., description="Nombre del usuario.")
     last_name: str = Field(..., description="Apellido del usuario.")
+    alias: str | None = Field(
+        None,
+        description=(
+            "Apodo público con el que la aplicación muestra a este usuario. "
+            "Null si no ha puesto ninguno, y entonces se muestra su nombre real."
+        ),
+    )
     country_code: str | None = Field(None, description="Código ISO del país (2 letras, ej: 'ES').")
     handicap: float | None = Field(None, description="Handicap de golf del usuario.")
     handicap_updated_at: datetime | None = Field(
@@ -395,6 +403,42 @@ class UpdateProfileRequestDTO(BaseModel):
         pattern="^(MALE|FEMALE)$",
         description="Nuevo género del usuario (MALE/FEMALE). Opcional.",
     )
+    alias: str | None = Field(
+        None,
+        description=(
+            "Nuevo alias público. Enviar cadena vacía lo borra y devuelve al "
+            "usuario a su nombre real. Omitir el campo lo deja como está."
+        ),
+    )
+
+    @field_validator("alias")
+    @classmethod
+    def sanitize_and_validate_alias(cls, v: str | None) -> str | None:
+        """
+        Sanitiza y valida el alias.
+
+        La cadena vacía NO se valida: es la forma de pedir que se borre, y se
+        deja pasar tal cual para que la entidad la traduzca a NULL.
+        """
+        if v is None:
+            return None
+
+        if v.strip() == "":
+            return ""
+
+        sanitized = sanitize_html(v)
+        if not sanitized:
+            raise ValueError("alias no puede estar vacío")
+
+        # Al contrario que en el nombre, aquí NO vale con sanear y seguir. El
+        # alias es único y es lo que otra gente teclea para encontrarte: si
+        # `Chu<b>chi` se guardara en silencio como `Chuchi`, quien lo pidió
+        # acabaría con un alias que no es el que escribió. Si el saneado ha
+        # cambiado algo, se dice
+        if sanitized != " ".join(v.split()):
+            raise ValueError("alias no puede contener HTML")
+
+        return AliasValidator.validate(sanitized, field_name="alias")
 
     @field_validator("first_name", "last_name")
     @classmethod
@@ -413,9 +457,20 @@ class UpdateProfileRequestDTO(BaseModel):
 
     def model_post_init(self, __context) -> None:
         """Valida que se proporcione al menos un campo."""
-        if not self.first_name and not self.last_name and not self.country_code and not self.gender:
+        # El alias se mira por si VINO en la petición, no por su valor: mandar
+        # `alias: ""` es una petición legítima —«quítame el alias»— y con la
+        # comprobación por valor se leía como «no has mandado nada»
+        alias_provided = "alias" in self.model_fields_set
+        if (
+            not self.first_name
+            and not self.last_name
+            and not self.country_code
+            and not self.gender
+            and not alias_provided
+        ):
             raise ValueError(
-                "Debe proporcionar al menos 'first_name', 'last_name', 'country_code' o 'gender'."
+                "Debe proporcionar al menos 'first_name', 'last_name', 'country_code', "
+                "'gender' o 'alias'."
             )
 
 

--- a/src/modules/user/application/use_cases/update_profile_use_case.py
+++ b/src/modules/user/application/use_cases/update_profile_use_case.py
@@ -5,12 +5,17 @@ Caso de uso para actualizar la información personal de un usuario (nombre y ape
 NO requiere validación de contraseña, solo autenticación JWT.
 """
 
+from sqlalchemy.exc import IntegrityError
+
 from src.modules.user.application.dto.user_dto import (
     UpdateProfileRequestDTO,
     UpdateProfileResponseDTO,
     UserResponseDTO,
 )
-from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.errors.user_errors import (
+    AliasAlreadyTakenError,
+    UserNotFoundError,
+)
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
@@ -59,34 +64,59 @@ class UpdateProfileUseCase:
 
         Raises:
             UserNotFoundError: Si el usuario no existe
+            AliasAlreadyTakenError: Si el alias pedido ya lo tiene otra persona
             ValueError: Si los datos no son válidos
         """
-        async with self._uow:
-            # Buscar usuario
-            user_id_vo = UserId(user_id)
-            user = await self._uow.users.find_by_id(user_id_vo)
-            if not user:
-                raise UserNotFoundError(f"User with id {user_id} not found")
+        try:
+            async with self._uow:
+                # Buscar usuario
+                user_id_vo = UserId(user_id)
+                user = await self._uow.users.find_by_id(user_id_vo)
+                if not user:
+                    raise UserNotFoundError(f"User with id {user_id} not found")
 
-            # Validar que el country_code existe (si se proporcionó)
-            if request.country_code:
-                country_code_vo = CountryCode(request.country_code)
-                country_exists = await self._country_repository.exists(country_code_vo)
-                if not country_exists:
-                    raise ValueError(f"El código de país '{request.country_code}' no es válido.")
+                # Validar que el country_code existe (si se proporcionó)
+                if request.country_code:
+                    country_code_vo = CountryCode(request.country_code)
+                    country_exists = await self._country_repository.exists(country_code_vo)
+                    if not country_exists:
+                        raise ValueError(
+                            f"El código de país '{request.country_code}' no es válido."
+                        )
 
-            # Actualizar perfil (entity valida y emite eventos)
-            user.update_profile(
-                first_name=request.first_name,
-                last_name=request.last_name,
-                country_code_str=request.country_code,
-                gender=request.gender,
-            )
+                # Alias libre. La cadena vacía es "quítamelo", y ahí no hay nada
+                # que comprobar. Que el alias siga siendo el suyo tampoco es
+                # conflicto: cambiar solo las mayúsculas debe poder hacerse
+                if request.alias:
+                    owner = await self._uow.users.find_by_alias(request.alias)
+                    if owner and owner.id != user.id:
+                        raise AliasAlreadyTakenError(
+                            f"El alias '{request.alias}' ya está en uso."
+                        )
 
-            # Guardar cambios
-            await self._uow.users.save(user)
+                # Actualizar perfil (entity valida y emite eventos)
+                user.update_profile(
+                    first_name=request.first_name,
+                    last_name=request.last_name,
+                    country_code_str=request.country_code,
+                    gender=request.gender,
+                    alias=request.alias,
+                )
 
-            # Context manager hace commit automático y publica eventos
+                # Guardar cambios
+                await self._uow.users.save(user)
+
+                # Context manager hace commit automático y publica eventos
+        except IntegrityError as e:
+            # La comprobación de arriba no basta: entre ella y el commit cabe
+            # otra petición pidiendo el mismo alias, y quien lo resuelve de
+            # verdad es el índice único. Solo se traduce SU violación;
+            # cualquier otra se deja subir como está
+            if "ix_users_alias_lower" in str(e.orig):
+                raise AliasAlreadyTakenError(
+                    f"El alias '{request.alias}' ya está en uso."
+                ) from e
+            raise
 
         # Construir respuesta
         return UpdateProfileResponseDTO(

--- a/src/modules/user/domain/entities/user.py
+++ b/src/modules/user/domain/entities/user.py
@@ -45,17 +45,28 @@ class User:
     y participar en torneos Ryder Cup.
     """
 
-    def _validate_profile_update(self, first_name, last_name, country_code_str, gender_str=None):
-        if first_name is None and last_name is None and country_code_str is None and gender_str is None:
+    def _validate_profile_update(
+        self, first_name, last_name, country_code_str, gender_str=None, alias=None
+    ):
+        if (
+            first_name is None
+            and last_name is None
+            and country_code_str is None
+            and gender_str is None
+            and alias is None
+        ):
             raise ValueError(
-                "At least one field (first_name, last_name, country_code, or gender) must be provided"
+                "At least one field (first_name, last_name, country_code, gender or alias) "
+                "must be provided"
             )
         if first_name is not None and first_name.strip() == "":
             raise ValueError("first_name cannot be empty")
         if last_name is not None and last_name.strip() == "":
             raise ValueError("last_name cannot be empty")
 
-    def _detect_profile_changes(self, first_name, last_name, country_code_str, gender_str=None):
+    def _detect_profile_changes(
+        self, first_name, last_name, country_code_str, gender_str=None, alias=None
+    ):
         old_first_name = self.first_name
         old_last_name = self.last_name
         old_country_code = self.country_code
@@ -72,16 +83,28 @@ class User:
         if gender_str is not None:
             new_gender = Gender(gender_str) if gender_str else None
             gender_changed = new_gender != old_gender
+        # Mismo convenio que country_code y gender: `None` es "no lo han
+        # mandado" y la cadena vacía es "quítamelo". Sin esa distinción no
+        # habría forma de volver al nombre real una vez puesto un alias
+        old_alias = self.alias
+        new_alias = old_alias
+        alias_changed = False
+        if alias is not None:
+            new_alias = alias or None
+            alias_changed = new_alias != old_alias
         return (
             first_name_changed,
             last_name_changed,
             country_code_changed,
             gender_changed,
+            alias_changed,
             new_country_code,
             new_gender,
+            new_alias,
             old_first_name,
             old_last_name,
             old_country_code,
+            old_alias,
         )
 
     def __init__(
@@ -91,6 +114,7 @@ class User:
         password: Password | None,
         first_name: str,
         last_name: str,
+        alias: str | None = None,
         handicap: Handicap | None = None,
         handicap_updated_at: datetime | None = None,
         created_at: datetime | None = None,
@@ -118,6 +142,7 @@ class User:
         self._password = password
         self._first_name = first_name
         self._last_name = last_name
+        self._alias = alias
         self._handicap = handicap
         self._handicap_updated_at = handicap_updated_at
         self._created_at = created_at or datetime.now()
@@ -162,6 +187,11 @@ class User:
     @property
     def last_name(self) -> str:
         return self._last_name
+
+    @property
+    def alias(self) -> str | None:
+        """El apodo público, o None si esta persona no ha puesto ninguno."""
+        return self._alias
 
     @property
     def handicap(self) -> Handicap | None:
@@ -291,8 +321,27 @@ class User:
         self._updated_at = datetime.now()
 
     def get_full_name(self) -> str:
-        """Devuelve el nombre completo del usuario."""
+        """
+        Devuelve el nombre LEGAL del usuario.
+
+        No mira el alias a propósito: la búsqueda de hándicap en la RFEG y los
+        correos transaccionales van por aquí, y la federación busca por el
+        nombre con el que uno está federado. Para enseñar a alguien por
+        pantalla, `display_name`.
+        """
         return f"{self.first_name} {self.last_name}".strip()
+
+    @property
+    def display_name(self) -> str:
+        """
+        El nombre con el que la aplicación pinta a esta persona: su alias si
+        lo tiene, y si no su nombre completo.
+
+        Este es el ÚNICO sitio donde vive ese fallback. El backend lo resuelve
+        y lo manda ya resuelto para que el frontend no reparta `alias || nombre`
+        por cada pantalla.
+        """
+        return self._alias or self.get_full_name()
 
     def has_valid_email(self) -> bool:
         """Verifica si el usuario tiene un email válido."""
@@ -590,26 +639,41 @@ class User:
         last_name: str | None = None,
         country_code_str: str | None = None,
         gender: str | None = None,
+        alias: str | None = None,
     ) -> None:
         """
-        Actualiza la información personal del usuario (nombre, apellidos, país y género).
+        Actualiza la información personal del usuario (nombre, apellidos, país,
+        género y alias).
         Solo emite evento si al menos uno de los campos cambió.
         El evento ahora incluye el cambio de country_code (old/new) si aplica.
+
+        El alias sigue el convenio de country_code y gender: `None` significa
+        "no se ha enviado" y la cadena vacía "quítamelo", que devuelve al
+        usuario a su nombre real.
         """
-        self._validate_profile_update(first_name, last_name, country_code_str, gender)
+        self._validate_profile_update(first_name, last_name, country_code_str, gender, alias)
         (
             first_name_changed,
             last_name_changed,
             country_code_changed,
             gender_changed,
+            alias_changed,
             new_country_code,
             new_gender,
+            new_alias,
             old_first_name,
             old_last_name,
             _old_country_code,
-        ) = self._detect_profile_changes(first_name, last_name, country_code_str, gender)
+            old_alias,
+        ) = self._detect_profile_changes(first_name, last_name, country_code_str, gender, alias)
 
-        if not first_name_changed and not last_name_changed and not country_code_changed and not gender_changed:
+        if (
+            not first_name_changed
+            and not last_name_changed
+            and not country_code_changed
+            and not gender_changed
+            and not alias_changed
+        ):
             return
 
         if first_name_changed:
@@ -620,6 +684,8 @@ class User:
             self._country_code = new_country_code
         if gender_changed:
             self._gender = new_gender
+        if alias_changed:
+            self._alias = new_alias
 
         self._updated_at = datetime.now()
 
@@ -630,6 +696,8 @@ class User:
                 new_first_name=first_name if first_name_changed else None,
                 old_last_name=old_last_name if last_name_changed else None,
                 new_last_name=last_name if last_name_changed else None,
+                old_alias=old_alias if alias_changed else None,
+                new_alias=new_alias if alias_changed else None,
                 updated_at=self.updated_at,
             )
         )

--- a/src/modules/user/domain/errors/user_errors.py
+++ b/src/modules/user/domain/errors/user_errors.py
@@ -65,6 +65,18 @@ class DuplicateEmailError(UserDomainError):
     pass
 
 
+class AliasAlreadyTakenError(UserDomainError):
+    """
+    Excepción lanzada cuando el alias pedido ya lo tiene otra persona.
+
+    La comparación ignora mayúsculas: "chuchi" y "Chuchi" son el mismo alias.
+    Llega a la API como un 409 con un mensaje que el frontend enseña tal cual
+    junto al campo.
+    """
+
+    pass
+
+
 class InvalidCredentialsError(UserDomainError):
     """
     Excepción lanzada cuando las credenciales proporcionadas son inválidas.

--- a/src/modules/user/domain/events/user_profile_updated_event.py
+++ b/src/modules/user/domain/events/user_profile_updated_event.py
@@ -25,6 +25,8 @@ class UserProfileUpdatedEvent(DomainEvent):
         new_first_name: Nuevo nombre (puede ser None si no cambió)
         old_last_name: Apellido anterior (puede ser None si no cambió)
         new_last_name: Nuevo apellido (puede ser None si no cambió)
+        old_alias: Alias anterior (None si no cambió, y también si no tenía)
+        new_alias: Nuevo alias (None si no cambió, y también si lo ha quitado)
         updated_at: Timestamp de la actualización
     """
 
@@ -39,6 +41,8 @@ class UserProfileUpdatedEvent(DomainEvent):
     new_last_name: str | None = None
     old_country_code: str | None = None
     new_country_code: str | None = None
+    old_alias: str | None = None
+    new_alias: str | None = None
 
     @property
     def aggregate_id(self) -> str:
@@ -54,6 +58,11 @@ class UserProfileUpdatedEvent(DomainEvent):
     def has_last_name_change(self) -> bool:
         """Verifica si el apellido cambió."""
         return self.old_last_name != self.new_last_name
+
+    @property
+    def has_alias_change(self) -> bool:
+        """Verifica si el alias cambió."""
+        return self.old_alias != self.new_alias
 
     def to_dict(self) -> dict:
         """
@@ -74,6 +83,11 @@ class UserProfileUpdatedEvent(DomainEvent):
                         "old": self.old_last_name,
                         "new": self.new_last_name,
                         "changed": self.has_last_name_change,
+                    },
+                    "alias": {
+                        "old": self.old_alias,
+                        "new": self.new_alias,
+                        "changed": self.has_alias_change,
                     },
                 },
                 "updated_at": self.updated_at.isoformat(),

--- a/src/modules/user/domain/repositories/user_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_repository_interface.py
@@ -121,6 +121,26 @@ class UserRepositoryInterface(ABC):
         pass
 
     @abstractmethod
+    async def find_by_alias(self, alias: str) -> User | None:
+        """
+        Busca un usuario por su alias, ignorando mayúsculas.
+
+        Es la consulta con la que se comprueba si un alias está libre antes de
+        guardarlo. No sustituye al índice único de la base de datos: entre esta
+        consulta y el commit cabe otra petición pidiendo el mismo alias.
+
+        Args:
+            alias (str): El alias a buscar
+
+        Returns:
+            Optional[User]: El usuario que lo tiene, o None si está libre
+
+        Raises:
+            RepositoryError: Si ocurre un error de consulta
+        """
+        pass
+
+    @abstractmethod
     async def find_by_full_name(self, full_name: str) -> User | None:
         """
         Busca un usuario por su nombre completo (first_name + last_name).

--- a/src/modules/user/infrastructure/api/v1/user_routes.py
+++ b/src/modules/user/infrastructure/api/v1/user_routes.py
@@ -48,6 +48,7 @@ from src.modules.user.application.use_cases.update_security_use_case import (
     UpdateSecurityUseCase,
 )
 from src.modules.user.domain.errors.user_errors import (
+    AliasAlreadyTakenError,
     DuplicateEmailError,
     InvalidCredentialsError,
     UserNotFoundError,
@@ -148,8 +149,14 @@ async def find_user(
     response_model=UpdateProfileResponseDTO,
     status_code=status.HTTP_200_OK,
     summary="Actualizar perfil del usuario",
-    description="Actualiza la información personal del usuario autenticado (nombre, apellidos y/o país).",
+    description=(
+        "Actualiza la información personal del usuario autenticado: nombre, apellidos, "
+        "país, género y/o alias. Devuelve 409 si el alias pedido ya lo tiene otra persona."
+    ),
     tags=["Users"],
+    responses={
+        status.HTTP_409_CONFLICT: {"description": "El alias ya está en uso por otro usuario."},
+    },
 )
 async def update_profile(
     request: UpdateProfileRequestDTO,
@@ -163,8 +170,11 @@ async def update_profile(
     - Nombre (first_name)
     - Apellidos (last_name)
     - Código de país (country_code) - ISO 3166-1 alpha-2
+    - Género (gender)
+    - Alias (alias) - apodo público, único entre todos los usuarios
 
     Al menos uno de los campos debe ser proporcionado.
+    Enviar `alias` como cadena vacía lo borra y devuelve al usuario a su nombre real.
     NO requiere contraseña actual (solo autenticación JWT).
     """
     try:
@@ -176,6 +186,13 @@ async def update_profile(
     except UserNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except AliasAlreadyTakenError as e:
+        # 409 y no 400: la petición es correcta, lo que pasa es que otra
+        # persona llegó antes. El mensaje va tal cual al campo del formulario
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
             detail=str(e),
         ) from e
     except ValueError as e:

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
@@ -1,4 +1,5 @@
 from src.modules.user.domain.entities.user import User
+from src.modules.user.domain.errors.user_errors import AliasAlreadyTakenError
 from src.modules.user.domain.repositories.user_repository_interface import (
     UserRepositoryInterface,
 )
@@ -15,6 +16,7 @@ class InMemoryUserRepository(UserRepositoryInterface):
         self._users: dict[UserId, User] = {}
 
     async def save(self, user: User) -> None:
+        self._guard_alias_is_free(user)
         self._users[user.id] = user
 
     async def find_by_id(self, user_id: UserId) -> User | None:
@@ -32,6 +34,30 @@ class InMemoryUserRepository(UserRepositoryInterface):
             if user.email == email:
                 return user
         return None
+
+    async def find_by_alias(self, alias: str) -> User | None:
+        normalized = alias.strip().lower()
+        if not normalized:
+            return None
+        for user in self._users.values():
+            if user.alias and user.alias.lower() == normalized:
+                return user
+        return None
+
+    def _guard_alias_is_free(self, user: User) -> None:
+        """
+        Impone la misma unicidad que el índice de la base de datos.
+
+        Sin esto, un caso de uso podría guardar dos veces el mismo alias en los
+        tests unitarios y pasar, contradiciendo lo que hace el repositorio real
+        en producción.
+        """
+        if not user.alias:
+            return
+        alias_lower = user.alias.lower()
+        for other in self._users.values():
+            if other.id != user.id and other.alias and other.alias.lower() == alias_lower:
+                raise AliasAlreadyTakenError(f"El alias '{user.alias}' ya está en uso.")
 
     def _matches_search(self, user: User, search: str | None) -> bool:
         if not search or not search.strip():
@@ -101,6 +127,7 @@ class InMemoryUserRepository(UserRepositoryInterface):
 
     async def update(self, user: User) -> None:
         if user.id in self._users:
+            self._guard_alias_is_free(user)
             self._users[user.id] = user
 
     async def find_by_full_name(self, full_name: str) -> User | None:

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -7,9 +7,11 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Table,
+    func,
     inspect,
 )
 from sqlalchemy.exc import NoInspectionAvailable
@@ -147,9 +149,7 @@ users_table = Table(
     Column("id", UserIdDecorator, primary_key=True),
     Column("first_name", String(50), nullable=False),
     Column("last_name", String(50), nullable=False),
-    # Apodo publico, opcional. La unicidad NO se declara aqui: es un indice
-    # unico funcional sobre LOWER(alias) y parcial (solo donde hay alias),
-    # que se crea en la migracion porque SQLAlchemy no lo expresa en Column
+    # Apodo publico, opcional. Su unicidad es un indice aparte, justo debajo
     Column("alias", String(20), nullable=True),
     Column("email", String(255), nullable=False, unique=True),
     Column("password", String(255), nullable=True),  # Nullable for OAuth-only users
@@ -198,6 +198,21 @@ users_table = Table(
         ),
         nullable=True,
     ),
+)
+
+
+# Unicidad del alias ignorando mayusculas. Va en los METADATOS y no solo en la
+# migracion a proposito: el esquema de los tests se construye con
+# `metadata.create_all`, asi que un indice que viviera solo en la migracion no
+# existiria en ningun test y la suite entera daria por buena una duplicidad que
+# en produccion revienta. Es funcional —sobre LOWER(alias)— y parcial —solo
+# donde hay alias—: en Postgres los NULL no chocan entre si, asi que indexarlos
+# no aportaria nada
+Index(
+    "ix_users_alias_lower",
+    func.lower(users_table.c.alias),
+    unique=True,
+    postgresql_where=users_table.c.alias.isnot(None),
 )
 
 

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/mappers.py
@@ -147,6 +147,10 @@ users_table = Table(
     Column("id", UserIdDecorator, primary_key=True),
     Column("first_name", String(50), nullable=False),
     Column("last_name", String(50), nullable=False),
+    # Apodo publico, opcional. La unicidad NO se declara aqui: es un indice
+    # unico funcional sobre LOWER(alias) y parcial (solo donde hay alias),
+    # que se crea en la migracion porque SQLAlchemy no lo expresa en Column
+    Column("alias", String(20), nullable=True),
     Column("email", String(255), nullable=False, unique=True),
     Column("password", String(255), nullable=True),  # Nullable for OAuth-only users
     Column("handicap", HandicapDecorator, nullable=True),
@@ -216,6 +220,7 @@ def start_mappers():
                 "_id": users_table.c.id,
                 "_first_name": users_table.c.first_name,
                 "_last_name": users_table.c.last_name,
+                "_alias": users_table.c.alias,
                 "_handicap": users_table.c.handicap,
                 "_handicap_updated_at": users_table.c.handicap_updated_at,
                 "_created_at": users_table.c.created_at,

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -115,6 +115,20 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
         """
         self._session.add(user)
 
+    async def find_by_alias(self, alias: str) -> User | None:
+        """
+        Busca un usuario por alias, ignorando mayúsculas.
+
+        `LOWER(alias) = LOWER(:alias)` es exactamente la expresión del índice
+        único `ix_users_alias_lower`, así que esta consulta lo usa.
+        """
+        normalized = alias.strip()
+        if not normalized:
+            return None
+        statement = select(User).filter(func.lower(User._alias) == normalized.lower())
+        result = await self._session.execute(statement)
+        return result.scalar_one_or_none()
+
     async def find_by_full_name(self, full_name: str) -> User | None:
         """Busca un usuario por su nombre completo."""
         # Separar el nombre completo en palabras para buscar

--- a/src/shared/application/validation/__init__.py
+++ b/src/shared/application/validation/__init__.py
@@ -11,9 +11,10 @@ OWASP Coverage:
 
 from .field_limits import FieldLimits
 from .sanitizers import sanitize_all_fields, sanitize_html
-from .validators import EmailValidator, NameValidator, validate_email_strict
+from .validators import AliasValidator, EmailValidator, NameValidator, validate_email_strict
 
 __all__ = [
+    "AliasValidator",
     "EmailValidator",
     "FieldLimits",
     "NameValidator",

--- a/src/shared/application/validation/field_limits.py
+++ b/src/shared/application/validation/field_limits.py
@@ -37,6 +37,12 @@ class FieldLimits:
     NAME_MIN_LENGTH = 2  # "Li" es un nombre válido corto
     NAME_MAX_LENGTH = 100  # Cubre nombres largos internacionales
 
+    # Alias (apodo público, opcional)
+    # El mínimo NO es cosmético: el autocompletado exige 2 caracteres para
+    # disparar la búsqueda, así que un alias de uno solo sería inencontrable
+    ALIAS_MIN_LENGTH = 2
+    ALIAS_MAX_LENGTH = 20  # Cabe en una tarjeta de resultados sin truncarse
+
     # Full Name (para búsquedas)
     FULL_NAME_MIN_LENGTH = 3  # "A B" mínimo
     FULL_NAME_MAX_LENGTH = 200  # first + last + espacio

--- a/src/shared/application/validation/validators.py
+++ b/src/shared/application/validation/validators.py
@@ -12,6 +12,8 @@ OWASP Coverage:
 import re
 from typing import Any, ClassVar
 
+from src.shared.application.validation.field_limits import FieldLimits
+
 
 class EmailValidator:
     """
@@ -230,6 +232,84 @@ class NameValidator:
         # Validar que no sea solo espacios/guiones
         if not any(c.isalpha() for c in normalized):
             raise ValueError(f"{field_name} debe contener al menos una letra")
+
+        return normalized
+
+
+class AliasValidator:
+    """
+    Validador del alias público del usuario.
+
+    El alias sustituye al nombre real en toda la aplicación, así que es lo
+    que otra gente teclea para encontrarte. De ahí las reglas:
+
+    - 2 a 20 caracteres.
+    - Letras (con acentos), dígitos, espacio y `.`, `_`, `-`.
+    - Ni emoji ni HTML.
+    - Se guarda tal y como se escribe; la unicidad la decide la base de
+      datos ignorando mayúsculas.
+    """
+
+    # NO se usa el rango `À-ÿ` de NameValidator: incluye los signos de
+    # multiplicar (U+00D7) y dividir (U+00F7), que no son letras. Aquí se
+    # saltan los dos a propósito en vez de heredar el fallo
+    ALIAS_REGEX = re.compile(r"^[a-zA-Z0-9À-ÖØ-öø-ÿ._\- ]+$")
+
+    # Los límites viven en FieldLimits, que es de donde los leen también los
+    # DTO: dos copias del número acabarían discrepando
+    MIN_LENGTH: ClassVar[int] = FieldLimits.ALIAS_MIN_LENGTH
+    MAX_LENGTH: ClassVar[int] = FieldLimits.ALIAS_MAX_LENGTH
+
+    @classmethod
+    def validate(cls, alias: str, field_name: str = "alias") -> str:
+        """
+        Valida y normaliza un alias.
+
+        Args:
+            alias: Alias a validar
+            field_name: Nombre del campo (para mensajes de error)
+
+        Returns:
+            Alias normalizado: sin espacios en los bordes y sin espacios
+            internos repetidos
+
+        Raises:
+            ValueError: Si el alias no cumple las reglas
+
+        Examples:
+            >>> AliasValidator.validate("Chuchi")
+            "Chuchi"
+
+            >>> AliasValidator.validate("  Chu  chi  ")
+            "Chu chi"
+
+            >>> AliasValidator.validate("C")
+            # ValueError: alias debe tener al menos 2 caracteres
+        """
+        if not alias:
+            raise ValueError(f"{field_name} no puede estar vacío")
+
+        # Normalizar: bordes fuera y espacios internos repetidos a uno solo.
+        # Sin esto, "Chu  chi" y "Chu chi" serían aliases distintos y el
+        # índice único no los vería como el mismo
+        normalized = " ".join(alias.split())
+
+        if len(normalized) < cls.MIN_LENGTH:
+            raise ValueError(f"{field_name} debe tener al menos {cls.MIN_LENGTH} caracteres")
+
+        if len(normalized) > cls.MAX_LENGTH:
+            raise ValueError(f"{field_name} no puede exceder {cls.MAX_LENGTH} caracteres")
+
+        if not cls.ALIAS_REGEX.match(normalized):
+            raise ValueError(
+                f"{field_name} solo puede contener letras, números, espacios y los signos "
+                f". _ -"
+            )
+
+        # Un alias de solo signos —"...", "-_-"— no identifica a nadie y no
+        # se puede buscar por él
+        if not any(c.isalnum() for c in normalized):
+            raise ValueError(f"{field_name} debe contener al menos una letra o un número")
 
         return normalized
 

--- a/tests/integration/api/v1/test_user_routes.py
+++ b/tests/integration/api/v1/test_user_routes.py
@@ -319,6 +319,162 @@ class TestUserRoutes:
         assert update_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # ========================================================================
+    # Tests del alias (BE #239)
+    # ========================================================================
+
+    async def test_update_profile_sets_an_alias(self, client: AsyncClient):
+        """Guardar un alias devuelve 200 y el alias en la respuesta."""
+        auth_data = await create_authenticated_user(
+            client, "alias1.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        token = auth_data["token"]
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Chuchi"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["alias"] == "Chuchi"
+
+    async def test_update_profile_alias_alone_is_enough(self, client: AsyncClient):
+        """
+        El alias cuenta como campo: no hace falta mandar nombre y apellidos.
+
+        Es lo que permite el lápiz del panel, que solo manda el alias.
+        """
+        auth_data = await create_authenticated_user(
+            client, "alias2.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        token = auth_data["token"]
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Chuchi2"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["first_name"] == "Agustin"
+
+    async def test_update_profile_clears_the_alias(self, client: AsyncClient):
+        """Mandar el alias vacío lo borra y devuelve al nombre real."""
+        auth_data = await create_authenticated_user(
+            client, "alias3.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        token = auth_data["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        await client.patch("/api/v1/users/profile", json={"alias": "Borrable"}, headers=headers)
+
+        response = await client.patch(
+            "/api/v1/users/profile", json={"alias": ""}, headers=headers
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["alias"] is None
+
+    async def test_update_profile_rejects_an_alias_taken_by_somebody_else(
+        self, client: AsyncClient
+    ):
+        """Un alias que ya tiene otra persona devuelve 409."""
+        owner = await create_authenticated_user(
+            client, "alias4.test@example.com", "s3cur3P@ssw0rd!", "Ana", "Garcia"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Repetido"},
+            headers={"Authorization": f"Bearer {owner['token']}"},
+        )
+        other = await create_authenticated_user(
+            client, "alias5.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Repetido"},
+            headers={"Authorization": f"Bearer {other['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "Repetido" in response.json()["detail"]
+
+    async def test_update_profile_alias_conflict_ignores_case(self, client: AsyncClient):
+        """La unicidad ignora mayúsculas: "repetido" choca con "Repetido"."""
+        owner = await create_authenticated_user(
+            client, "alias6.test@example.com", "s3cur3P@ssw0rd!", "Ana", "Garcia"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Mayusculas"},
+            headers={"Authorization": f"Bearer {owner['token']}"},
+        )
+        other = await create_authenticated_user(
+            client, "alias7.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "mayusculas"},
+            headers={"Authorization": f"Bearer {other['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    async def test_update_profile_keeping_your_own_alias_is_not_a_conflict(
+        self, client: AsyncClient
+    ):
+        """Reenviar el alias propio con otro campo no choca consigo mismo."""
+        auth_data = await create_authenticated_user(
+            client, "alias8.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        headers = {"Authorization": f"Bearer {auth_data['token']}"}
+        await client.patch("/api/v1/users/profile", json={"alias": "Propio"}, headers=headers)
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Propio", "first_name": "Agus"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["alias"] == "Propio"
+        assert response.json()["user"]["first_name"] == "Agus"
+
+    async def test_update_profile_rejects_an_invalid_alias(self, client: AsyncClient):
+        """
+        Un alias inválido lo para Pydantic, que devuelve 422.
+
+        NO es un 400: la validación vive en el DTO, así que la petición ni
+        llega al caso de uso.
+        """
+        auth_data = await create_authenticated_user(
+            client, "alias9.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        headers = {"Authorization": f"Bearer {auth_data['token']}"}
+
+        for invalid in ("C", "a" * 21, "Chu<b>chi", "chu@chi"):
+            response = await client.patch(
+                "/api/v1/users/profile", json={"alias": invalid}, headers=headers
+            )
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, invalid
+
+    async def test_update_profile_normalises_spaces_in_the_alias(self, client: AsyncClient):
+        """Los espacios de los bordes se quitan y los internos se colapsan."""
+        auth_data = await create_authenticated_user(
+            client, "alias10.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "  Chu  chi  "},
+            headers={"Authorization": f"Bearer {auth_data['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["alias"] == "Chu chi"
+
+    # ========================================================================
     # Tests para Update Security (PATCH /api/v1/users/security)
     # ========================================================================
 

--- a/tests/integration/api/v1/test_user_routes.py
+++ b/tests/integration/api/v1/test_user_routes.py
@@ -459,6 +459,42 @@ class TestUserRoutes:
             )
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, invalid
 
+    async def test_update_profile_rejects_a_null_alias_on_its_own(self, client: AsyncClient):
+        """
+        `{"alias": null}` a secas es «no mandas nada», y lo para el DTO.
+
+        Debe salir como 422 con el mensaje del propio DTO, no como un 400 en
+        inglés desde la entidad.
+        """
+        auth_data = await create_authenticated_user(
+            client, "alias11.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": None},
+            headers={"Authorization": f"Bearer {auth_data['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    async def test_update_profile_null_alias_does_not_clear_it(self, client: AsyncClient):
+        """Con otro campo al lado, el alias a null se queda como estaba."""
+        auth_data = await create_authenticated_user(
+            client, "alias12.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        headers = {"Authorization": f"Bearer {auth_data['token']}"}
+        await client.patch("/api/v1/users/profile", json={"alias": "Intacto"}, headers=headers)
+
+        response = await client.patch(
+            "/api/v1/users/profile",
+            json={"first_name": "Agus", "alias": None},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["user"]["alias"] == "Intacto"
+
     async def test_update_profile_normalises_spaces_in_the_alias(self, client: AsyncClient):
         """Los espacios de los bordes se quitan y los internos se colapsan."""
         auth_data = await create_authenticated_user(

--- a/tests/integration/modules/user/infrastructure/persistence/sqlalchemy/test_user_repository.py
+++ b/tests/integration/modules/user/infrastructure/persistence/sqlalchemy/test_user_repository.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from src.modules.user.domain.entities.user import User
 from src.modules.user.infrastructure.persistence.sqlalchemy.user_repository import (
@@ -124,3 +125,107 @@ async def test_search_by_partial_name_finds_a_reactivated_account(db_session):
     results = await repository.search_by_partial_name("Reactivado")
 
     assert user.id in {found.id for found in results}
+
+
+async def test_the_database_refuses_two_users_with_the_same_alias(db_session):
+    """
+    La unicidad del alias la impone la BASE DE DATOS, no solo el caso de uso.
+
+    El índice `ix_users_alias_lower` se declara en los metadatos y no solo en
+    la migración, así que existe también en el esquema de los tests: si algún
+    día desapareciera la comprobación previa del caso de uso, este test se
+    pondría en rojo en vez de dejar pasar dos aliases iguales hasta producción.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    first = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str="alias.uno@example.com",
+        plain_password="ValidPassword123!",
+    )
+    first.update_profile(alias="Chuchi")
+    await repository.save(first)
+    await db_session.commit()
+
+    second = User.create(
+        first_name="Agustin",
+        last_name="Estevez",
+        email_str="alias.dos@example.com",
+        plain_password="ValidPassword123!",
+    )
+    second.update_profile(alias="Chuchi")
+    await repository.save(second)
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_the_unique_alias_ignores_case(db_session):
+    """
+    "chuchi" y "Chuchi" son el mismo alias para la base de datos.
+
+    Es la mitad de la decisión de producto: dos cuentas llamadas igual harían
+    inútil el alias para encontrar gente. Lo resuelve el índice funcional sobre
+    LOWER(alias), no una comparación en Python.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    first = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str="alias.tres@example.com",
+        plain_password="ValidPassword123!",
+    )
+    first.update_profile(alias="Chuchi")
+    await repository.save(first)
+    await db_session.commit()
+
+    second = User.create(
+        first_name="Agustin",
+        last_name="Estevez",
+        email_str="alias.cuatro@example.com",
+        plain_password="ValidPassword123!",
+    )
+    second.update_profile(alias="chuchi")
+    await repository.save(second)
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_users_without_an_alias_do_not_collide(db_session):
+    """
+    El índice es parcial: las filas sin alias no entran, así que cualquier
+    número de cuentas puede convivir sin apodo. Es el caso de TODAS las
+    existentes el día del despliegue.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    for i in range(3):
+        user = User.create(
+            first_name="Sin",
+            last_name="Alias",
+            email_str=f"alias.libre{i}@example.com",
+            plain_password="ValidPassword123!",
+        )
+        await repository.save(user)
+    await db_session.commit()
+
+    assert await repository.find_by_alias("Chuchi") is None
+
+
+async def test_find_by_alias_ignores_case(db_session):
+    """`find_by_alias` encuentra el alias sea cual sea la caja que se teclee."""
+    repository = SQLAlchemyUserRepository(db_session)
+    user = User.create(
+        first_name="Ana",
+        last_name="Garcia",
+        email_str="alias.cinco@example.com",
+        plain_password="ValidPassword123!",
+    )
+    user.update_profile(alias="Chuchi")
+    await repository.save(user)
+    await db_session.commit()
+
+    found = await repository.find_by_alias("cHuChI")
+
+    assert found is not None
+    assert found.id == user.id

--- a/tests/unit/modules/user/application/use_cases/test_update_profile_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_update_profile_use_case.py
@@ -292,6 +292,26 @@ class TestUpdateProfileAlias:
 
         assert response.user.alias == "Chuchi"
 
+    async def test_a_null_alias_does_not_clear_an_existing_one(
+        self, uow, country_repository, existing_user
+    ):
+        """
+        `null` no borra el alias; para eso está la cadena vacía.
+
+        Un formulario que mande el perfil entero con el alias a null no puede
+        dejar sin apodo a quien solo quería cambiarse el nombre.
+        """
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+        await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+        response = await use_case.execute(
+            user_id, UpdateProfileRequestDTO(first_name="Johnny", alias=None)
+        )
+
+        assert response.user.alias == "Chuchi"
+        assert response.user.first_name == "Johnny"
+
     async def test_translates_the_unique_index_violation_into_a_conflict(
         self, uow, country_repository, existing_user
     ):
@@ -343,3 +363,58 @@ class TestUpdateProfileAlias:
         uow.commit = commit_failing
         with pytest.raises(IntegrityError):
             await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+
+class TestUpdateProfileAliasRequestDTO:
+    """
+    Tests del DTO de entrada para el alias (BE #239).
+
+    Aquí se decide qué llega al caso de uso y qué se rechaza antes.
+    """
+
+    def test_empty_string_is_kept_as_the_clear_request(self):
+        """
+        La cadena vacía no se valida: es «quítame el alias» y llega tal cual
+        para que la entidad la traduzca a NULL.
+        """
+        assert UpdateProfileRequestDTO(alias="").alias == ""
+
+    def test_null_alias_alone_is_rejected_by_the_dto(self):
+        """
+        `{"alias": null}` a secas es «no me mandas nada».
+
+        `null` significa "no lo toques" en todos los campos de este endpoint
+        —`{"last_name": null}` ya funcionaba así—, así que el alias no puede
+        ser la excepción. Y tiene que pararlo el DTO: dejándolo pasar reventaba
+        más adentro, en la entidad, con un 400 y un mensaje en inglés.
+        """
+        with pytest.raises(ValidationError, match="al menos"):
+            UpdateProfileRequestDTO(alias=None)
+
+    def test_null_alias_next_to_another_field_is_accepted_as_untouched(self):
+        """Mandar el alias a null junto a otro campo no es un error."""
+        request = UpdateProfileRequestDTO(first_name="Jane", alias=None)
+
+        assert request.alias is None
+
+    def test_a_forbidden_sign_is_reported_as_such_not_as_html(self):
+        """
+        El mensaje dice la verdad para el caso que lo provoca.
+
+        Validar después de sanear hacía que `Chuchi & Co` —donde el `&` se
+        escapa a `&amp;`— se rechazara con un «no puede contener HTML» que no
+        era cierto: lo que sobra es el `&`, y eso ya lo dice el mensaje de los
+        caracteres permitidos.
+        """
+        with pytest.raises(ValidationError, match="solo puede contener"):
+            UpdateProfileRequestDTO(alias="Chuchi & Co")
+
+    def test_an_oversized_alias_is_stopped_by_the_field_limit(self):
+        """
+        Un alias larguísimo lo para el límite del campo, antes de sanearlo.
+
+        Sin `max_length` en el Field, una cadena de megabytes se paseaba por
+        los tres regex de `sanitize_html` antes de que nadie la rechazara.
+        """
+        with pytest.raises(ValidationError):
+            UpdateProfileRequestDTO(alias="a" * 5000)

--- a/tests/unit/modules/user/application/use_cases/test_update_profile_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_update_profile_use_case.py
@@ -8,13 +8,17 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 
 from src.modules.user.application.dto.user_dto import UpdateProfileRequestDTO
 from src.modules.user.application.use_cases.update_profile_use_case import (
     UpdateProfileUseCase,
 )
 from src.modules.user.domain.entities.user import User
-from src.modules.user.domain.errors.user_errors import UserNotFoundError
+from src.modules.user.domain.errors.user_errors import (
+    AliasAlreadyTakenError,
+    UserNotFoundError,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.modules.user.infrastructure.persistence.in_memory.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
@@ -170,3 +174,172 @@ class TestUpdateProfileUseCase:
         # Verificar que se guardó en el repositorio
         updated_user = await uow.users.find_by_id(UserId(user_id))
         assert updated_user.first_name == "Jane"
+
+
+@pytest.mark.asyncio
+class TestUpdateProfileAlias:
+    """
+    Tests del alias en el caso de uso (BE #239).
+
+    La unicidad la comprueba el caso de uso ANTES de guardar y la garantiza el
+    índice único al hacer commit. Aquí se ejercitan los dos caminos.
+    """
+
+    async def test_sets_the_alias(self, uow, country_repository, existing_user):
+        """Debe guardar el alias y devolverlo en la respuesta."""
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+
+        response = await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+        assert response.user.alias == "Chuchi"
+        saved = await uow.users.find_by_id(UserId(user_id))
+        assert saved.alias == "Chuchi"
+        assert saved.display_name == "Chuchi"
+
+    async def test_clears_the_alias_with_an_empty_string(
+        self, uow, country_repository, existing_user
+    ):
+        """La cadena vacía borra el alias y devuelve al nombre real."""
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+        await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+        response = await use_case.execute(user_id, UpdateProfileRequestDTO(alias=""))
+
+        assert response.user.alias is None
+        saved = await uow.users.find_by_id(UserId(user_id))
+        assert saved.alias is None
+        assert saved.display_name == "John Doe"
+
+    async def test_rejects_an_alias_taken_by_somebody_else(
+        self, uow, country_repository, existing_user
+    ):
+        """Un alias que ya tiene otra persona se rechaza."""
+        other = User.create(
+            first_name="Ana",
+            last_name="Garcia",
+            email_str="ana@example.com",
+            plain_password="V@l1dP@ss123!",
+        )
+        other.update_profile(alias="Chuchi")
+        async with uow:
+            await uow.users.save(other)
+            await uow.commit()
+
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+
+        with pytest.raises(AliasAlreadyTakenError):
+            await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+    async def test_rejects_the_same_alias_in_another_case(
+        self, uow, country_repository, existing_user
+    ):
+        """
+        La unicidad ignora mayúsculas: "chuchi" choca con "Chuchi".
+
+        Es la mitad de la decisión de producto — dos cuentas llamadas igual
+        harían inútil el alias para encontrar gente.
+        """
+        other = User.create(
+            first_name="Ana",
+            last_name="Garcia",
+            email_str="ana@example.com",
+            plain_password="V@l1dP@ss123!",
+        )
+        other.update_profile(alias="Chuchi")
+        async with uow:
+            await uow.users.save(other)
+            await uow.commit()
+
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+
+        with pytest.raises(AliasAlreadyTakenError):
+            await use_case.execute(user_id, UpdateProfileRequestDTO(alias="chuchi"))
+
+    async def test_keeping_your_own_alias_is_not_a_conflict(
+        self, uow, country_repository, existing_user
+    ):
+        """
+        Reenviar el alias propio no choca consigo mismo.
+
+        Pasa en cuanto el formulario manda el perfil entero: el alias viaja sin
+        haber cambiado, y tratarlo como conflicto haría imposible editar el
+        país sin borrar antes el alias.
+        """
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+        await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+        response = await use_case.execute(
+            user_id, UpdateProfileRequestDTO(alias="Chuchi", first_name="Johnny")
+        )
+
+        assert response.user.alias == "Chuchi"
+        assert response.user.first_name == "Johnny"
+
+    async def test_changing_only_the_case_of_your_own_alias_is_allowed(
+        self, uow, country_repository, existing_user
+    ):
+        """Cambiar solo las mayúsculas del alias propio debe poder hacerse."""
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+        await use_case.execute(user_id, UpdateProfileRequestDTO(alias="chuchi"))
+
+        response = await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+
+        assert response.user.alias == "Chuchi"
+
+    async def test_translates_the_unique_index_violation_into_a_conflict(
+        self, uow, country_repository, existing_user
+    ):
+        """
+        La carrera la resuelve el índice, y su error sale como conflicto.
+
+        Entre la comprobación y el commit cabe otra petición pidiendo el mismo
+        alias. Se simula que el commit revienta con la violación del índice.
+        """
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+
+        original_commit = uow.commit
+
+        async def commit_conflicting(*args, **kwargs):
+            raise IntegrityError(
+                "INSERT INTO users ...",
+                {},
+                Exception('duplicate key value violates unique constraint "ix_users_alias_lower"'),
+            )
+
+        uow.commit = commit_conflicting
+        try:
+            with pytest.raises(AliasAlreadyTakenError):
+                await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))
+        finally:
+            uow.commit = original_commit
+
+    async def test_other_integrity_errors_are_not_swallowed(
+        self, uow, country_repository, existing_user
+    ):
+        """
+        Solo se traduce la violación del índice del alias.
+
+        Cualquier otro IntegrityError seguiría subiendo: convertirlo en «ese
+        alias está cogido» mandaría al usuario a cambiar algo que no es lo que
+        falla.
+        """
+        use_case = UpdateProfileUseCase(uow, country_repository)
+        user_id = str(existing_user.id.value)
+
+        async def commit_failing(*args, **kwargs):
+            raise IntegrityError(
+                "INSERT INTO users ...",
+                {},
+                Exception('duplicate key value violates unique constraint "users_email_key"'),
+            )
+
+        uow.commit = commit_failing
+        with pytest.raises(IntegrityError):
+            await use_case.execute(user_id, UpdateProfileRequestDTO(alias="Chuchi"))

--- a/tests/unit/modules/user/domain/entities/test_user.py
+++ b/tests/unit/modules/user/domain/entities/test_user.py
@@ -969,3 +969,173 @@ class TestUserEmailVerification:
         # Assert
         assert user.email_verified is False
         assert user.verification_token is None
+
+
+class TestUserAlias:
+    """
+    Tests del alias público del perfil (BE #239).
+
+    El alias sustituye al nombre real en toda la aplicación. `None` en
+    `update_profile` significa "no lo han mandado" y la cadena vacía
+    "quítamelo", igual que ya hacían country_code y gender.
+    """
+
+    def _user(self, alias=None):
+        user = User.create(
+            first_name="Agustin",
+            last_name="Estevez",
+            email_str="agustin@example.com",
+            plain_password="DefaultPassword123!",
+        )
+        user.clear_domain_events()
+        if alias is not None:
+            user.update_profile(alias=alias)
+            user.clear_domain_events()
+        return user
+
+    def test_new_user_has_no_alias(self):
+        """
+        Test: Un usuario nace sin alias
+
+        Given: Un usuario recién creado
+        When: Se mira su alias
+        Then: Es None, y display_name es su nombre completo
+        """
+        user = self._user()
+
+        assert user.alias is None
+        assert user.display_name == "Agustin Estevez"
+
+    def test_setting_an_alias_changes_display_name(self):
+        """
+        Test: Poner un alias cambia el nombre con el que se muestra
+
+        Given: Un usuario sin alias
+        When: Se le pone "Chuchi"
+        Then: display_name pasa a ser "Chuchi" y el nombre legal no cambia
+        """
+        user = self._user()
+
+        user.update_profile(alias="Chuchi")
+
+        assert user.alias == "Chuchi"
+        assert user.display_name == "Chuchi"
+        assert user.get_full_name() == "Agustin Estevez"
+
+    def test_get_full_name_ignores_the_alias(self):
+        """
+        Test: El nombre legal nunca es el alias
+
+        Given: Un usuario con alias
+        When: Se pide get_full_name()
+        Then: Devuelve el nombre real — la búsqueda de hándicap en la RFEG y
+              los correos van por ahí, y la federación busca por nombre legal
+        """
+        user = self._user("Chuchi")
+
+        assert user.get_full_name() == "Agustin Estevez"
+
+    def test_clearing_the_alias_returns_to_the_real_name(self):
+        """
+        Test: La cadena vacía borra el alias
+
+        Given: Un usuario con alias "Chuchi"
+        When: Se actualiza el perfil con alias=""
+        Then: El alias queda a None y vuelve a mostrarse el nombre real
+        """
+        user = self._user("Chuchi")
+
+        user.update_profile(alias="")
+
+        assert user.alias is None
+        assert user.display_name == "Agustin Estevez"
+
+    def test_not_sending_the_alias_leaves_it_alone(self):
+        """
+        Test: Omitir el alias no lo toca
+
+        Given: Un usuario con alias
+        When: Se actualiza solo el nombre
+        Then: El alias sigue ahí
+        """
+        user = self._user("Chuchi")
+
+        user.update_profile(first_name="Agus")
+
+        assert user.alias == "Chuchi"
+        assert user.display_name == "Chuchi"
+
+    def test_setting_the_same_alias_emits_no_event(self):
+        """
+        Test: Repetir el alias que ya se tiene no es un cambio
+
+        Given: Un usuario con alias "Chuchi"
+        When: Se manda el mismo alias
+        Then: No se emite evento
+        """
+        user = self._user("Chuchi")
+
+        user.update_profile(alias="Chuchi")
+
+        assert user.get_domain_events() == []
+
+    def test_alias_change_travels_in_the_profile_updated_event(self):
+        """
+        Test: El evento de perfil lleva el cambio de alias
+
+        Given: Un usuario con alias "Chuchi"
+        When: Lo cambia a "Chuchito"
+        Then: El evento lleva el anterior y el nuevo
+        """
+        user = self._user("Chuchi")
+
+        user.update_profile(alias="Chuchito")
+
+        event = user.get_domain_events()[0]
+        assert event.old_alias == "Chuchi"
+        assert event.new_alias == "Chuchito"
+        assert event.has_alias_change is True
+        assert event.to_dict()["profile_changes"]["alias"]["changed"] is True
+
+    def test_clearing_the_alias_travels_in_the_event(self):
+        """
+        Test: Quitar el alias también es un cambio que viaja en el evento
+
+        Given: Un usuario con alias
+        When: Lo borra
+        Then: El evento lleva el anterior y None como nuevo
+        """
+        user = self._user("Chuchi")
+
+        user.update_profile(alias="")
+
+        event = user.get_domain_events()[0]
+        assert event.old_alias == "Chuchi"
+        assert event.new_alias is None
+
+    def test_alias_alone_is_enough_to_update_the_profile(self):
+        """
+        Test: El alias cuenta como campo para "al menos uno"
+
+        Given: Un usuario
+        When: Se actualiza el perfil mandando solo el alias
+        Then: No se levanta el error de "ningún campo"
+        """
+        user = self._user()
+
+        user.update_profile(alias="Chuchi")
+
+        assert user.alias == "Chuchi"
+
+    def test_updating_with_no_field_at_all_still_fails(self):
+        """
+        Test: Sin ningún campo sigue siendo un error
+
+        Given: Un usuario
+        When: Se llama a update_profile sin nada
+        Then: ValueError, y el mensaje menciona el alias
+        """
+        user = self._user()
+
+        with pytest.raises(ValueError, match="alias"):
+            user.update_profile()

--- a/tests/unit/modules/user/domain/repositories/test_user_repository_interface.py
+++ b/tests/unit/modules/user/domain/repositories/test_user_repository_interface.py
@@ -187,6 +187,9 @@ class TestUserRepositoryInterface:
             async def find_by_full_name(self, full_name: str):
                 return None
 
+            async def find_by_alias(self, alias: str):
+                return None
+
             async def search_by_partial_name(self, query: str, limit: int = 10):
                 return []
 

--- a/tests/unit/shared/application/validation/test_validators.py
+++ b/tests/unit/shared/application/validation/test_validators.py
@@ -9,6 +9,7 @@ OWASP Coverage Test: A03 (Injection), A07 (Authentication Failures)
 import pytest
 
 from src.shared.application.validation.validators import (
+    AliasValidator,
     EmailValidator,
     NameValidator,
     validate_country_code,
@@ -388,6 +389,158 @@ class TestNameValidator:
             NameValidator.validate("---")
 
         assert "al menos una letra" in str(exc_info.value)
+
+
+class TestAliasValidator:
+    """Tests para AliasValidator (alias público del perfil, BE #239)."""
+
+    def test_validate_accepts_simple_alias(self):
+        """
+        Test: Acepta un alias corriente
+
+        Given: El alias "Chuchi"
+        When: Se valida
+        Then: Se devuelve tal cual, sin cambiar mayúsculas
+        """
+        assert AliasValidator.validate("Chuchi") == "Chuchi"
+
+    def test_validate_preserves_case(self):
+        """
+        Test: No normaliza mayúsculas
+
+        Given: El alias "ChuChi"
+        When: Se valida
+        Then: Se conserva como se escribió — la unicidad la resuelve el
+              índice de la base de datos ignorando mayúsculas, no el
+              validador cambiando lo que la persona escribió
+        """
+        assert AliasValidator.validate("ChuChi") == "ChuChi"
+
+    def test_validate_accepts_digits_and_allowed_signs(self):
+        """
+        Test: Acepta dígitos, punto, guion bajo y guion
+
+        Given: Aliases con números y los signos permitidos
+        When: Se validan
+        Then: Se aceptan
+        """
+        for alias in ("Peña_23", "j.garcia", "el-cangrejo", "Tiger 18"):
+            assert AliasValidator.validate(alias) == alias
+
+    def test_validate_accepts_accents(self):
+        """
+        Test: Acepta acentos y eñes
+
+        Given: El alias "Muñóz"
+        When: Se valida
+        Then: Se acepta
+        """
+        assert AliasValidator.validate("Muñóz") == "Muñóz"
+
+    def test_validate_trims_and_collapses_inner_spaces(self):
+        """
+        Test: Normaliza espacios
+
+        Given: El alias "  Chu  chi  "
+        When: Se valida
+        Then: Queda "Chu chi" — si no se colapsan los espacios internos,
+              "Chu  chi" y "Chu chi" serían dos aliases distintos y el
+              índice único no los vería como el mismo
+        """
+        assert AliasValidator.validate("  Chu  chi  ") == "Chu chi"
+
+    def test_validate_rejects_one_character(self):
+        """
+        Test: Rechaza un alias de un solo carácter
+
+        Given: El alias "C"
+        When: Se valida
+        Then: ValueError — el autocompletado necesita 2 caracteres para
+              disparar la búsqueda, así que uno solo sería inencontrable
+        """
+        with pytest.raises(ValueError, match="al menos 2 caracteres"):
+            AliasValidator.validate("C")
+
+    def test_validate_rejects_more_than_twenty_characters(self):
+        """
+        Test: Rechaza un alias de más de 20 caracteres
+
+        Given: Un alias de 21 caracteres
+        When: Se valida
+        Then: ValueError
+        """
+        with pytest.raises(ValueError, match="no puede exceder 20 caracteres"):
+            AliasValidator.validate("a" * 21)
+
+    def test_validate_accepts_the_length_bounds(self):
+        """
+        Test: Los límites son inclusivos
+
+        Given: Aliases de exactamente 2 y 20 caracteres
+        When: Se validan
+        Then: Los dos se aceptan
+        """
+        assert AliasValidator.validate("ab") == "ab"
+        assert AliasValidator.validate("a" * 20) == "a" * 20
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "Chu<b>chi",
+            "<script>alert(1)</script>",
+            "Chuchi🏌",
+            "chu@chi",
+            "chu/chi",
+            "chu#chi",
+        ],
+    )
+    def test_validate_rejects_html_emoji_and_other_signs(self, alias):
+        """
+        Test: Rechaza HTML, emoji y signos fuera de la lista
+
+        Given: Aliases con marcado, emoji o signos no permitidos
+        When: Se validan
+        Then: ValueError
+        """
+        with pytest.raises(ValueError):
+            AliasValidator.validate(alias)
+
+    def test_validate_rejects_multiplication_and_division_signs(self):
+        """
+        Test: Rechaza los signos de multiplicar y dividir
+
+        Given: Aliases con U+00D7 y U+00F7, que caen dentro del rango
+               `À-ÿ` que usa NameValidator sin ser letras
+        When: Se validan
+        Then: ValueError — este validador se salta los dos a propósito en
+              vez de heredar ese fallo
+        """
+        for alias in ("chu\u00d7chi", "chu\u00f7chi"):
+            with pytest.raises(ValueError):
+                AliasValidator.validate(alias)
+
+    def test_validate_rejects_only_signs(self):
+        """
+        Test: Rechaza un alias sin letras ni números
+
+        Given: El alias "..."
+        When: Se valida
+        Then: ValueError — no identifica a nadie y no se puede buscar por él
+        """
+        with pytest.raises(ValueError, match="al menos una letra o un número"):
+            AliasValidator.validate("...")
+
+    def test_validate_rejects_empty(self):
+        """
+        Test: Rechaza la cadena vacía
+
+        Given: Un alias vacío
+        When: Se valida
+        Then: ValueError — vaciar el alias es cosa del DTO, que lo traduce
+              a NULL sin pasar por aquí
+        """
+        with pytest.raises(ValueError, match="no puede estar vacío"):
+            AliasValidator.validate("")
 
 
 class TestValidateCountryCode:


### PR DESCRIPTION
Part 1 of #239: the alias exists, is unique, and can be set and cleared from the profile endpoint.

Parts 2 (matching the alias in every user search) and 3 (`display_name` in the response DTOs) come as their own PRs on top of `develop`, not stacked on this one.

## What this adds

- **`User.alias` and `User.display_name`.** `display_name` is the only place the "alias if there is one, full name otherwise" fallback lives. `get_full_name()` is untouched on purpose: the RFEG handicap lookup and the transactional emails go through it, and the federation searches by legal name.
- **`AliasValidator`** — 2 to 20 characters; letters (accents included), digits, space and `. _ -`. Its bounds come from `FieldLimits` so the DTO and the validator cannot drift.
- **The column and its unique index**, migration `c8e1d5b73f92`: functional over `LOWER(alias)` and partial (`WHERE alias IS NOT NULL`).
- **`PATCH /users/profile` takes `alias`**, `GET /users/me` returns it, and a taken alias answers **409** with a message the frontend can show as-is next to the field.

## Decisions worth reviewing

- **Clearing is the empty string; `null` means "leave it alone".** That is what `null` already meant for every other field of this endpoint — `{"last_name": null}` never cleared a surname — so the alias is not made an exception. Distinguishing the two needed `model_fields_set` in `model_post_init`, whose "at least one field" check looks at falsy values.
- **Invalid input answers 422, not the 400 the issue predicted.** Validation lives in the DTO, so the request never reaches the use case. The frontend needs to expect 422 for format and 409 for conflict.
- **A sanitised alias is refused, not accepted quietly.** The name fields sanitise and carry on; here `Chu<b>chi` is rejected rather than stored as `Chuchi`, because the alias is unique and it is what other people type to find you.
- **Uniqueness is enforced twice**: checked before saving, and the index violation is translated on commit — between the two another request can claim the same alias. Only that index's violation is translated; any other `IntegrityError` still propagates.
- **The index is declared in the metadata, not only in the migration.** The test schema is built with `metadata.create_all`, so an index living only in the migration would not exist in any test and the suite would bless duplicates that break in production.
- **An alias is only checked against other aliases**, not against real names — so somebody can take another player's name as their alias. Decided deliberately and written down in #239.
- **The migration revises `f1a4c86d2e59`**, not the `d3c7a5f18e42` the issue names — that was the head five weeks ago.

## Deployment

Backwards compatible: new nullable column, new optional request field, added response field. `first_name` / `last_name` still travel in every payload, so the frontend currently in production keeps working between the two deploys. Backend ships first, without a dangerous window.

The index is created over zero rows on deploy day — nobody has an alias yet — so it is instant regardless of how many accounts exist.

## Testing

- 3023 unit tests green; `ruff` and `mypy` clean on everything touched.
- `/code-review high` before pushing; its findings are the last two commits.
- **The integration tests were not run locally** — they need Postgres on 5434 (the Kind port-forward) and neither Docker nor the cluster was up. CI runs `alembic upgrade head` before them, so the migration and the index are exercised there. Worth a look at that job before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrmca8GvTCsF7tbjaM7Ss
