### PR TITLE
fix(user): Send a quick match's name in the recent-matches history

### DIFF
--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -104,6 +104,14 @@ class RecentMatchDTO(BaseModel):
     scoring_format: str | None = None
     golf_course_id: str | None = None
     golf_course_name: str | None = None
+    match_name: str | None = Field(
+        default=None,
+        description=(
+            "El nombre que le puso quien creó la partida rápida. Nulo en un "
+            "partido de torneo, que no tiene nombre propio: tiene el de su "
+            "competición, y ese va en `tournament_name`."
+        ),
+    )
     tournament_name: str | None = None
     result: str | None = Field(
         default=None, description="WON / LOST / HALVED en match play; None si no aplica"

--- a/src/modules/user/application/use_cases/get_recent_matches_use_case.py
+++ b/src/modules/user/application/use_cases/get_recent_matches_use_case.py
@@ -334,6 +334,10 @@ class GetRecentMatchesUseCase:
             scoring_format=match.scoring_format.value if match.scoring_format else None,
             golf_course_id=str(match.golf_course_id.value),
             golf_course_name=course.name if course else None,
+            # Lo que el jugador le puso al crearla, que es como reconoce la
+            # partida después. Es opcional: sin nombre viaja nulo y el cliente
+            # decide con qué titular la fila (BE #261)
+            match_name=match.name,
             tournament_name=None,
             result=result,
             score=score,
@@ -398,6 +402,9 @@ class GetRecentMatchesUseCase:
             scoring_format=None,
             golf_course_id=str(raw.round_.golf_course_id.value),
             golf_course_name=course.name if course else None,
+            # Un partido de torneo no tiene nombre propio: tiene el de su
+            # competición, que va en `tournament_name`
+            match_name=None,
             tournament_name=raw.tournament_name,
             result=self._result_for_team(match.get_winner(), "A" if in_team_a else "B"),
             score=match.result.get("score") if match.result else None,

--- a/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_recent_matches_use_case.py
@@ -156,6 +156,7 @@ async def played_quick_match(
     scoring_participant_indexes: set[int] | None = None,
     creator_tee_color: TeeColor | None = None,
     creator_tee_gender: Gender | None = None,
+    name: str | None = None,
 ):
     """
     Una partida rápida terminada con la vuelta anotada.
@@ -175,6 +176,7 @@ async def played_quick_match(
         scoring_format=scoring_format,
         creator_tee_color=creator_tee_color,
         creator_tee_gender=creator_tee_gender,
+        name=name,
     )
     for participant in others:
         match.add_participant(participant)
@@ -1189,3 +1191,67 @@ class TestParPorBarra:
         feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(user.id)
 
         assert feed.matches[0].stableford_points == 38
+
+
+@pytest.mark.asyncio
+class TestMatchName:
+    """
+    El nombre que le puso quien creó la partida rápida (BE #261). Sin él, el
+    historial no tenía con qué titular la fila y el cliente acababa poniendo el
+    nombre del rival donde se espera el de la partida.
+    """
+
+    async def test_a_quick_match_carries_the_name_it_was_created_with(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        player = await create_user(user_uow, "Named", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_quick_match(qm_uow, course, player, name="Meis Fourball")
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].match_name == "Meis Fourball"
+
+    async def test_a_quick_match_without_a_name_sends_null(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        El nombre es opcional, y quien no lo puso no tiene que recibir una
+        cadena vacía que el cliente confunda con un nombre de verdad.
+        """
+        player = await create_user(user_uow, "Nameless", handicap=0)
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_quick_match(qm_uow, course, player)
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].match_name is None
+
+    async def test_a_tournament_match_has_no_name_of_its_own(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """
+        Tiene el de su competición, y ese ya viaja en `tournament_name`.
+        """
+        player = await create_user(user_uow, "Tourney", handicap=0)
+        rival = await create_user(user_uow, "Away")
+        course = await create_golf_course(golf_course_uow, player.id)
+        await played_competition_match(
+            competition_uow,
+            course,
+            team_a_user_ids=[player.id],
+            team_b_user_ids=[rival.id],
+            round_date=date(2026, 6, 1),
+            result={"winner": "A", "score": "2UP"},
+        )
+
+        feed = await _use_case(user_uow, competition_uow, qm_uow, golf_course_uow).execute(
+            player.id
+        )
+
+        assert feed.matches[0].match_name is None
+        assert feed.matches[0].tournament_name == "Ryder Cup Test"


### PR DESCRIPTION
Closes #261

`GET /users/me/recent-matches` hardcoded `tournament_name=None` for a quick match and never sent `QuickMatch.name` — the name whoever created it typed in, and how a player recognises the match afterwards. With nothing to title the row, the dashboard fell back to the opponents' names: you read "Rival Real" where you expect "Meis Fourball".

## What changed

- `match_name: str | None` on `RecentMatchDTO`, filled from `QuickMatch.name`.
- A tournament match sends `null` there: it has no name of its own, it has its competition's, and that already travels in `tournament_name`.

Its own field rather than reusing `tournament_name`, because the client tells the two apart through `isFromTournament()`, which keys off `tournament_name` being present. Merging them would have made every quick match look like a tournament one.

**Additive**, so the current frontend keeps working untouched — it just ignores the field until RyderCupWeb#575 ships.

## Checks

- `pytest tests/unit/` — 3062 passed, including three new ones: a named quick match, one without a name (must be `null`, not `""`), and a tournament match.
- `ruff` clean on the touched files, `mypy src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rze3QE1CDwfjmRbivTrbui