### PR TITLE
fix(ci): Bump nltk past five CVEs that are breaking every build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,8 @@ mako==1.3.12
 # Fijada explícitamente para resolver:
 # - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
 # - CVE-2026-54293, CVE-2026-12243, CVE-2026-12252 (path traversal / firma criptográfica, GHSA Dependabot #29/#31)
-nltk==3.10.0
+# - CVE-2026-72818 (arreglada en 3.10.1) y CVE-2026-78680, -12876, -81723, -71513 (en 3.10.3)
+nltk==3.10.3
 
 # click - Command line interface creation kit (dependencia transitiva de nltk/safety/typer/uvicorn)
 # Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)


### PR DESCRIPTION
## What is broken

`pip-audit` is the arbiter of the **Security Checks** job — it fails the build on CVEs that already have a published fix — and `nltk 3.10.0` now has five:

| CVE | Fixed in |
|---|---|
| CVE-2026-72818 | 3.10.1 |
| CVE-2026-78680 | 3.10.3 |
| CVE-2026-12876 | 3.10.3 |
| CVE-2026-81723 | 3.10.3 |
| CVE-2026-71513 | 3.10.3 |

**Every PR is red until this moves, and `develop` is red too** — the pin is identical there; its last scheduled run (3 Sep) simply predates the advisories.

`nltk` is not imported anywhere in `src/`. It rides in as a transitive dependency of `safety`, the scanner itself, and is pinned by hand precisely because this keeps happening: the comment above the pin already lists ten earlier advisories.

## Verification

Ran the same `pip-audit` the workflow runs, locally, on 3.10.3:

- The five CVEs are **gone**.
- What remains for `nltk` is `PYSEC-2026-3740`, which has **no fix published** and does not count towards the job's threshold — it counts only ids starting with `CVE` that carry a `fix_versions` entry.

## Note

This was found while merging #255 (BE #254), whose build it was blocking. That PR was merged with an admin override on the owner's explicit call, since the failure predates it and touches no dependency file it changes. This PR is the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rze3QE1CDwfjmRbivTrbui