### PR TITLE
feat(user): Find people by their alias, and show it next to the name

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -295,16 +295,22 @@ Returned in all endpoints that include user data (login, current-user, register,
 **GET /api/v1/users/search-autocomplete** (Authenticated)
 
 **Query Parameters:**
-- `query` (string, required, 2-100 chars) - Partial name to search for
+- `query` (string, required, 2-100 chars) - Partial name or alias to search for
 
 **Response (200 OK):**
 - `users` (array, max 10 results)
   - `user_id` (string, UUID)
-  - `email` (string)
   - `full_name` (string) - "first_name last_name"
+  - `first_name` (string)
+  - `last_name` (string)
+  - `alias` (string or null) - public nickname, if the user set one
+  - `avatar_source`, `avatar_preset_id`, `has_avatar_upload`
 
 **Business Rules:**
-- Case-insensitive partial match on first_name or last_name
+- Case-insensitive partial match on first_name, last_name or alias
+- The alias travels next to the real name, so two similar players can be told apart
+- No email: it was removed so addresses could not be harvested by typing names
+- Deactivated accounts never appear, not even when the query matches their alias
 - Returns max 10 results
 - Only authenticated users can search
 

--- a/src/modules/competition/domain/repositories/competition_repository_interface.py
+++ b/src/modules/competition/domain/repositories/competition_repository_interface.py
@@ -258,7 +258,7 @@ class CompetitionRepositoryInterface(ABC):
 
         Args:
             search_name: Búsqueda parcial case-insensitive en nombre de competición
-            search_creator: Búsqueda parcial case-insensitive en nombre del creador (first_name o last_name)
+            search_creator: Búsqueda parcial case-insensitive en nombre del creador (first_name, last_name o alias)
             status: Filtrar por estado específico
             creator_id: Filtrar por creador específico
             limit: Número máximo de resultados (default: 100)

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -337,22 +337,28 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
             conditions.append(Competition._name_value.ilike(f"%{search_name}%"))
 
         # Filtro: search_creator (búsqueda en first_name OR last_name OR alias)
+        #
+        # El texto va SIN `strip()` a propósito: con `search_creator="  "` la
+        # condición de arriba es cierta —no es cadena vacía— y recortarlo
+        # dejaría un `contains("")`, que casa con TODO. Es decir, buscar dos
+        # espacios devolvería la lista entera en vez de nada. Tal cual llega,
+        # se busca «  » y no casa nada, que es lo que hacía antes.
+        #
+        # Las tres ramas usan `LOWER(...).contains(..., autoescape=True)` y no
+        # `ilike(f"%{x}%")`: aquel interpolaba el texto tecleado dentro del
+        # patrón, así que un `%` devolvía todas las competiciones y un `_`
+        # casaba con cualquier carácter. Las dos primeras venían ya así y se
+        # arreglan aquí en vez de añadir una tercera con el mismo fallo.
+        #
+        # Para las cuentas sin alias, LOWER(NULL) es NULL: no casan por esa
+        # rama, pero siguen entrando por las otras dos.
         if search_creator:
+            creator_query = search_creator.lower()
             conditions.append(
                 or_(
-                    User._first_name.ilike(f"%{search_creator}%"),
-                    User._last_name.ilike(f"%{search_creator}%"),
-                    # El alias también (BE #239): quien organiza aparece por su
-                    # apodo en el resto de la aplicación, así que buscarlo por
-                    # el nombre que se ve en pantalla tiene que funcionar.
-                    # Con `LOWER(...).contains(...)` y no con `ilike(f"%{x}%")`
-                    # como sus vecinas: aquel interpola el texto tal cual, así
-                    # que un `%` o un `_` tecleados actúan de comodín. Para las
-                    # cuentas sin alias, LOWER(NULL) es NULL y siguen entrando
-                    # por las otras dos ramas del OR
-                    func.lower(User._alias).contains(
-                        search_creator.strip().lower(), autoescape=True
-                    ),
+                    func.lower(User._first_name).contains(creator_query, autoescape=True),
+                    func.lower(User._last_name).contains(creator_query, autoescape=True),
+                    func.lower(User._alias).contains(creator_query, autoescape=True),
                 )
             )
 

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/competition_repository.py
@@ -306,7 +306,7 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
 
         Implementa búsqueda case-insensitive con ILIKE:
         - search_name: Busca en competition.name
-        - search_creator: Busca en creator.first_name OR creator.last_name
+        - search_creator: Busca en creator.first_name OR creator.last_name OR creator.alias
 
         Args:
             search_name: Texto a buscar en nombre de competición
@@ -336,12 +336,23 @@ class SQLAlchemyCompetitionRepository(CompetitionRepositoryInterface):
         if search_name:
             conditions.append(Competition._name_value.ilike(f"%{search_name}%"))
 
-        # Filtro: search_creator (búsqueda en first_name OR last_name)
+        # Filtro: search_creator (búsqueda en first_name OR last_name OR alias)
         if search_creator:
             conditions.append(
                 or_(
                     User._first_name.ilike(f"%{search_creator}%"),
                     User._last_name.ilike(f"%{search_creator}%"),
+                    # El alias también (BE #239): quien organiza aparece por su
+                    # apodo en el resto de la aplicación, así que buscarlo por
+                    # el nombre que se ve en pantalla tiene que funcionar.
+                    # Con `LOWER(...).contains(...)` y no con `ilike(f"%{x}%")`
+                    # como sus vecinas: aquel interpola el texto tal cual, así
+                    # que un `%` o un `_` tecleados actúan de comodín. Para las
+                    # cuentas sin alias, LOWER(NULL) es NULL y siguen entrando
+                    # por las otras dos ramas del OR
+                    func.lower(User._alias).contains(
+                        search_creator.strip().lower(), autoescape=True
+                    ),
                 )
             )
 

--- a/src/modules/user/application/dto/admin_dto.py
+++ b/src/modules/user/application/dto/admin_dto.py
@@ -10,7 +10,7 @@ class AdminListUsersRequestDTO(BaseModel):
     """DTO de entrada para listar usuarios (admin)."""
 
     search: str | None = Field(
-        default=None, description="Filtro por nombre, apellidos o email (opcional)."
+        default=None, description="Filtro por nombre, apellidos, alias o email (opcional)."
     )
     is_admin: bool | None = Field(
         default=None, description="Filtra por rol: True=admins, False=jugadores."
@@ -31,6 +31,11 @@ class AdminUserSummaryDTO(BaseModel):
     id: UUID
     first_name: str
     last_name: str
+    # El alias va JUNTO al nombre real, no en su lugar: quien administra
+    # necesita saber de quien es la cuenta. Pero el listado ya se puede
+    # buscar por alias (BE #239), y sin este campo una busqueda por apodo
+    # devolvia filas donde nada de lo que se ve contiene lo que se busco
+    alias: str | None = None
     email: EmailStr
     handicap: float | None = None
     is_admin: bool

--- a/src/modules/user/application/dto/user_dto.py
+++ b/src/modules/user/application/dto/user_dto.py
@@ -137,8 +137,10 @@ class SearchUsersItemDTO(BaseModel):
 
     **No lleva correo.** Cualquiera puede buscar por nombre, asi que lo que
     devuelva esta busqueda es publico entre usuarios registrados: solo nombre,
-    apellidos y foto. Antes devolvia el correo, lo que permitia recolectar
-    direcciones tecleando nombres sueltos.
+    apellidos, alias y foto. Antes devolvia el correo, lo que permitia
+    recolectar direcciones tecleando nombres sueltos. El alias no amplia esa
+    exposicion: es publico por diseño, porque es lo que otros teclean para
+    encontrarte.
 
     La foto es lo que permite distinguir a dos jugadores que se llamen igual,
     que es el trabajo que hacia el correo.
@@ -148,6 +150,14 @@ class SearchUsersItemDTO(BaseModel):
     full_name: str = Field(..., description="Nombre completo del usuario.")
     first_name: str = Field(default="", description="Nombre, ya separado del apellido.")
     last_name: str = Field(default="", description="Apellidos, ya separados del nombre.")
+    alias: str | None = Field(
+        default=None,
+        description=(
+            "Apodo público, si tiene. Se puede buscar por él, así que aquí se "
+            "devuelve junto al nombre real: es lo que permite saber cuál de los "
+            "dos 'Chuchi' que salen es el que se buscaba."
+        ),
+    )
     avatar_source: str = Field(default="", description="De donde sale su foto de perfil.")
     avatar_preset_id: int | None = Field(default=None, description="Avatar predefinido, si usa uno.")
     has_avatar_upload: bool = Field(

--- a/src/modules/user/application/use_cases/admin_list_users_use_case.py
+++ b/src/modules/user/application/use_cases/admin_list_users_use_case.py
@@ -42,6 +42,7 @@ class AdminListUsersUseCase:
                     id=user.id.value,
                     first_name=user.first_name,
                     last_name=user.last_name,
+                    alias=user.alias,
                     email=str(user.email),
                     handicap=float(user.handicap) if user.handicap is not None else None,
                     is_admin=user.is_admin,

--- a/src/modules/user/application/use_cases/admin_update_user_use_case.py
+++ b/src/modules/user/application/use_cases/admin_update_user_use_case.py
@@ -61,6 +61,7 @@ class AdminUpdateUserUseCase:
             id=user.id.value,
             first_name=user.first_name,
             last_name=user.last_name,
+            alias=user.alias,
             email=str(user.email),
             handicap=float(user.handicap) if user.handicap is not None else None,
             is_admin=user.is_admin,

--- a/src/modules/user/application/use_cases/search_users_use_case.py
+++ b/src/modules/user/application/use_cases/search_users_use_case.py
@@ -12,11 +12,12 @@ class SearchUsersUseCase:
     Use case for autocomplete user search by partial name.
     Returns a list of users matching the query.
 
-    Devuelve **solo lo publico**: nombre, apellidos y foto. Cualquier usuario
-    registrado puede buscar por nombre, asi que todo lo que salga de aqui es
-    visible para cualquiera. El correo se retiro por eso: tecleando nombres
-    sueltos se podian recolectar direcciones de gente con la que no tienes
-    ninguna relacion.
+    Devuelve **solo lo publico**: nombre, apellidos, alias y foto. Cualquier
+    usuario registrado puede buscar por nombre, asi que todo lo que salga de
+    aqui es visible para cualquiera. El correo se retiro por eso: tecleando
+    nombres sueltos se podian recolectar direcciones de gente con la que no
+    tienes ninguna relacion. El alias no amplia esa exposicion: es publico por
+    diseño, porque es lo que otra gente teclea para encontrarte.
     """
 
     MIN_QUERY_LENGTH = 2
@@ -41,6 +42,7 @@ class SearchUsersUseCase:
                         full_name=user.get_full_name(),
                         first_name=user.first_name,
                         last_name=user.last_name,
+                        alias=user.alias,
                         avatar_source=user.avatar_source.value,
                         avatar_preset_id=user.avatar_preset_id,
                         has_avatar_upload=user.active_avatar_upload_id is not None,

--- a/src/modules/user/domain/repositories/user_repository_interface.py
+++ b/src/modules/user/domain/repositories/user_repository_interface.py
@@ -159,7 +159,7 @@ class UserRepositoryInterface(ABC):
     @abstractmethod
     async def search_by_partial_name(self, query: str, limit: int = 10) -> list[User]:
         """
-        Searches users whose first_name or last_name partially matches the query (case-insensitive).
+        Searches users whose first_name, last_name or alias partially matches the query (case-insensitive).
 
         Solo devuelve cuentas activas: esta búsqueda está abierta a cualquier
         usuario registrado, así que una cuenta desactivada no puede aparecer en
@@ -222,7 +222,7 @@ class UserRepositoryInterface(ABC):
             limit (int): Número máximo de usuarios a retornar (default: 100)
             offset (int): Número de usuarios a saltar (default: 0)
             search (str | None): Si se indica, filtra por coincidencia parcial
-                (case-insensitive) en nombre, apellidos o email
+                (case-insensitive) en nombre, apellidos, alias o email
             is_admin (bool | None): Si se indica, filtra por rol (admin/jugador)
             is_active (bool | None): Si se indica, filtra por cuentas activas/desactivadas
             email_verified (bool | None): Si se indica, filtra por email verificado o no

--- a/src/modules/user/infrastructure/api/v1/user_routes.py
+++ b/src/modules/user/infrastructure/api/v1/user_routes.py
@@ -81,7 +81,7 @@ router = APIRouter()
     response_model=SearchUsersResponseDTO,
     status_code=status.HTTP_200_OK,
     summary="Autocompletar busqueda de usuarios",
-    description="Busca usuarios por nombre parcial para autocompletado.",
+    description="Busca usuarios por nombre o alias parcial para autocompletado.",
     tags=["Users"],
 )
 async def search_users_autocomplete(
@@ -91,7 +91,9 @@ async def search_users_autocomplete(
 ):
     """
     Endpoint de autocompletado para buscar usuarios por nombre parcial.
-    Devuelve hasta 10 resultados que coincidan parcialmente con el nombre o apellido.
+    Devuelve hasta 10 resultados que coincidan parcialmente con el nombre, el
+    apellido o el alias. Cada resultado lleva el alias junto al nombre real:
+    es lo que permite distinguir a dos jugadores parecidos.
     """
     return await use_case.execute(query)
 

--- a/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
+++ b/src/modules/user/infrastructure/persistence/in_memory/in_memory_user_repository.py
@@ -65,11 +65,13 @@ class InMemoryUserRepository(UserRepositoryInterface):
         q = search.strip().lower()
         full_name = f"{user.first_name} {user.last_name}".lower()
         email = str(user.email).lower() if user.email else ""
+        alias = user.alias.lower() if user.alias else ""
         return (
             q in user.first_name.lower()
             or q in user.last_name.lower()
             or q in full_name
             or q in email
+            or (bool(alias) and q in alias)
         )
 
     def _matches_filters(
@@ -142,10 +144,10 @@ class InMemoryUserRepository(UserRepositoryInterface):
 
     async def search_by_partial_name(self, query: str, limit: int = 10) -> list[User]:
         """
-        Searches active users by partial name match.
+        Searches active users by partial name or alias match.
 
         Requires at least 2 characters. Excluye las cuentas desactivadas, igual
-        que el repositorio real.
+        que el repositorio real, y busca en el alias por la misma razon.
         """
         query_lower = query.lower().strip()
         if len(query_lower) < self.MIN_SEARCH_LENGTH:
@@ -155,10 +157,12 @@ class InMemoryUserRepository(UserRepositoryInterface):
             if not user.is_active:
                 continue
             full_name = f"{user.first_name} {user.last_name}".lower()
+            alias = user.alias.lower() if user.alias else ""
             if (
                 query_lower in full_name
                 or query_lower in user.first_name.lower()
                 or query_lower in user.last_name.lower()
+                or (bool(alias) and query_lower in alias)
             ):
                 results.append(user)
                 if len(results) >= limit:

--- a/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
+++ b/src/modules/user/infrastructure/persistence/sqlalchemy/user_repository.py
@@ -62,6 +62,11 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
             func.lower(User._last_name).contains(q, autoescape=True),
             func.lower(User._first_name + " " + User._last_name).contains(q, autoescape=True),
             func.lower(User._email_value).contains(q, autoescape=True),
+            # El alias tambien: quien administra ve el nombre legal, pero si
+            # busca por el apodo que le han dado tiene que encontrar la cuenta.
+            # LOWER(NULL) es NULL, asi que las cuentas sin alias no se pierden:
+            # siguen entrando por cualquiera de las otras ramas del OR
+            func.lower(User._alias).contains(q, autoescape=True),
         )
 
     def _build_filters(
@@ -156,9 +161,11 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
 
     async def search_by_partial_name(self, query: str, limit: int = 10) -> list[User]:
         """
-        Searches active users by partial name match using ILIKE.
+        Searches active users by partial name or alias match using ILIKE.
 
-        Requires at least 2 characters.
+        Requires at least 2 characters. El alias entra en la busqueda porque es
+        justo lo que otra gente teclea para encontrarte: sin esto, ponerse un
+        apodo te hacia invisible para quien solo lo conoce por el.
 
         Las cuentas desactivadas se excluyen: cualquiera puede buscar por
         nombre, así que dejarlas visibles significa exponer a quien pidió
@@ -179,6 +186,7 @@ class SQLAlchemyUserRepository(UserRepositoryInterface):
                     func.lower(User._first_name + " " + User._last_name).contains(
                         q, autoescape=True
                     ),
+                    func.lower(User._alias).contains(q, autoescape=True),
                 ),
             )
             .limit(limit)

--- a/tests/integration/api/v1/test_competition_endpoints.py
+++ b/tests/integration/api/v1/test_competition_endpoints.py
@@ -199,7 +199,9 @@ class TestListCompetitions:
 
         start = date.today() + timedelta(days=30)
         end = start + timedelta(days=3)
-        await create_competition(
+        # El nombre se guarda normalizado —«del» sale como «Del»—, así que lo
+        # que se espera sale de la respuesta y no del literal que se envía
+        creada = await create_competition(
             client,
             user["cookies"],
             {
@@ -244,7 +246,7 @@ class TestListCompetitions:
 
         assert response.status_code == 200
         data = response.json()
-        assert [c["name"] for c in data] == ["Torneo del Chuchi"]
+        assert [c["name"] for c in data] == [creada["name"]]
 
     async def test_list_competitions_by_creator_ignores_a_blank_search(
         self, client: AsyncClient
@@ -339,7 +341,7 @@ class TestListCompetitions:
 
         start = date.today() + timedelta(days=30)
         end = start + timedelta(days=3)
-        await create_competition(
+        creada = await create_competition(
             client,
             user["cookies"],
             {
@@ -359,7 +361,7 @@ class TestListCompetitions:
 
         assert response.status_code == 200
         data = response.json()
-        assert [c["name"] for c in data] == ["Torneo de Ana"]
+        assert [c["name"] for c in data] == [creada["name"]]
 
     async def test_list_competitions_filter_by_search_name(self, client: AsyncClient):
         """Filtrar competiciones por nombre de búsqueda."""

--- a/tests/integration/api/v1/test_competition_endpoints.py
+++ b/tests/integration/api/v1/test_competition_endpoints.py
@@ -213,6 +213,31 @@ class TestListCompetitions:
             },
         )
 
+        # Una segunda competición de OTRO creador con OTRO alias. Sin ella el
+        # test pasaría aunque la búsqueda devolviera todo, que es justo el
+        # fallo que puede tener esta rama
+        otro = await create_authenticated_user(
+            client, "otroorganizador@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Anita"},
+            cookies=otro["cookies"],
+        )
+        await create_competition(
+            client,
+            otro["cookies"],
+            {
+                "name": "Torneo de Anita",
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "main_country": "ES",
+                "play_mode": "SCRATCH",
+                "max_players": 24,
+                "team_assignment": "MANUAL",
+            },
+        )
+
         response = await client.get(
             "/api/v1/competitions?search_creator=Chuchi", cookies=user["cookies"]
         )
@@ -220,6 +245,84 @@ class TestListCompetitions:
         assert response.status_code == 200
         data = response.json()
         assert [c["name"] for c in data] == ["Torneo del Chuchi"]
+
+    async def test_list_competitions_by_creator_ignores_a_blank_search(
+        self, client: AsyncClient
+    ):
+        """
+        Buscar por espacios no devuelve la lista entera.
+
+        `LOWER(alias) LIKE '%%'` casa con cualquier alias, así que recortar el
+        texto antes de buscarlo convertía «  » en «devuélvemelo todo». El texto
+        va tal cual, y dos espacios no casan con nada.
+        """
+        user = await create_authenticated_user(
+            client, "blanco@test.com", "P@ssw0rd123!", "Agustin", "Estevez"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Chuchi"},
+            cookies=user["cookies"],
+        )
+
+        start = date.today() + timedelta(days=30)
+        end = start + timedelta(days=3)
+        await create_competition(
+            client,
+            user["cookies"],
+            {
+                "name": "Torneo que no debe salir",
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "main_country": "ES",
+                "play_mode": "SCRATCH",
+                "max_players": 24,
+                "team_assignment": "MANUAL",
+            },
+        )
+
+        response = await client.get(
+            "/api/v1/competitions?search_creator=%20%20", cookies=user["cookies"]
+        )
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_competitions_by_creator_does_not_treat_a_percent_as_a_wildcard(
+        self, client: AsyncClient
+    ):
+        """
+        Un `%` tecleado se busca como carácter, no como comodín.
+
+        Interpolando el texto dentro del patrón —`ILIKE f"%{x}%"`— buscar `%`
+        devolvía todas las competiciones.
+        """
+        user = await create_authenticated_user(
+            client, "comodin@test.com", "P@ssw0rd123!", "Agustin", "Estevez"
+        )
+
+        start = date.today() + timedelta(days=30)
+        end = start + timedelta(days=3)
+        await create_competition(
+            client,
+            user["cookies"],
+            {
+                "name": "Torneo tampoco visible",
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "main_country": "ES",
+                "play_mode": "SCRATCH",
+                "max_players": 24,
+                "team_assignment": "MANUAL",
+            },
+        )
+
+        response = await client.get(
+            "/api/v1/competitions?search_creator=%25", cookies=user["cookies"]
+        )
+
+        assert response.status_code == 200
+        assert response.json() == []
 
     async def test_list_competitions_by_creator_still_finds_a_real_name(
         self, client: AsyncClient

--- a/tests/integration/api/v1/test_competition_endpoints.py
+++ b/tests/integration/api/v1/test_competition_endpoints.py
@@ -181,6 +181,83 @@ class TestListCompetitions:
         assert data[0]["status"] == "ACTIVE"
 
     @pytest.mark.asyncio
+    async def test_list_competitions_filter_by_creator_alias(self, client: AsyncClient):
+        """
+        Buscar por el creador encuentra también por su alias (BE #239).
+
+        Quien organiza aparece por su apodo en el resto de la aplicación, así
+        que buscarlo por el nombre que se ve en pantalla tiene que funcionar.
+        """
+        user = await create_authenticated_user(
+            client, "organizador@test.com", "P@ssw0rd123!", "Agustin", "Estevez"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Chuchi"},
+            cookies=user["cookies"],
+        )
+
+        start = date.today() + timedelta(days=30)
+        end = start + timedelta(days=3)
+        await create_competition(
+            client,
+            user["cookies"],
+            {
+                "name": "Torneo del Chuchi",
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "main_country": "ES",
+                "play_mode": "SCRATCH",
+                "max_players": 24,
+                "team_assignment": "MANUAL",
+            },
+        )
+
+        response = await client.get(
+            "/api/v1/competitions?search_creator=Chuchi", cookies=user["cookies"]
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [c["name"] for c in data] == ["Torneo del Chuchi"]
+
+    async def test_list_competitions_by_creator_still_finds_a_real_name(
+        self, client: AsyncClient
+    ):
+        """
+        La rama nueva del OR no puede tapar la búsqueda de siempre.
+
+        Quien no tiene alias —LOWER(NULL)— tiene que seguir apareciendo al
+        buscarlo por su nombre real.
+        """
+        user = await create_authenticated_user(
+            client, "sinapodo@test.com", "P@ssw0rd123!", "Ana", "Garcia"
+        )
+
+        start = date.today() + timedelta(days=30)
+        end = start + timedelta(days=3)
+        await create_competition(
+            client,
+            user["cookies"],
+            {
+                "name": "Torneo de Ana",
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "main_country": "ES",
+                "play_mode": "SCRATCH",
+                "max_players": 24,
+                "team_assignment": "MANUAL",
+            },
+        )
+
+        response = await client.get(
+            "/api/v1/competitions?search_creator=Garcia", cookies=user["cookies"]
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [c["name"] for c in data] == ["Torneo de Ana"]
+
     async def test_list_competitions_filter_by_search_name(self, client: AsyncClient):
         """Filtrar competiciones por nombre de búsqueda."""
         user = await create_authenticated_user(

--- a/tests/integration/api/v1/test_user_routes.py
+++ b/tests/integration/api/v1/test_user_routes.py
@@ -319,6 +319,85 @@ class TestUserRoutes:
         assert update_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # ========================================================================
+    # Tests del autocompletado por alias (BE #239)
+    # ========================================================================
+
+    async def test_autocomplete_finds_a_user_by_their_alias(self, client: AsyncClient):
+        """El autocompletado encuentra por alias, no solo por nombre."""
+        owner = await create_authenticated_user(
+            client, "auto1.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Chuchi"},
+            headers={"Authorization": f"Bearer {owner['token']}"},
+        )
+        searcher = await create_authenticated_user(
+            client, "auto2.test@example.com", "s3cur3P@ssw0rd!", "Otra", "Persona"
+        )
+
+        response = await client.get(
+            "/api/v1/users/search-autocomplete",
+            params={"query": "Chuchi"},
+            headers={"Authorization": f"Bearer {searcher['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        users = response.json()["users"]
+        assert [u["alias"] for u in users] == ["Chuchi"]
+        assert users[0]["full_name"] == "Agustin Estevez"
+
+    async def test_autocomplete_carries_a_null_alias_when_there_is_none(
+        self, client: AsyncClient
+    ):
+        """Quien no tiene alias sale igual, con el campo a null."""
+        await create_authenticated_user(
+            client, "auto3.test@example.com", "s3cur3P@ssw0rd!", "Ana", "Buscable"
+        )
+        searcher = await create_authenticated_user(
+            client, "auto4.test@example.com", "s3cur3P@ssw0rd!", "Otra", "Persona"
+        )
+
+        response = await client.get(
+            "/api/v1/users/search-autocomplete",
+            params={"query": "Buscable"},
+            headers={"Authorization": f"Bearer {searcher['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        users = response.json()["users"]
+        assert len(users) == 1
+        assert users[0]["alias"] is None
+
+    async def test_autocomplete_does_not_leak_the_email(self, client: AsyncClient):
+        """
+        El alias no amplía lo que esta búsqueda expone.
+
+        Sigue sin llevar correo, que es lo que se retiró para que no se
+        pudieran recolectar direcciones tecleando nombres sueltos.
+        """
+        owner = await create_authenticated_user(
+            client, "auto5.test@example.com", "s3cur3P@ssw0rd!", "Agustin", "Estevez"
+        )
+        await client.patch(
+            "/api/v1/users/profile",
+            json={"alias": "Discreto"},
+            headers={"Authorization": f"Bearer {owner['token']}"},
+        )
+        searcher = await create_authenticated_user(
+            client, "auto6.test@example.com", "s3cur3P@ssw0rd!", "Otra", "Persona"
+        )
+
+        response = await client.get(
+            "/api/v1/users/search-autocomplete",
+            params={"query": "Discreto"},
+            headers={"Authorization": f"Bearer {searcher['token']}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "email" not in response.json()["users"][0]
+
+    # ========================================================================
     # Tests del alias (BE #239)
     # ========================================================================
 

--- a/tests/integration/modules/user/infrastructure/persistence/sqlalchemy/test_user_repository.py
+++ b/tests/integration/modules/user/infrastructure/persistence/sqlalchemy/test_user_repository.py
@@ -229,3 +229,102 @@ async def test_find_by_alias_ignores_case(db_session):
 
     assert found is not None
     assert found.id == user.id
+
+
+async def test_search_by_partial_name_finds_a_user_by_alias(db_session):
+    """
+    El autocompletado encuentra por alias, por fragmento y sin distinguir
+    mayúsculas.
+
+    Es lo que hace útil el apodo: quien solo te conoce por él teclea eso.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    user = User.create(
+        first_name="Agustin",
+        last_name="Estevez",
+        email_str="busca.alias@example.com",
+        plain_password="ValidPassword123!",
+    )
+    user.update_profile(alias="Chuchi")
+    await repository.save(user)
+    await db_session.commit()
+
+    por_entero = await repository.search_by_partial_name("Chuchi")
+    por_fragmento = await repository.search_by_partial_name("chu")
+
+    assert [u.id for u in por_entero] == [user.id]
+    assert [u.id for u in por_fragmento] == [user.id]
+
+
+async def test_search_by_alias_does_not_resurface_deactivated_accounts(db_session):
+    """
+    El alias no es una puerta trasera a la regla de visibilidad.
+
+    Una cuenta desactivada no aparece en el autocompletado, y buscar por su
+    alias no puede saltarse eso: protege a quien pidió desactivarse.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    active = User.create(
+        first_name="Alicia",
+        last_name="Activa",
+        email_str="alias.activa@example.com",
+        plain_password="ValidPassword123!",
+    )
+    hidden = User.create(
+        first_name="Alberto",
+        last_name="Inactivo",
+        email_str="alias.inactivo@example.com",
+        plain_password="ValidPassword123!",
+    )
+    hidden.update_profile(alias="Escondido")
+    hidden.deactivate(deactivated_by_user_id=str(active.id.value))
+    await repository.save(active)
+    await repository.save(hidden)
+    await db_session.commit()
+
+    results = await repository.search_by_partial_name("Escondido")
+
+    assert results == []
+
+
+async def test_search_still_finds_accounts_without_an_alias(db_session):
+    """
+    La rama nueva del OR no puede tapar a nadie: LOWER(NULL) es NULL, así que
+    quien no tiene apodo sigue apareciendo por su nombre.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    user = User.create(
+        first_name="Ana",
+        last_name="Sinapodo",
+        email_str="sin.apodo@example.com",
+        plain_password="ValidPassword123!",
+    )
+    await repository.save(user)
+    await db_session.commit()
+
+    results = await repository.search_by_partial_name("Sinapodo")
+
+    assert [u.id for u in results] == [user.id]
+
+
+async def test_admin_listing_matches_the_alias_too(db_session):
+    """
+    El listado de administración busca también por alias.
+
+    Ahí se sigue viendo el nombre legal —quien administra necesita saber de
+    quién es la cuenta—, pero si busca por el apodo tiene que encontrarla.
+    """
+    repository = SQLAlchemyUserRepository(db_session)
+    user = User.create(
+        first_name="Agustin",
+        last_name="Estevez",
+        email_str="admin.busca@example.com",
+        plain_password="ValidPassword123!",
+    )
+    user.update_profile(alias="Chuchi")
+    await repository.save(user)
+    await db_session.commit()
+
+    results = await repository.find_all(search="Chuchi")
+
+    assert [u.id for u in results] == [user.id]

--- a/tests/unit/modules/user/infrastructure/persistence/test_in_memory_user_repository_search.py
+++ b/tests/unit/modules/user/infrastructure/persistence/test_in_memory_user_repository_search.py
@@ -87,3 +87,75 @@ async def test_the_limit_counts_only_visible_accounts():
     results = await repository.search_by_partial_name("Compartido", limit=2)
 
     assert visible.id in {found.id for found in results}
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_user_by_their_alias():
+    """
+    GIVEN: Una cuenta cuyo alias no se parece a su nombre
+    WHEN: Se busca por el alias
+    THEN: Aparece — sin esto, ponerse un apodo te haría invisible para quien
+          solo te conoce por él
+    """
+    repository = InMemoryUserRepository()
+    user = build_user("Agustin", "Estevez", "agustin@example.com")
+    user.update_profile(alias="Chuchi")
+    await repository.save(user)
+
+    results = await repository.search_by_partial_name("Chuchi")
+
+    assert [found.id for found in results] == [user.id]
+
+
+@pytest.mark.asyncio
+async def test_search_by_alias_matches_a_fragment_and_ignores_case():
+    """
+    GIVEN: Una cuenta con alias "Chuchi"
+    WHEN: Se busca "chu"
+    THEN: Aparece, igual que ocurre con el nombre
+    """
+    repository = InMemoryUserRepository()
+    user = build_user("Agustin", "Estevez", "agustin2@example.com")
+    user.update_profile(alias="Chuchi")
+    await repository.save(user)
+
+    results = await repository.search_by_partial_name("chu")
+
+    assert [found.id for found in results] == [user.id]
+
+
+@pytest.mark.asyncio
+async def test_search_by_alias_still_excludes_deactivated_accounts():
+    """
+    GIVEN: Una cuenta desactivada cuyo alias casa con la búsqueda
+    WHEN: Se busca por ese alias
+    THEN: No aparece — el alias no es una puerta trasera a la regla de
+          visibilidad que protege a quien pidió desactivarse
+    """
+    repository = InMemoryUserRepository()
+    active = build_user("Alicia", "Activa", "alicia2@example.com")
+    deactivated = build_user("Alberto", "Inactivo", "alberto2@example.com")
+    deactivated.update_profile(alias="Escondido")
+    deactivated.deactivate(deactivated_by_user_id=str(active.id.value))
+    await repository.save(active)
+    await repository.save(deactivated)
+
+    results = await repository.search_by_partial_name("Escondido")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_still_finds_users_without_an_alias():
+    """
+    GIVEN: Una cuenta sin alias
+    WHEN: Se busca por su apellido
+    THEN: Sigue apareciendo — la rama nueva del OR no puede tapar a nadie
+    """
+    repository = InMemoryUserRepository()
+    user = build_user("Ana", "Sinalias", "ana@example.com")
+    await repository.save(user)
+
+    results = await repository.search_by_partial_name("Sinalias")
+
+    assert [found.id for found in results] == [user.id]


### PR DESCRIPTION
Part 2 of #239: typing somebody's alias finds them. Part 1 shipped in #247; Part 3 (`display_name` in the response DTOs) comes next, on top of `develop`.

## What this adds

**The four queries that search users by name now match the alias too** — the public autocomplete, the admin listing (shared by `find_all`/`count_all`), the competition creator filter, and the in-memory repository so the unit tests exercise the same rule the real one enforces. Without this, setting a nickname made you invisible to the people who only know you by it, which is most of the point.

**The autocomplete returns `alias` next to the real name** (null when there is none). Showing only one of the two leaves you guessing: only the real name and you cannot tell which of the two "Chuchi" you found; only the alias and you cannot tell whose account it is. This does not widen what the search exposes — the alias is public by design — and the email is still absent, with a test saying so.

**The admin listing shows the alias next to the legal name.** It gained alias *matching* here, so without the field a search for "Chuchi" returned rows where nothing visible contained "Chuchi". Next to the real name, never instead of it: #239 is explicit that an admin has to know whose account it is.

## Two things worth reviewing

**A regression I introduced and then fixed** (`8c59065`). The alias branch stripped the query before searching it, and `if search_creator:` is true for `"  "` — so `contains("")` matched every non-NULL alias and `?search_creator=%20` returned the whole first page instead of nothing. The text now goes in as it arrives.

**The competition creator search stops interpolating the query into the pattern.** `ILIKE f"%{x}%"` meant a typed `%` returned every competition and a `_` matched any character. All three branches now use `LOWER(...).contains(..., autoescape=True)`. That part is pre-existing and technically outside #239, but the first version of this branch documented the hazard in a comment while leaving it in place, which was the wrong half of the job.

## Behaviour protected by tests

- A **deactivated account does not reappear** when searched by its alias — it would be a back door into the visibility rule that protects whoever asked to be deactivated. Tested in both repositories.
- **Accounts without an alias are not hidden** by the new OR branch: `LOWER(NULL)` is NULL, so they keep matching through the others. Tested in both repositories, because a search that quietly stopped finding people would be the worst possible way to learn it.
- The creator-alias test seeds a **second competition from a different creator**, so a branch that matched everything fails it.

## Deliberately not done

`find_by_full_name` (behind `GET /users/search?full_name=`) still resolves legal names only, so typing an alias there answers 404. It is an exact-match lookup, it is not one of the four queries #239 lists, and a fallback would mix two namespaces exactly where we accepted that an alias may be another user's real name. Written up on the issue.

## Testing

- 3027 unit tests green; `ruff` and `mypy` clean on everything touched.
- `/code-review high` before pushing; its findings are the last two commits.
- **Integration tests not run locally** — they need Postgres on 5434 and neither Docker nor the Kind cluster was up. CI covers them, and this branch adds four of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrmca8GvTCsF7tbjaM7Ss


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User searches and competition creator filters now match aliases alongside names.
  * Search results and administrative listings now include users’ aliases.
  * Autocomplete responses include alias and avatar details while omitting email addresses.
* **Bug Fixes**
  * Deactivated accounts remain excluded from searches.
  * Special characters such as `%` are treated literally rather than as wildcards.
* **Documentation**
  * Updated API and search behavior documentation to reflect alias matching and privacy rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->