### PR TITLE
feat(competition): Default a competition to the player's legal name

### DIFF
--- a/alembic/versions/d1c4b7e93a52_name_preference_defaults_to_legal_name.py
+++ b/alembic/versions/d1c4b7e93a52_name_preference_defaults_to_legal_name.py
@@ -1,0 +1,56 @@
+"""name preference defaults to the legal name
+
+La 4aeb1cb3223f dejó `use_real_name` en `false`: una competición seguía
+mostrando el alias mientras nadie dijera lo contrario, que era el
+comportamiento anterior a BE #254.
+
+Se invierte por decisión de producto: una competición tiene lista de salida y
+clasificación pública, y ahí lo normal es el nombre legal. El alias pasa a ser
+lo que se pide a propósito, inscripción a inscripción.
+
+Se arrastran TAMBIÉN las inscripciones que ya existen, no solo las nuevas: el
+`server_default` a secas dejaría dos reglas conviviendo —las de antes con
+alias, las de después con nombre legal— sin nada en la pantalla que explicara
+la diferencia.
+
+El downgrade devuelve el `server_default` y pone todo a `false`. Lo que NO
+puede devolver es quién había elegido qué antes de este `UPDATE`: esa
+información no está en ninguna parte una vez aplicado.
+
+Revision ID: d1c4b7e93a52
+Revises: 4aeb1cb3223f
+Create Date: 2026-09-04
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d1c4b7e93a52"
+down_revision = "4aeb1cb3223f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "enrollments",
+        "use_real_name",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.true(),
+    )
+    op.execute("UPDATE enrollments SET use_real_name = true")
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "enrollments",
+        "use_real_name",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.false(),
+    )
+    op.execute("UPDATE enrollments SET use_real_name = false")

--- a/src/modules/competition/application/dto/enrollment_dto.py
+++ b/src/modules/competition/application/dto/enrollment_dto.py
@@ -267,7 +267,7 @@ class SetCustomHandicapResponseDTO(BaseModel):
 class SetNamePreferenceRequestDTO(BaseModel):
     """
     DTO de entrada para que un jugador elija cómo se le muestra en esta
-    competición: por su alias (por defecto) o por su nombre legal (BE #254).
+    competición: por su nombre legal (por defecto) o por su alias (BE #254).
     """
 
     enrollment_id: UUID = Field(..., description="ID de la inscripción.")
@@ -341,7 +341,7 @@ class EnrollmentResponseDTO(BaseModel):
     custom_handicap: Decimal | None = Field(None, description="Hándicap personalizado (si aplica).")
     tee_color: str | None = Field(None, description="Color de barras elegido por el jugador.")
     use_real_name: bool = Field(
-        False,
+        True,
         description="Si esta competición muestra el nombre legal del jugador en vez de su alias.",
     )
     created_at: datetime = Field(..., description="Fecha y hora de creación.")

--- a/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
+++ b/src/modules/competition/application/use_cases/get_scoring_view_use_case.py
@@ -308,7 +308,9 @@ class GetScoringViewUseCase:
             enrollment = await self._uow.enrollments.find_by_user_and_competition(
                 uid, competition_id
             )
+            # Sin inscripción no hay preferencia que leer, y en una competición
+            # lo que se muestra por defecto es el nombre legal (BE #254)
             names[uid] = user.display_name_or_legal(
-                bool(enrollment and enrollment.use_real_name)
+                enrollment.use_real_name if enrollment else True
             )
         return names

--- a/src/modules/competition/domain/entities/enrollment.py
+++ b/src/modules/competition/domain/entities/enrollment.py
@@ -51,7 +51,7 @@ class Enrollment:
         team_id: str | None = None,
         custom_handicap: Decimal | None = None,
         tee_color: TeeColor | None = None,
-        use_real_name: bool = False,
+        use_real_name: bool = True,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
         domain_events: list[DomainEvent] | None = None,
@@ -187,8 +187,10 @@ class Enrollment:
     def use_real_name(self) -> bool:
         """
         Si esta competición muestra el nombre legal del jugador en vez de su
-        alias (BE #254). `False` por defecto: mantiene el comportamiento de
-        antes de esta issue, donde el alias se pinta siempre que existe.
+        alias (BE #254). `True` por defecto: una competición tiene lista de
+        salida y clasificación pública, así que enseña el nombre legal salvo
+        que el jugador pida su alias para ella. En las partidas rápidas el
+        alias sigue siendo incondicional.
         """
         return self._use_real_name
 

--- a/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
+++ b/src/modules/competition/infrastructure/persistence/sqlalchemy/mappers.py
@@ -731,7 +731,7 @@ enrollments_table = Table(
     Column("team_id", String(10), nullable=True),
     Column("custom_handicap", Numeric(precision=4, scale=1), nullable=True),
     Column("tee_color", TeeColorDecorator, nullable=True),
-    Column("use_real_name", Boolean, nullable=False, server_default="false"),
+    Column("use_real_name", Boolean, nullable=False, server_default="true"),
     Column("created_at", DateTime, nullable=False),
     Column("updated_at", DateTime, nullable=False),
 )

--- a/tests/integration/api/v1/test_enrollment_endpoints.py
+++ b/tests/integration/api/v1/test_enrollment_endpoints.py
@@ -629,8 +629,8 @@ class TestSetNamePreference:
     async def test_enrolled_players_list_shows_the_chosen_name(self, client: AsyncClient):
         """
         La lista de inscritos —la que ve cualquiera que mire la competición—
-        enseña el nombre legal en cuanto el jugador lo elige, y el alias
-        antes de elegirlo.
+        arranca con el nombre legal, que es el defecto de una competición, y
+        pasa al alias en cuanto el jugador lo pide.
         """
         creator = await create_authenticated_user(
             client, "creator_np3@test.com", "P@ssw0rd123!", "Creator", "NamePrefThree"
@@ -654,12 +654,13 @@ class TestSetNamePreference:
             cookies=creator["cookies"],
         )
         before_dto = next(e for e in before.json() if e["id"] == enrollment_id)
-        assert before_dto["use_real_name"] is False
+        # Nadie ha elegido nada todavía y ya se muestra el nombre legal
+        assert before_dto["use_real_name"] is True
         assert before_dto["user"]["display_name"] == "Player NamePrefThree"
 
         await client.put(
             f"/api/v1/enrollments/{enrollment_id}/name-preference",
-            json={"use_real_name": True},
+            json={"use_real_name": False},
             cookies=player["cookies"],
         )
 
@@ -668,7 +669,8 @@ class TestSetNamePreference:
             cookies=creator["cookies"],
         )
         after_dto = next(e for e in after.json() if e["id"] == enrollment_id)
-        assert after_dto["use_real_name"] is True
+        assert after_dto["use_real_name"] is False
+        # Este jugador no tiene alias, así que el nombre que se pinta no cambia
         assert after_dto["user"]["display_name"] == "Player NamePrefThree"
 
     @pytest.mark.asyncio

--- a/tests/unit/modules/competition/application/use_cases/test_get_scoring_view_use_case.py
+++ b/tests/unit/modules/competition/application/use_cases/test_get_scoring_view_use_case.py
@@ -228,10 +228,9 @@ class TestScoringViewPaintsTheDisplayName:
 
 class TestScoringViewRespectsNamePreference:
     """
-    Salvo que la inscripción de esa competición haya elegido el nombre legal
-    (BE #254), en cuyo caso ese jugador se pinta por su nombre y el resto
-    sigue por su alias — la preferencia es por inscripción, no arrastra a
-    los demás jugadores del mismo partido.
+    Una competición pinta el nombre legal salvo que la inscripción haya pedido
+    el alias (BE #254), y esa elección es de esa inscripción: no arrastra a los
+    demás jugadores del mismo partido.
     """
 
     @pytest.fixture
@@ -252,23 +251,27 @@ class TestScoringViewRespectsNamePreference:
         return repo
 
     @pytest.mark.asyncio
-    async def test_el_jugador_que_eligio_su_nombre_legal_se_pinta_por_el(
+    async def test_el_jugador_que_pidio_su_alias_se_pinta_por_el_y_el_resto_no(
         self, uow, user_repo_con_alias
     ):
         match, yellow, red, gc_repo = await _setup(uow, _course_two_tees())
         # La única competición que `_setup` deja montada en el repo en memoria.
         competition_id = next(iter(uow._competitions._competitions.values())).id
-        enrollment = Enrollment.direct_enroll(
-            id=EnrollmentId.generate(),
-            competition_id=competition_id,
-            user_id=yellow.user_id,
-        )
-        enrollment.set_name_preference(True)
-        await uow.enrollments.add(enrollment)
+        for user_id, quiere_alias in ((yellow.user_id, True), (red.user_id, False)):
+            enrollment = Enrollment.direct_enroll(
+                id=EnrollmentId.generate(),
+                competition_id=competition_id,
+                user_id=user_id,
+            )
+            if quiere_alias:
+                enrollment.set_name_preference(False)
+            await uow.enrollments.add(enrollment)
 
         uc = GetScoringViewUseCase(uow, user_repo_con_alias, ScoringService(), gc_repo)
         view = await uc.execute(str(match.id))
 
         names = {p.user_id: p.user_name for p in view.players}
-        assert names[str(yellow.user_id)] == "Nombre Legal"
-        assert names[str(red.user_id)] == "Chuchi"
+        assert names[str(yellow.user_id)] == "Chuchi"
+        # Sin haber elegido nada: el nombre legal, que es el defecto de una
+        # competición desde que se invirtió
+        assert names[str(red.user_id)] == "Nombre Legal"

--- a/tests/unit/modules/competition/domain/entities/test_enrollment_name_preference.py
+++ b/tests/unit/modules/competition/domain/entities/test_enrollment_name_preference.py
@@ -1,0 +1,43 @@
+"""El nombre con el que una competición muestra a un jugador (BE #254)."""
+
+from src.modules.competition.domain.entities.enrollment import Enrollment
+from src.modules.competition.domain.value_objects.competition_id import CompetitionId
+from src.modules.competition.domain.value_objects.enrollment_id import EnrollmentId
+from src.modules.user.domain.value_objects.user_id import UserId
+
+
+class TestNamePreferenceDefault:
+    """
+    El valor de partida, que es una decisión de producto y no un detalle de la
+    columna: una competición tiene lista de salida y clasificación pública, así
+    que enseña el nombre legal mientras nadie pida su alias para ella.
+    """
+
+    def test_una_inscripcion_nueva_nace_con_el_nombre_legal(self):
+        enrollment = Enrollment.request(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId.generate(),
+            user_id=UserId.generate(),
+        )
+
+        assert enrollment.use_real_name is True
+
+    def test_la_inscripcion_directa_del_creador_tambien(self):
+        enrollment = Enrollment.direct_enroll(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId.generate(),
+            user_id=UserId.generate(),
+        )
+
+        assert enrollment.use_real_name is True
+
+    def test_pedir_el_alias_es_una_eleccion_explicita(self):
+        enrollment = Enrollment.request(
+            id=EnrollmentId.generate(),
+            competition_id=CompetitionId.generate(),
+            user_id=UserId.generate(),
+        )
+
+        enrollment.set_name_preference(False)
+
+        assert enrollment.use_real_name is False


### PR DESCRIPTION
Closes #257

BE #254 shipped `use_real_name` defaulting to `false`, which kept the behaviour of the time: the alias everywhere. A competition has a starting sheet and public standings, so the legal name is what belongs there, and the alias becomes the thing a player asks for, enrollment by enrollment.

## What is in here

- `use_real_name` defaults to **true** on the entity, on `EnrollmentResponseDTO` and on the column's `server_default`.
- A **new migration** (`d1c4b7e93a52`) rather than editing `4aeb1cb3223f`: that one is already merged into `develop` and applied in local environments, so rewriting it would leave those databases silently out of step.
- The migration runs `UPDATE enrollments SET use_real_name = true` alongside the default change: moving only the default would leave older enrollments on the alias and newer ones on the legal name, with nothing on screen to explain why.
- The scoring view's fallback for a participant with no enrollment now reads legal name instead of alias, for the same reason.

## What is deliberately untouched

- **Quick matches** — the alias there is unconditional and stays that way.
- The endpoint, its body and its permissions.
- Anything that renders a name: the backend keeps resolving it before sending.

## The downgrade

Restores the `server_default` and sets every row back to `false`. It cannot restore **who had chosen what** before the `UPDATE` — that is gone once applied.

## Deploy order

The frontend half is RyderCupWeb FE #571. This one goes **first**, and the two should go out together: alone, each leaves a window where either nobody can recover their alias, or the switch shows up turned on for everyone.

## Checks

- `pytest tests/unit/` — 3056 passed
- `pytest tests/integration -n 2` — 480 passed, 1 skipped
- `ruff check` clean on the touched files, `mypy src/` clean
- Migration verified with `alembic upgrade 4aeb1cb3223f:d1c4b7e93a52 --sql`, without touching any database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rze3QE1CDwfjmRbivTrbui