### PR TITLE
chore(release): Prepare v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-09-06
+
+### Added
+
+- **Desglose de golpes del jugador: dónde gana y dónde pierde.** Las métricas que ya había dicen *cuánto* juega de bien —media respecto al par, diferencial, índice estimado—. Estas dicen **dónde**, que es lo que se puede llevar al campo de prácticas (#168).
+
+  `GET /users/me/stats/breakdown` devuelve cuatro cosas: en qué acaban los hoyos (birdie o mejor, par, bogey, doble o peor), la media respecto al par **separada por el par del hoyo**, los primeros nueve contra los segundos, y la media por campo de mejor a peor.
+
+  **Sin un solo dato nuevo ni migración**: sale de las tarjetas que ya se guardan.
+
+  Decisiones que conviene conocer antes de consumirlo:
+
+  - **La distribución viene en bruto y en neto.** En bruto un birdie es un birdie; en neto un jugador de hándicap alto ve los pares netos que sí está haciendo en lugar de una lista de bogeys que no le dice dónde mejora. Medido sobre una vuelta real: la misma tarjeta son 0 birdies y 3 dobles en bruto, y 2 birdies y ningún doble en neto.
+  - **Hay dos escalas, a propósito.** Por par y por mitad de vuelta son medias **por hoyo** —escalar un par 3 a dieciocho hoyos no significa nada—; por campo va **por vuelta de 18**, que es la escala de `scoring_avg` y con la que hay que poder compararla.
+  - **Una entrada por cada par jugado de verdad**, no una lista fija de 3-4-5: hay hoyos par 6 y un pitch & putt es todo par 3.
+  - Las vueltas sin campo conocido quedan fuera del ranking de campos —no hay con qué compararlas— pero cuentan en todo lo demás.
+
+  Mide **exactamente** las vueltas que mide la media, porque ambos leen de la misma recolección. Una cuenta sin historial devuelve ceros y listas vacías, no un 404.
+
+### Fixed
+
+- **Un doble bogey de un jugador *plus* se contaba como bogey** en la distribución en bruto. El bruto se derivaba del golpe ya topado en el doble bogey neto; para quien recibe golpes el tope está por encima del par y no cambia nada, pero un jugador plus recibe golpes negativos y el tope cae por debajo. Ahora los golpes dados y los computables viajan por separado, que es como el calculador de partida rápida ya los trataba.
+
 ## [2.15.0] - 2026-09-05
 
 ### Added

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -10,7 +10,7 @@ una release ha llegado realmente a produccion.
 
 import os
 
-APP_VERSION = "2.15.0"
+APP_VERSION = "2.16.0"
 
 
 def get_deployed_commit() -> str:

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -4,7 +4,7 @@
 # clase: de ahi el alias
 from datetime import date as date_type
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PlayerStatsResponseDTO(BaseModel):
@@ -180,8 +180,7 @@ class HoleDistributionDTO(BaseModel):
     double_or_worse: int = Field(0, description="Hoyos en doble bogey o peor")
     holes: int = Field(0, description="Hoyos contados en esta distribución")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ParPerformanceDTO(BaseModel):
@@ -193,8 +192,7 @@ class ParPerformanceDTO(BaseModel):
         ..., description="Media neta respecto al par, POR HOYO (+0.8 = casi un golpe de más)"
     )
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class NinePerformanceDTO(BaseModel):
@@ -203,8 +201,7 @@ class NinePerformanceDTO(BaseModel):
     holes: int = Field(..., description="Hoyos contados en esa mitad")
     average_to_par: float = Field(..., description="Media neta respecto al par, POR HOYO")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CoursePerformanceDTO(BaseModel):
@@ -217,8 +214,7 @@ class CoursePerformanceDTO(BaseModel):
         ..., description="Media neta respecto al par por vuelta de 18, como `scoring_avg`"
     )
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ScoringBreakdownResponseDTO(BaseModel):
@@ -260,5 +256,4 @@ class ScoringBreakdownResponseDTO(BaseModel):
         default_factory=list, description="Campos ordenados de mejor a peor media"
     )
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/src/modules/user/application/dto/player_stats_dto.py
+++ b/src/modules/user/application/dto/player_stats_dto.py
@@ -159,3 +159,106 @@ class RecentMatchesResponseDTO(BaseModel):
     """Historial de partidas del jugador, de la más reciente a la más antigua."""
 
     matches: list[RecentMatchDTO] = Field(default_factory=list)
+
+
+# ============================================================================
+# Desglose de golpes (BE #168)
+# ============================================================================
+
+
+class HoleDistributionDTO(BaseModel):
+    """
+    Cuántos hoyos acabaron en cada cesta, sobre el total contado.
+
+    Se devuelven cuentas y no porcentajes: el porcentaje se saca dividiendo, y
+    dar los dos invita a que dejen de cuadrar.
+    """
+
+    birdie_or_better: int = Field(0, description="Hoyos en birdie o mejor")
+    par: int = Field(0, description="Hoyos en par")
+    bogey: int = Field(0, description="Hoyos en bogey")
+    double_or_worse: int = Field(0, description="Hoyos en doble bogey o peor")
+    holes: int = Field(0, description="Hoyos contados en esta distribución")
+
+    class Config:
+        from_attributes = True
+
+
+class ParPerformanceDTO(BaseModel):
+    """Rendimiento en los hoyos de un par concreto."""
+
+    par: int = Field(..., description="Par del hoyo (3, 4, 5 o 6)")
+    holes: int = Field(..., description="Hoyos de ese par contados")
+    average_to_par: float = Field(
+        ..., description="Media neta respecto al par, POR HOYO (+0.8 = casi un golpe de más)"
+    )
+
+    class Config:
+        from_attributes = True
+
+
+class NinePerformanceDTO(BaseModel):
+    """Rendimiento en una mitad de la vuelta."""
+
+    holes: int = Field(..., description="Hoyos contados en esa mitad")
+    average_to_par: float = Field(..., description="Media neta respecto al par, POR HOYO")
+
+    class Config:
+        from_attributes = True
+
+
+class CoursePerformanceDTO(BaseModel):
+    """Rendimiento en un campo, en la escala de una vuelta de 18."""
+
+    golf_course_id: str = Field(..., description="ID del campo")
+    golf_course_name: str | None = Field(None, description="Nombre del campo")
+    rounds: int = Field(..., description="Vueltas contadas en ese campo")
+    average_to_par: float = Field(
+        ..., description="Media neta respecto al par por vuelta de 18, como `scoring_avg`"
+    )
+
+    class Config:
+        from_attributes = True
+
+
+class ScoringBreakdownResponseDTO(BaseModel):
+    """
+    Dónde gana y dónde pierde los golpes un jugador.
+
+    `scoring_avg` dice cuánto juega de bien; esto dice dónde, que es lo que se
+    puede llevar al campo de prácticas. Sale de las mismas tarjetas y de las
+    mismas vueltas computables que la media, con el mismo tope de doble bogey
+    neto: los dos números no pueden contar historias distintas.
+
+    **Las medias van en dos escalas distintas, y es a propósito.** Por par y por
+    mitad de vuelta son medias POR HOYO —escalar un par 3 a 18 hoyos no
+    significa nada—; por campo va por vuelta de 18, que es la escala en la que
+    ya se publica `scoring_avg` y con la que hay que poder compararla.
+
+    La distribución se da **en bruto y en neto**: en bruto un birdie es un
+    birdie, y en neto un jugador de hándicap alto ve los pares netos que hace
+    en lugar de una lista de bogeys que no le dice dónde mejorar.
+
+    Una cuenta sin vueltas devuelve ceros y listas vacías, no un 404.
+    """
+
+    holes_counted: int = Field(0, description="Hoyos contados en todo el desglose")
+    rounds_counted: int = Field(0, description="Vueltas computables contadas")
+    gross_distribution: HoleDistributionDTO = Field(
+        default_factory=HoleDistributionDTO, description="Distribución en bruto"
+    )
+    net_distribution: HoleDistributionDTO = Field(
+        default_factory=HoleDistributionDTO, description="Distribución en neto"
+    )
+    by_par: list[ParPerformanceDTO] = Field(
+        default_factory=list,
+        description="Una entrada por cada par jugado de verdad, de menor a mayor",
+    )
+    front_nine: NinePerformanceDTO | None = Field(None, description="Hoyos 1-9")
+    back_nine: NinePerformanceDTO | None = Field(None, description="Hoyos 10-18")
+    by_course: list[CoursePerformanceDTO] = Field(
+        default_factory=list, description="Campos ordenados de mejor a peor media"
+    )
+
+    class Config:
+        from_attributes = True

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -1,6 +1,6 @@
 """Caso de Uso: resumen de rendimiento de un jugador (BE #128, BE #167)."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date as date_type
 from decimal import Decimal
 
@@ -25,12 +25,20 @@ from src.modules.quick_match.domain.services.stableford_calculator import (
     StablefordCalculator,
 )
 from src.modules.quick_match.domain.value_objects.quick_match_status import QuickMatchStatus
-from src.modules.user.application.dto.player_stats_dto import PlayerStatsResponseDTO
+from src.modules.user.application.dto.player_stats_dto import (
+    PlayerStatsResponseDTO,
+    ScoringBreakdownResponseDTO,
+)
 from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
+from src.modules.user.domain.services.scoring_breakdown_calculator import (
+    RoundOutcome,
+    ScoringBreakdownCalculator,
+)
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.domain.services.countable_round import HALF_ROUND_HOLES, countable_holes
+from src.shared.domain.value_objects.hole_outcome import HoleOutcome
 
 # Tope de partidas que se agregan para la media, por cada fuente. Sin él, una
 # cuenta con años de historial cargaría todos sus scores para calcular un único
@@ -57,6 +65,11 @@ class _ComputableRound:
     played_on: date_type
     to_par: int
     played_round: PlayedRound | None
+    # Los hoyos de la vuelta, para el desglose de golpes (BE #168). La media de
+    # arriba se suma de estos mismos, así que las dos vistas no pueden discrepar.
+    holes: list[HoleOutcome] = field(default_factory=list)
+    golf_course_id: str | None = None
+    golf_course_name: str | None = None
 
 
 class GetPlayerStatsUseCase:
@@ -102,20 +115,73 @@ class GetPlayerStatsUseCase:
         self._golf_course_uow = golf_course_uow
         self._calculator = stableford_calculator or StablefordCalculator()
         self._differentials = differential_calculator or ScoreDifferentialCalculator()
+        self._breakdown = ScoringBreakdownCalculator()
 
-    async def execute(
+    async def execute_breakdown(
         self, user_id: UserId, golf_course_id: GolfCourseId | None = None
-    ) -> PlayerStatsResponseDTO:
+    ) -> ScoringBreakdownResponseDTO:
         """
-        Resumen del jugador, opcionalmente restringido a un campo.
+        Desglose de golpes del jugador (BE #168): dónde gana y dónde pierde.
 
-        Con `golf_course_id` solo entran las rondas de ese campo, y los
-        contadores de torneos se dejan a cero: son globales del jugador y
-        repetirlos en un desglose por campo induciría a error.
+        Mide sobre EXACTAMENTE las mismas vueltas que `execute`, porque sale de
+        la misma recolección: si una tarjeta no entra en la media tampoco entra
+        aquí, y al revés. Dos recorridos distintos acabarían dando dos verdades.
+
+        Una cuenta sin vueltas devuelve el desglose vacío, no un 404: el panel
+        de un usuario nuevo es un caso normal.
         """
+        rounds = await self._collect_rounds(user_id, golf_course_id)
+
+        breakdown = self._breakdown.compute(
+            [
+                RoundOutcome(
+                    golf_course_id=item.golf_course_id,
+                    golf_course_name=item.golf_course_name,
+                    holes=item.holes,
+                )
+                for item in rounds
+            ]
+        )
+
+        return ScoringBreakdownResponseDTO.model_validate(breakdown)
+
+    async def _profile_handicap(self, user_id: UserId) -> float | None:
+        """El hándicap del perfil, o None si el jugador no tiene."""
         async with self._user_uow:
             user = await self._user_uow.users.find_by_id(user_id)
-            handicap = float(user.handicap.value) if user and user.handicap else None
+            return float(user.handicap.value) if user and user.handicap else None
+
+    async def _tournament_counters(
+        self, user_id: UserId, golf_course_id: GolfCourseId | None
+    ) -> tuple[int, int]:
+        """
+        Torneos totales y activos del jugador.
+
+        Con un campo elegido van a cero: son globales del jugador y repetirlos
+        dentro de un desglose por campo daría a entender que jugó ahí esos
+        torneos.
+        """
+        if golf_course_id is not None:
+            return 0, 0
+
+        async with self._competition_uow:
+            enrollments = await self._competition_uow.enrollments.find_by_user(user_id)
+            active = await self._competition_uow.enrollments.count_active_by_user(user_id)
+
+        return len(enrollments), active
+
+    async def _collect_rounds(
+        self, user_id: UserId, golf_course_id: GolfCourseId | None
+    ) -> list["_ComputableRound"]:
+        """
+        Las vueltas computables del jugador, de las dos fuentes y ya ordenadas.
+
+        La usan el resumen Y el desglose, y esa es la razón de que exista: si
+        cada uno recolectara por su cuenta, bastaría con tocar una de las dos
+        copias para que la media y el desglose dejaran de hablar de las mismas
+        vueltas, sin que ningún test lo viera.
+        """
+        handicap = await self._profile_handicap(user_id)
 
         quick_rounds = await self._collect_quick_match_rounds(user_id, golf_course_id, handicap)
 
@@ -139,24 +205,32 @@ class GetPlayerStatsUseCase:
                 for match in competition_matches
             }
 
-            tournaments_total = 0
-            tournaments_active = 0
-            if golf_course_id is None:
-                enrollments = await self._competition_uow.enrollments.find_by_user(user_id)
-                tournaments_total = len(enrollments)
-                tournaments_active = (
-                    await self._competition_uow.enrollments.count_active_by_user(user_id)
-                )
-
         competition_rounds = await self._collect_competition_rounds(
             user_id, competition_matches, rounds_by_match, scorecards, handicap
         )
 
         # Las dos fuentes llegan ordenadas por su cuenta; el registro del WHS es
         # cronológico y no distingue de dónde salió cada vuelta
-        computable_rounds = sorted(
+        return sorted(
             quick_rounds + competition_rounds, key=lambda item: item.played_on, reverse=True
         )
+
+    async def execute(
+        self, user_id: UserId, golf_course_id: GolfCourseId | None = None
+    ) -> PlayerStatsResponseDTO:
+        """
+        Resumen del jugador, opcionalmente restringido a un campo.
+
+        Con `golf_course_id` solo entran las rondas de ese campo, y los
+        contadores de torneos se dejan a cero: son globales del jugador y
+        repetirlos en un desglose por campo induciría a error.
+        """
+        handicap = await self._profile_handicap(user_id)
+        computable_rounds = await self._collect_rounds(user_id, golf_course_id)
+        tournaments_total, tournaments_active = await self._tournament_counters(
+            user_id, golf_course_id
+        )
+
         differentials = self._differentials.differentials(
             [item.played_round for item in computable_rounds if item.played_round is not None]
         )
@@ -288,6 +362,14 @@ class GetPlayerStatsUseCase:
                             tee_color=participant.tee_color,
                             tee_gender=participant.tee_gender,
                         ),
+                        holes=self._quick_match_hole_outcomes(
+                            holes=holes,
+                            scores_by_hole=scores_by_hole,
+                            handicap=scoring_handicap,
+                            allowance_percentage=match.get_effective_allowance(),
+                        ),
+                        golf_course_id=str(course.id) if course is not None else None,
+                        golf_course_name=str(course.name) if course is not None else None,
                     )
                 )
 
@@ -373,6 +455,9 @@ class GetPlayerStatsUseCase:
                             tee_color=player.tee_color if player else None,
                             tee_gender=player.tee_gender if player else None,
                         ),
+                        holes=self._competition_hole_outcomes(hole_scores, hole_card) or [],
+                        golf_course_id=str(course.id) if course is not None else None,
+                        golf_course_name=str(course.name) if course is not None else None,
                     )
                 )
 
@@ -543,6 +628,27 @@ class GetPlayerStatsUseCase:
         número: sin número está la raya y está el hoyo que nadie tocó, y
         significan lo contrario.
         """
+        outcomes = self._competition_hole_outcomes(hole_scores, hole_card)
+        if outcomes is None:
+            return None
+
+        to_par = sum(outcome.net_to_par for outcome in outcomes)
+        return self._to_eighteen(to_par, len(outcomes))
+
+    def _competition_hole_outcomes(
+        self, hole_scores: list, hole_card: list
+    ) -> list[HoleOutcome] | None:
+        """
+        Los hoyos de una tarjeta de competición, o None si no forman vuelta.
+
+        Es el mismo recorrido que alimenta la media —de hecho la media se suma
+        de aquí— para que el desglose (BE #168) no mida sobre otros hoyos ni con
+        otro tope que el titular del panel.
+
+        Los golpes recibidos vienen del propio hoyo guardado, no se recalculan:
+        en competición el reparto se resolvió al anotar y es lo que el jugador
+        vio.
+        """
         scored = {
             hole_score.hole_number: hole_score
             for hole_score in hole_scores
@@ -552,7 +658,7 @@ class GetPlayerStatsUseCase:
         if played is None:
             return None
 
-        to_par = 0
+        outcomes = []
         for hole in played:
             hole_score = scored[hole.number]
             if hole_score.own_score is None:
@@ -563,9 +669,67 @@ class GetPlayerStatsUseCase:
                 computable = self._calculator.adjusted_gross(
                     hole_score.own_score, hole.par, hole_score.strokes_received
                 )
-            to_par += computable - hole_score.strokes_received - hole.par
+            outcomes.append(
+                HoleOutcome(
+                    number=hole.number,
+                    par=hole.par,
+                    adjusted_gross=computable,
+                    strokes_received=hole_score.strokes_received,
+                )
+            )
 
-        return self._to_eighteen(to_par, len(played))
+        return outcomes
+
+    def _quick_match_hole_outcomes(
+        self,
+        holes: list,
+        scores_by_hole: dict,
+        handicap: float | None,
+        allowance_percentage: int,
+    ) -> list[HoleOutcome]:
+        """
+        Los hoyos de una partida rápida, con el mismo tope que la media.
+
+        Aquí los golpes recibidos SÍ se calculan, porque en partida rápida el
+        reparto no se guarda hoyo a hoyo: sale del hándicap, del índice de
+        dificultad y del allowance, exactamente como al puntuar.
+
+        Se usa el calculador por sus métodos públicos y no se toca: su reparto
+        vive en el arnés de paridad con el frontend, y cambiarlo obliga a
+        regenerar el JSON de referencia.
+
+        La raya —clave presente con valor None, el hoyo recogido— vale doble
+        bogey neto, que es lo que el WHS manda anotar en un hoyo sin terminar.
+        Un hoyo que nadie tocó no está en `scores_by_hole` y no entra.
+        """
+        strokes_basis = self._calculator.resolve_strokes_basis(
+            handicap, None, allowance_percentage
+        )
+
+        outcomes = []
+        for hole in holes:
+            if hole.hole_number not in scores_by_hole:
+                continue
+
+            strokes_received = self._calculator.allocate_strokes(
+                strokes_basis, hole.stroke_index
+            )
+            score = scores_by_hole[hole.hole_number]
+            computable = (
+                self._calculator.net_double_bogey(hole.par, strokes_received)
+                if score is None
+                else self._calculator.adjusted_gross(score, hole.par, strokes_received)
+            )
+            outcomes.append(
+                HoleOutcome(
+                    number=hole.hole_number,
+                    par=hole.par,
+                    adjusted_gross=computable,
+                    strokes_received=strokes_received,
+                )
+            )
+
+        return outcomes
 
     # ==================== Jugadores y hándicaps ====================
 

--- a/src/modules/user/application/use_cases/get_player_stats_use_case.py
+++ b/src/modules/user/application/use_cases/get_player_stats_use_case.py
@@ -21,6 +21,7 @@ from src.modules.quick_match.domain.repositories.quick_match_unit_of_work_interf
     QuickMatchUnitOfWorkInterface,
 )
 from src.modules.quick_match.domain.services.stableford_calculator import (
+    NET_DOUBLE_BOGEY_OVER_PAR,
     HoleSetup,
     StablefordCalculator,
 )
@@ -130,7 +131,9 @@ class GetPlayerStatsUseCase:
         Una cuenta sin vueltas devuelve el desglose vacío, no un 404: el panel
         de un usuario nuevo es un caso normal.
         """
-        rounds = await self._collect_rounds(user_id, golf_course_id)
+        rounds = await self._collect_rounds(
+            user_id, golf_course_id, await self._profile_handicap(user_id)
+        )
 
         breakdown = self._breakdown.compute(
             [
@@ -171,7 +174,7 @@ class GetPlayerStatsUseCase:
         return len(enrollments), active
 
     async def _collect_rounds(
-        self, user_id: UserId, golf_course_id: GolfCourseId | None
+        self, user_id: UserId, golf_course_id: GolfCourseId | None, handicap: float | None
     ) -> list["_ComputableRound"]:
         """
         Las vueltas computables del jugador, de las dos fuentes y ya ordenadas.
@@ -181,8 +184,6 @@ class GetPlayerStatsUseCase:
         copias para que la media y el desglose dejaran de hablar de las mismas
         vueltas, sin que ningún test lo viera.
         """
-        handicap = await self._profile_handicap(user_id)
-
         quick_rounds = await self._collect_quick_match_rounds(user_id, golf_course_id, handicap)
 
         async with self._competition_uow:
@@ -226,7 +227,7 @@ class GetPlayerStatsUseCase:
         repetirlos en un desglose por campo induciría a error.
         """
         handicap = await self._profile_handicap(user_id)
-        computable_rounds = await self._collect_rounds(user_id, golf_course_id)
+        computable_rounds = await self._collect_rounds(user_id, golf_course_id, handicap)
         tournaments_total, tournaments_active = await self._tournament_counters(
             user_id, golf_course_id
         )
@@ -421,9 +422,12 @@ class GetPlayerStatsUseCase:
                 hole_scores = scorecards.get(match.id, [])
                 player = self._find_match_player(match, user_id)
                 hole_card = self._hole_card(course, player)
-                to_par = self._scorecard_to_par(hole_scores, hole_card)
-                if to_par is None:
+                outcomes = self._competition_hole_outcomes(hole_scores, hole_card)
+                if outcomes is None:
                     continue
+                to_par = self._to_eighteen(
+                    sum(outcome.net_to_par for outcome in outcomes), len(outcomes)
+                )
 
                 # Por `own_submitted`, no por si hay número: la raya (hoyo
                 # recogido) está anotada y sin número, y el calculador la cuenta
@@ -455,7 +459,7 @@ class GetPlayerStatsUseCase:
                             tee_color=player.tee_color if player else None,
                             tee_gender=player.tee_gender if player else None,
                         ),
-                        holes=self._competition_hole_outcomes(hole_scores, hole_card) or [],
+                        holes=outcomes,
                         golf_course_id=str(course.id) if course is not None else None,
                         golf_course_name=str(course.name) if course is not None else None,
                     )
@@ -609,32 +613,6 @@ class GetPlayerStatsUseCase:
         round_ = rounds_by_match.get(match.id)
         return round_.golf_course_id if round_ is not None else None
 
-    def _scorecard_to_par(self, hole_scores: list, hole_card: list) -> int | None:
-        """
-        Neto respecto al par de la tarjeta, o None si no forma una vuelta.
-
-        Lo que decide es la tarjeta, no en qué hoyo se ganó el partido: un match
-        play resuelto en el 15 cuenta igual que cualquier otra vuelta si los
-        jugadores siguieron anotando hasta el 18. Lo que deja la ronda fuera es
-        dejar de anotar, no cerrar pronto.
-
-        Un hoyo RECOGIDO —anotado (`own_submitted`) y sin número— es un hoyo
-        jugado, no un hueco: cuenta como doble bogey neto, que es lo que el WHS
-        (Regla 3.1) manda anotar en un hoyo no terminado. Antes invalidaba la
-        vuelta entera, y eso dejaba a la misma vuelta contando para la media si
-        se jugaba en partida rápida y fuera si se jugaba en competición.
-
-        De ahí que lo anotado se mire por `own_submitted` y no por si hay
-        número: sin número está la raya y está el hoyo que nadie tocó, y
-        significan lo contrario.
-        """
-        outcomes = self._competition_hole_outcomes(hole_scores, hole_card)
-        if outcomes is None:
-            return None
-
-        to_par = sum(outcome.net_to_par for outcome in outcomes)
-        return self._to_eighteen(to_par, len(outcomes))
-
     def _competition_hole_outcomes(
         self, hole_scores: list, hole_card: list
     ) -> list[HoleOutcome] | None:
@@ -662,10 +640,14 @@ class GetPlayerStatsUseCase:
         for hole in played:
             hole_score = scored[hole.number]
             if hole_score.own_score is None:
+                # La raya: se anota `par + 2` de bruto —un total de golpes no
+                # puede depender del reparto— y doble bogey NETO en lo computable
+                gross = hole.par + NET_DOUBLE_BOGEY_OVER_PAR
                 computable = self._calculator.net_double_bogey(
                     hole.par, hole_score.strokes_received
                 )
             else:
+                gross = hole_score.own_score
                 computable = self._calculator.adjusted_gross(
                     hole_score.own_score, hole.par, hole_score.strokes_received
                 )
@@ -673,6 +655,7 @@ class GetPlayerStatsUseCase:
                 HoleOutcome(
                     number=hole.number,
                     par=hole.par,
+                    gross=gross,
                     adjusted_gross=computable,
                     strokes_received=hole_score.strokes_received,
                 )
@@ -715,6 +698,7 @@ class GetPlayerStatsUseCase:
                 strokes_basis, hole.stroke_index
             )
             score = scores_by_hole[hole.hole_number]
+            gross = hole.par + NET_DOUBLE_BOGEY_OVER_PAR if score is None else score
             computable = (
                 self._calculator.net_double_bogey(hole.par, strokes_received)
                 if score is None
@@ -724,6 +708,7 @@ class GetPlayerStatsUseCase:
                 HoleOutcome(
                     number=hole.hole_number,
                     par=hole.par,
+                    gross=gross,
                     adjusted_gross=computable,
                     strokes_received=strokes_received,
                 )

--- a/src/modules/user/domain/services/scoring_breakdown_calculator.py
+++ b/src/modules/user/domain/services/scoring_breakdown_calculator.py
@@ -109,7 +109,9 @@ class ScoringBreakdownCalculator:
 
         return ScoringBreakdown(
             holes_counted=len(holes),
-            rounds_counted=len(rounds),
+            # Solo las que aportan hoyos: una vuelta vacía no es una vuelta
+            # jugada, y `by_par` y `by_course` ya la ignoran
+            rounds_counted=sum(1 for round_ in rounds if round_.holes),
             gross_distribution=self._distribution(hole.gross_to_par for hole in holes),
             net_distribution=self._distribution(hole.net_to_par for hole in holes),
             by_par=self._by_par(holes),

--- a/src/modules/user/domain/services/scoring_breakdown_calculator.py
+++ b/src/modules/user/domain/services/scoring_breakdown_calculator.py
@@ -1,0 +1,218 @@
+"""
+Desglose de golpes: dónde gana y dónde pierde un jugador (BE #168).
+
+Las métricas que ya existían dicen *cuánto* juega de bien —media respecto al par,
+diferencial, índice estimado—. Estas dicen **dónde**, que es lo accionable: si
+los golpes se van en los par 3, o en los segundos nueve, o en un campo concreto.
+
+No lee nada nuevo. Trabaja sobre los hoyos que ya se guardan, reducidos antes a
+`HoleOutcome` por quien conoce las reglas del WHS.
+"""
+
+from dataclasses import dataclass, field
+
+from src.shared.domain.services.countable_round import HALF_ROUND_HOLES
+from src.shared.domain.value_objects.hole_outcome import HoleOutcome
+
+# Un hoyo cae en una de estas cuatro cestas según lo que se hizo respecto al par.
+# Cuatro y no siete: separar el eagle del albatros da categorías que un amateur
+# no llena nunca, y una distribución con ceros no dice nada.
+BIRDIE_OR_BETTER = "birdie_or_better"
+PAR = "par"
+BOGEY = "bogey"
+DOUBLE_OR_WORSE = "double_or_worse"
+
+# La ida son los nueve primeros; el resto, la vuelta. Un campo de 9 hoyos jugado
+# dos veces sigue numerando 1-18 en la tarjeta, así que la regla vale igual.
+FRONT_NINE_LAST_HOLE = HALF_ROUND_HOLES
+
+_ROUND_HOLES = 18
+
+
+@dataclass(frozen=True)
+class RoundOutcome:
+    """Una vuelta computable, con el campo donde se jugó y sus hoyos."""
+
+    golf_course_id: str | None
+    golf_course_name: str | None
+    holes: list[HoleOutcome]
+
+
+@dataclass(frozen=True)
+class Distribution:
+    """Cuántos hoyos cayeron en cada cesta, y el total sobre el que se reparten."""
+
+    birdie_or_better: int = 0
+    par: int = 0
+    bogey: int = 0
+    double_or_worse: int = 0
+    holes: int = 0
+
+
+@dataclass(frozen=True)
+class ParPerformance:
+    """Rendimiento en los hoyos de un par concreto."""
+
+    par: int
+    holes: int
+    average_to_par: float
+
+
+@dataclass(frozen=True)
+class NinePerformance:
+    """Rendimiento en una mitad de la vuelta."""
+
+    holes: int
+    average_to_par: float
+
+
+@dataclass(frozen=True)
+class CoursePerformance:
+    """Media de un jugador en un campo, en la escala de una vuelta de 18."""
+
+    golf_course_id: str
+    golf_course_name: str | None
+    rounds: int
+    average_to_par: float
+
+
+@dataclass(frozen=True)
+class ScoringBreakdown:
+    """El desglose completo. Todo vacío o a None cuando no hay vueltas."""
+
+    holes_counted: int = 0
+    rounds_counted: int = 0
+    gross_distribution: Distribution = field(default_factory=Distribution)
+    net_distribution: Distribution = field(default_factory=Distribution)
+    by_par: list[ParPerformance] = field(default_factory=list)
+    front_nine: NinePerformance | None = None
+    back_nine: NinePerformance | None = None
+    by_course: list[CoursePerformance] = field(default_factory=list)
+
+
+class ScoringBreakdownCalculator:
+    """
+    Agrega hoyos ya computados en las cuatro vistas del desglose.
+
+    Las medias por par y por mitad van **por hoyo**, no por vuelta: un par 3 no
+    se escala a 18 hoyos sin decir un disparate, y así media vuelta y vuelta
+    entera hablan en la misma unidad sin corregir nada.
+
+    La media por campo sí va **por vuelta de 18**, porque es la que se compara
+    con `scoring_avg`, que ya se publica en esa escala.
+    """
+
+    def compute(self, rounds: list[RoundOutcome]) -> ScoringBreakdown:
+        holes = [hole for round_ in rounds for hole in round_.holes]
+        if not holes:
+            return ScoringBreakdown()
+
+        return ScoringBreakdown(
+            holes_counted=len(holes),
+            rounds_counted=len(rounds),
+            gross_distribution=self._distribution(hole.gross_to_par for hole in holes),
+            net_distribution=self._distribution(hole.net_to_par for hole in holes),
+            by_par=self._by_par(holes),
+            front_nine=self._nine(
+                [hole for hole in holes if hole.number <= FRONT_NINE_LAST_HOLE]
+            ),
+            back_nine=self._nine(
+                [hole for hole in holes if hole.number > FRONT_NINE_LAST_HOLE]
+            ),
+            by_course=self._by_course(rounds),
+        )
+
+    @staticmethod
+    def _distribution(to_par_values) -> Distribution:
+        cestas = {BIRDIE_OR_BETTER: 0, PAR: 0, BOGEY: 0, DOUBLE_OR_WORSE: 0}
+        total = 0
+        for to_par in to_par_values:
+            total += 1
+            if to_par <= -1:
+                cestas[BIRDIE_OR_BETTER] += 1
+            elif to_par == 0:
+                cestas[PAR] += 1
+            elif to_par == 1:
+                cestas[BOGEY] += 1
+            else:
+                cestas[DOUBLE_OR_WORSE] += 1
+
+        return Distribution(
+            birdie_or_better=cestas[BIRDIE_OR_BETTER],
+            par=cestas[PAR],
+            bogey=cestas[BOGEY],
+            double_or_worse=cestas[DOUBLE_OR_WORSE],
+            holes=total,
+        )
+
+    @classmethod
+    def _by_par(cls, holes: list[HoleOutcome]) -> list[ParPerformance]:
+        """
+        Una entrada por cada par que aparezca de verdad, no una lista fija de
+        3-4-5: hay campos con hoyos par 6 —La Marquesa tiene uno— y un pitch &
+        putt es todo par 3. Fijar las categorías escondería los primeros y
+        llenaría de vacíos los segundos.
+        """
+        por_par: dict[int, list[int]] = {}
+        for hole in holes:
+            por_par.setdefault(hole.par, []).append(hole.net_to_par)
+
+        return [
+            ParPerformance(par=par, holes=len(valores), average_to_par=cls._average(valores))
+            for par, valores in sorted(por_par.items())
+        ]
+
+    @classmethod
+    def _nine(cls, holes: list[HoleOutcome]) -> NinePerformance | None:
+        """None sin hoyos: quien solo juega la ida no tiene una vuelta mala."""
+        if not holes:
+            return None
+        return NinePerformance(
+            holes=len(holes),
+            average_to_par=cls._average([hole.net_to_par for hole in holes]),
+        )
+
+    @classmethod
+    def _by_course(cls, rounds: list[RoundOutcome]) -> list[CoursePerformance]:
+        """
+        Media por campo, ordenada de mejor a peor.
+
+        Las vueltas sin campo conocido se quedan fuera en vez de agruparse bajo
+        un campo inventado: no se pueden comparar con nada.
+        """
+        por_campo: dict[str, tuple[str | None, list[float]]] = {}
+        for round_ in rounds:
+            if round_.golf_course_id is None or not round_.holes:
+                continue
+            _, vueltas = por_campo.setdefault(
+                round_.golf_course_id, (round_.golf_course_name, [])
+            )
+            vueltas.append(cls._round_to_par_over_eighteen(round_.holes))
+
+        return sorted(
+            (
+                CoursePerformance(
+                    golf_course_id=course_id,
+                    golf_course_name=nombre,
+                    rounds=len(vueltas),
+                    average_to_par=round(sum(vueltas) / len(vueltas), 1),
+                )
+                for course_id, (nombre, vueltas) in por_campo.items()
+            ),
+            key=lambda item: item.average_to_par,
+        )
+
+    @staticmethod
+    def _round_to_par_over_eighteen(holes: list[HoleOutcome]) -> float:
+        """
+        Lo que la vuelta hizo sobre el par, llevado a la escala de 18.
+
+        Es la misma corrección que aplica `scoring_avg`, y por el mismo motivo:
+        sin ella, jugar medias vueltas parecería mejorar el juego.
+        """
+        to_par = sum(hole.net_to_par for hole in holes)
+        return to_par * (_ROUND_HOLES / len(holes))
+
+    @staticmethod
+    def _average(values: list[int]) -> float:
+        return round(sum(values) / len(values), 2)

--- a/src/modules/user/infrastructure/api/v1/user_routes.py
+++ b/src/modules/user/infrastructure/api/v1/user_routes.py
@@ -21,6 +21,7 @@ from src.modules.golf_course.domain.value_objects.golf_course_id import GolfCour
 from src.modules.user.application.dto.player_stats_dto import (
     PlayerStatsResponseDTO,
     RecentMatchesResponseDTO,
+    ScoringBreakdownResponseDTO,
 )
 from src.modules.user.application.dto.user_dto import (
     FindUserRequestDTO,
@@ -367,6 +368,30 @@ async def get_my_stats(
     hándicap; el campo está para no cambiar el contrato cuando lo haya.
     """
     return await use_case.execute(UserId(str(current_user.id)))
+
+
+@router.get(
+    "/me/stats/breakdown",
+    response_model=ScoringBreakdownResponseDTO,
+    status_code=status.HTTP_200_OK,
+    summary="Desglose de golpes del jugador",
+    description="Dónde gana y dónde pierde golpes: por par, por mitad de vuelta y por campo.",
+    tags=["Users"],
+)
+async def get_my_scoring_breakdown(
+    current_user: UserResponseDTO = Depends(get_current_user),
+    use_case: GetPlayerStatsUseCase = Depends(get_get_player_stats_use_case),
+):
+    """
+    Desglose de golpes (BE #168).
+
+    Va aparte de `/me/stats` y no dentro: son bastantes datos y el panel no
+    siempre los necesita, así que la pantalla de resumen no tiene que pagarlos.
+
+    Mide sobre las mismas vueltas que la media, con el mismo tope de doble bogey
+    neto. Una cuenta sin historial devuelve ceros y listas vacías, no un 404.
+    """
+    return await use_case.execute_breakdown(UserId(str(current_user.id)))
 
 
 @router.get(

--- a/src/modules/user/infrastructure/api/v1/user_routes.py
+++ b/src/modules/user/infrastructure/api/v1/user_routes.py
@@ -385,8 +385,11 @@ async def get_my_scoring_breakdown(
     """
     Desglose de golpes (BE #168).
 
-    Va aparte de `/me/stats` y no dentro: son bastantes datos y el panel no
-    siempre los necesita, así que la pantalla de resumen no tiene que pagarlos.
+    Va aparte de `/me/stats` y no dentro porque son bastantes datos y el panel
+    no siempre los necesita. Lo que ahorra es la serialización, no el trabajo de
+    base de datos: recorre las mismas vueltas que el resumen, así que una
+    pantalla que pida los dos endpoints hace ese recorrido dos veces. Si algún
+    día pesa, la salida es un endpoint que devuelva ambos, no cachear este.
 
     Mide sobre las mismas vueltas que la media, con el mismo tope de doble bogey
     neto. Una cuenta sin historial devuelve ceros y listas vacías, no un 404.

--- a/src/shared/domain/value_objects/hole_outcome.py
+++ b/src/shared/domain/value_objects/hole_outcome.py
@@ -1,0 +1,49 @@
+"""
+Resultado de un jugador en un hoyo, ya reducido a lo que las estadísticas
+necesitan.
+
+Existe para que el desglose de golpes (BE #168) no tenga que repetir las reglas
+delicadas que ya resuelve `GetPlayerStatsUseCase._scorecard_to_par`: el tope de
+doble bogey neto, el hoyo recogido que cuenta como jugado y la tarjeta de la
+barra concreta que juega cada uno. Quien construye estos objetos aplica esas
+reglas una sola vez; quien los agrega solo suma.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HoleOutcome:
+    """
+    Un hoyo jugado, con los golpes ya topados en el doble bogey neto.
+
+    `adjusted_gross` NO son los golpes que el jugador escribió: son los que el
+    WHS deja computar (Regla 3.1). Un desastre puntual queda topado, que es
+    justo lo que evita que un hoyo mueva la media de una temporada.
+
+    Attributes:
+        number: Número del hoyo (1-18), que es lo que separa la ida de la vuelta
+        par: Par del hoyo EN LA BARRA que juega este jugador, no el de referencia
+        adjusted_gross: Golpes computables, ya topados
+        strokes_received: Golpes que recibe en este hoyo por su hándicap
+    """
+
+    number: int
+    par: int
+    adjusted_gross: int
+    strokes_received: int
+
+    @property
+    def net(self) -> int:
+        """Golpes netos: los computables menos los que recibe."""
+        return self.adjusted_gross - self.strokes_received
+
+    @property
+    def gross_to_par(self) -> int:
+        """Respecto al par, en bruto. Un birdie es -1 lo juegue quien lo juegue."""
+        return self.adjusted_gross - self.par
+
+    @property
+    def net_to_par(self) -> int:
+        """Respecto al par, en neto: contra el par que le toca a este jugador."""
+        return self.net - self.par

--- a/src/shared/domain/value_objects/hole_outcome.py
+++ b/src/shared/domain/value_objects/hole_outcome.py
@@ -3,10 +3,10 @@ Resultado de un jugador en un hoyo, ya reducido a lo que las estadísticas
 necesitan.
 
 Existe para que el desglose de golpes (BE #168) no tenga que repetir las reglas
-delicadas que ya resuelve `GetPlayerStatsUseCase._scorecard_to_par`: el tope de
-doble bogey neto, el hoyo recogido que cuenta como jugado y la tarjeta de la
-barra concreta que juega cada uno. Quien construye estos objetos aplica esas
-reglas una sola vez; quien los agrega solo suma.
+delicadas que ya resuelve `GetPlayerStatsUseCase`: el tope de doble bogey neto,
+el hoyo recogido que cuenta como jugado y la tarjeta de la barra concreta que
+juega cada uno. Quien construye estos objetos aplica esas reglas una sola vez;
+quien los agrega solo suma.
 """
 
 from dataclasses import dataclass
@@ -15,21 +15,32 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class HoleOutcome:
     """
-    Un hoyo jugado, con los golpes ya topados en el doble bogey neto.
+    Un hoyo jugado, con los golpes que se dieron y los que el WHS deja computar.
 
-    `adjusted_gross` NO son los golpes que el jugador escribió: son los que el
-    WHS deja computar (Regla 3.1). Un desastre puntual queda topado, que es
-    justo lo que evita que un hoyo mueva la media de una temporada.
+    Son DOS números y no uno, por la misma razón por la que el calculador de
+    partida rápida los lleva separados:
+
+    - `gross` son los golpes de la tarjeta. Un birdie es un birdie, y ese dato
+      no puede depender del reparto de golpes.
+    - `adjusted_gross` es lo computable, topado en el doble bogey neto (Regla
+      WHS 3.1), que es lo que impide que un hoyo desastroso mueva la media de
+      una temporada.
+
+    Derivar el bruto del topado parecía inofensivo y no lo es: para un jugador
+    **plus** los golpes recibidos son negativos, así que el tope cae POR DEBAJO
+    de `par + 2` y un doble bogey de verdad se contaría como bogey.
 
     Attributes:
         number: Número del hoyo (1-18), que es lo que separa la ida de la vuelta
         par: Par del hoyo EN LA BARRA que juega este jugador, no el de referencia
-        adjusted_gross: Golpes computables, ya topados
+        gross: Golpes dados. En un hoyo recogido, el `par + 2` que se anota
+        adjusted_gross: Golpes computables, topados en el doble bogey neto
         strokes_received: Golpes que recibe en este hoyo por su hándicap
     """
 
     number: int
     par: int
+    gross: int
     adjusted_gross: int
     strokes_received: int
 
@@ -41,7 +52,7 @@ class HoleOutcome:
     @property
     def gross_to_par(self) -> int:
         """Respecto al par, en bruto. Un birdie es -1 lo juegue quien lo juegue."""
-        return self.adjusted_gross - self.par
+        return self.gross - self.par
 
     @property
     def net_to_par(self) -> int:

--- a/tests/integration/api/v1/test_player_stats_endpoints.py
+++ b/tests/integration/api/v1/test_player_stats_endpoints.py
@@ -339,3 +339,86 @@ class TestScoreDifferentials:
 
         assert body["rounds_with_differential"] == 3
         assert body["estimated_index"] == 15.5
+
+
+class TestScoringBreakdownEndpoint:
+    """El desglose de golpes (BE #168), sobre una partida jugada por la API."""
+
+    @pytest.mark.asyncio
+    async def test_breakdown_requires_a_session(self, client: AsyncClient):
+        client.cookies.clear()
+
+        response = await client.get("/api/v1/users/me/stats/breakdown")
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_an_account_with_no_rounds_gets_zeros_not_a_404(self, client: AsyncClient):
+        player = await create_authenticated_user(
+            client, "breakdown_empty@test.com", "P@ssw0rd123!", "Empty", "Breakdown"
+        )
+        set_auth_cookies(client, player["cookies"])
+
+        response = await client.get("/api/v1/users/me/stats/breakdown")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["holes_counted"] == 0
+        assert body["by_par"] == []
+        assert body["front_nine"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_played_round_lands_in_every_view(self, client: AsyncClient):
+        """
+        Jugador sin hándicap en par 72, 5 golpes por hoyo: dieciocho bogeys.
+        Es la misma vuelta que da `scoring_avg` +18, vista por dentro.
+        """
+        admin = await create_admin_user(
+            client, "breakdown_admin@test.com", "P@ssw0rd123!", "Admin", "Breakdown"
+        )
+        player = await create_authenticated_user(
+            client, "breakdown_player@test.com", "P@ssw0rd123!", "Played", "Breakdown"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        response = await client.get("/api/v1/users/me/stats/breakdown")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+
+        assert body["holes_counted"] == 18
+        assert body["rounds_counted"] == 1
+        assert body["gross_distribution"]["bogey"] == 18
+        # Sin hándicap, el neto es el bruto
+        assert body["net_distribution"]["bogey"] == 18
+        # El campo del helper es todo par 4, así que hay una sola entrada
+        assert [entry["par"] for entry in body["by_par"]] == [4]
+        assert body["by_par"][0]["average_to_par"] == 1.0
+        assert body["front_nine"]["average_to_par"] == 1.0
+        assert body["back_nine"]["average_to_par"] == 1.0
+        assert body["by_course"][0]["golf_course_id"] == golf_course_id
+        assert body["by_course"][0]["average_to_par"] == 18.0
+
+    @pytest.mark.asyncio
+    async def test_the_breakdown_agrees_with_the_average(self, client: AsyncClient):
+        """
+        El invariante que importa: las dos pantallas miran las mismas vueltas.
+        Si discreparan, el panel diría dos cosas a la vez sobre el mismo juego.
+        """
+        admin = await create_admin_user(
+            client, "breakdown_admin2@test.com", "P@ssw0rd123!", "Admin", "Agree"
+        )
+        player = await create_authenticated_user(
+            client, "breakdown_player2@test.com", "P@ssw0rd123!", "Agree", "Breakdown"
+        )
+        golf_course_id = await _approved_golf_course(client, admin, player)
+        await _played_medal_match(client, player, golf_course_id)
+
+        set_auth_cookies(client, player["cookies"])
+        stats = (await client.get("/api/v1/users/me/stats")).json()
+        breakdown = (await client.get("/api/v1/users/me/stats/breakdown")).json()
+
+        assert breakdown["rounds_counted"] == stats["rounds_played"]
+        assert breakdown["by_course"][0]["average_to_par"] == stats["scoring_avg"]

--- a/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
+++ b/tests/unit/modules/user/application/use_cases/test_get_player_stats_use_case.py
@@ -1508,3 +1508,140 @@ class TestParPorBarra:
 
         assert stats.rounds_with_differential == 1
         assert stats.best_differential is not None
+
+
+@pytest.mark.asyncio
+class TestScoringBreakdown:
+    """
+    El desglose de golpes (BE #168): dónde gana y dónde pierde el jugador.
+
+    Lo que se prueba aquí no es la aritmética —eso vive en los tests del
+    calculador— sino que el desglose mira EXACTAMENTE las mismas vueltas que la
+    media, que es lo que impide que el panel cuente dos historias distintas.
+    """
+
+    async def test_an_empty_account_returns_an_empty_breakdown_not_an_error(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-empty"))
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert breakdown.holes_counted == 0
+        assert breakdown.rounds_counted == 0
+        assert breakdown.by_par == []
+        assert breakdown.by_course == []
+        assert breakdown.front_nine is None
+        assert breakdown.back_nine is None
+
+    async def test_counts_the_holes_of_a_played_quick_match(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-qm"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=4)
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert breakdown.holes_counted == 18
+        assert breakdown.rounds_counted == 1
+        # Campo de par 4 jugado en 4: los dieciocho hoyos son pares
+        assert breakdown.gross_distribution.par == 18
+        assert breakdown.gross_distribution.holes == 18
+
+    async def test_a_bogey_round_lands_in_the_bogey_bucket(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-bogey"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert breakdown.gross_distribution.bogey == 18
+
+    async def test_separates_the_front_nine_from_the_back_nine(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-nines"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        # Ida en par, vuelta en bogey
+        scores = {hole: (4 if hole <= 9 else 5) for hole in range(1, 19)}
+        await _played_quick_match(qm_uow, course, user, scores_by_hole=scores)
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert breakdown.front_nine.average_to_par == 0.0
+        assert breakdown.back_nine.average_to_par == 1.0
+
+    async def test_reports_the_course_with_its_name(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-course"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert len(breakdown.by_course) == 1
+        assert breakdown.by_course[0].golf_course_name == "Test Golf Club"
+        assert breakdown.by_course[0].rounds == 1
+        assert breakdown.by_course[0].average_to_par == 18.0
+
+    # Este es el que importa: si el desglose y la media miraran vueltas
+    # distintas, el panel diría dos cosas a la vez
+    async def test_counts_the_same_rounds_the_average_counts(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        user = await create_user(user_uow, unique_email("breakdown-same"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=5)
+        await _played_quick_match(qm_uow, course, user, strokes_per_hole=4)
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+        stats = await use_case.execute(user.id)
+        breakdown = await use_case.execute_breakdown(user.id)
+
+        assert breakdown.rounds_counted == stats.rounds_played
+
+    async def test_an_incomplete_card_stays_out_of_both(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Una vuelta a la que le falta un hoyo suelto no cuenta en ningún sitio."""
+        user = await create_user(user_uow, unique_email("breakdown-partial"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, holes=[1, 2, 3, 4, 5])
+
+        use_case = _use_case(user_uow, competition_uow, qm_uow, golf_course_uow)
+        stats = await use_case.execute(user.id)
+        breakdown = await use_case.execute_breakdown(user.id)
+
+        assert stats.rounds_played == 0
+        assert breakdown.rounds_counted == 0
+        assert breakdown.holes_counted == 0
+
+    async def test_a_half_round_counts_in_the_breakdown_too(
+        self, user_uow, competition_uow, qm_uow, golf_course_uow
+    ):
+        """Los nueve de ida son vuelta computable, aquí igual que en la media."""
+        user = await create_user(user_uow, unique_email("breakdown-half"))
+        course = await create_golf_course(golf_course_uow, user.id)
+        await _played_quick_match(qm_uow, course, user, holes=list(range(1, 10)))
+
+        breakdown = await _use_case(
+            user_uow, competition_uow, qm_uow, golf_course_uow
+        ).execute_breakdown(user.id)
+
+        assert breakdown.holes_counted == 9
+        assert breakdown.front_nine.holes == 9
+        assert breakdown.back_nine is None

--- a/tests/unit/modules/user/domain/services/test_scoring_breakdown_calculator.py
+++ b/tests/unit/modules/user/domain/services/test_scoring_breakdown_calculator.py
@@ -1,0 +1,216 @@
+"""
+Tests del desglose de golpes (BE #168).
+
+Las métricas anteriores dicen cuánto juega de bien un jugador; estas dicen
+dónde pierde los golpes, así que lo que se prueba aquí es que cada hoyo cae
+donde le toca y que las medias hablan todas en la misma unidad.
+"""
+
+from src.modules.user.domain.services.scoring_breakdown_calculator import (
+    RoundOutcome,
+    ScoringBreakdownCalculator,
+)
+from src.shared.domain.value_objects.hole_outcome import HoleOutcome
+
+
+def hoyo(number: int, par: int, adjusted_gross: int, strokes_received: int = 0) -> HoleOutcome:
+    return HoleOutcome(
+        number=number,
+        par=par,
+        adjusted_gross=adjusted_gross,
+        strokes_received=strokes_received,
+    )
+
+
+def vuelta_de_par(pares: list[int], golpes: list[int], **kwargs) -> RoundOutcome:
+    """Una vuelta con tantos hoyos como pares se den, numerados desde el 1."""
+    return RoundOutcome(
+        golf_course_id=kwargs.get("golf_course_id"),
+        golf_course_name=kwargs.get("golf_course_name"),
+        holes=[
+            hoyo(i + 1, par, golpe, kwargs.get("strokes_received", 0))
+            for i, (par, golpe) in enumerate(zip(pares, golpes, strict=True))
+        ],
+    )
+
+
+class TestSinDatos:
+    def test_sin_vueltas_devuelve_el_desglose_vacio(self):
+        """Una cuenta nueva es un caso normal, no un error."""
+        resultado = ScoringBreakdownCalculator().compute([])
+
+        assert resultado.holes_counted == 0
+        assert resultado.rounds_counted == 0
+        assert resultado.by_par == []
+        assert resultado.by_course == []
+        assert resultado.front_nine is None
+        assert resultado.back_nine is None
+
+    def test_una_vuelta_sin_hoyos_no_cuenta_como_vuelta_jugada(self):
+        vacia = RoundOutcome(golf_course_id="c1", golf_course_name="Campo", holes=[])
+
+        resultado = ScoringBreakdownCalculator().compute([vacia])
+
+        assert resultado.holes_counted == 0
+        assert resultado.by_course == []
+
+
+class TestDistribucion:
+    def test_reparte_cada_hoyo_en_su_cesta(self):
+        # birdie, par, bogey, doble, triple
+        vuelta = vuelta_de_par([4, 4, 4, 4, 4], [3, 4, 5, 6, 7])
+
+        bruto = ScoringBreakdownCalculator().compute([vuelta]).gross_distribution
+
+        assert bruto.birdie_or_better == 1
+        assert bruto.par == 1
+        assert bruto.bogey == 1
+        # El triple entra en la misma cesta que el doble
+        assert bruto.double_or_worse == 2
+        assert bruto.holes == 5
+
+    def test_un_eagle_cuenta_como_birdie_o_mejor(self):
+        vuelta = vuelta_de_par([5], [3])
+
+        bruto = ScoringBreakdownCalculator().compute([vuelta]).gross_distribution
+
+        assert bruto.birdie_or_better == 1
+
+    def test_bruto_y_neto_difieren_cuando_el_jugador_recibe_golpes(self):
+        """
+        El mismo hoyo: bogey en bruto, par en neto. Es justo lo que hace útil
+        dar las dos, y por lo que un hándicap alto no ve solo bogeys.
+        """
+        vuelta = vuelta_de_par([4], [5], strokes_received=1)
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        assert resultado.gross_distribution.bogey == 1
+        assert resultado.gross_distribution.par == 0
+        assert resultado.net_distribution.par == 1
+        assert resultado.net_distribution.bogey == 0
+
+    def test_sin_golpes_recibidos_bruto_y_neto_coinciden(self):
+        vuelta = vuelta_de_par([4, 3, 5], [5, 3, 6])
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        assert resultado.gross_distribution == resultado.net_distribution
+
+
+class TestRendimientoPorPar:
+    def test_separa_la_media_por_cada_par(self):
+        # par 3 en bogey, par 4 en par, par 5 en birdie
+        vuelta = vuelta_de_par([3, 4, 5], [4, 4, 4])
+
+        por_par = {p.par: p for p in ScoringBreakdownCalculator().compute([vuelta]).by_par}
+
+        assert por_par[3].average_to_par == 1.0
+        assert por_par[4].average_to_par == 0.0
+        assert por_par[5].average_to_par == -1.0
+        assert por_par[3].holes == 1
+
+    # La issue solo hablaba de par 3, 4 y 5, pero el par 6 existe: La Marquesa
+    # tiene uno en el hoyo 9, en sus ocho barras
+    def test_incluye_el_par_6_en_vez_de_perderlo(self):
+        vuelta = vuelta_de_par([4, 6], [4, 7])
+
+        pares = [p.par for p in ScoringBreakdownCalculator().compute([vuelta]).by_par]
+
+        assert pares == [4, 6]
+
+    def test_no_inventa_pares_que_no_se_jugaron(self):
+        """Un pitch & putt es todo par 3, y su desglose no debe tener huecos."""
+        vuelta = vuelta_de_par([3, 3, 3], [3, 4, 3])
+
+        por_par = ScoringBreakdownCalculator().compute([vuelta]).by_par
+
+        assert len(por_par) == 1
+        assert por_par[0].par == 3
+
+    def test_la_media_por_par_es_por_hoyo_y_no_por_vuelta(self):
+        """
+        Dos par 3, uno en par y otro en doble: la media es +1 por hoyo. Si se
+        escalara a la vuelta daría un número sin sentido para un par 3.
+        """
+        vuelta = vuelta_de_par([3, 3], [3, 5])
+
+        assert ScoringBreakdownCalculator().compute([vuelta]).by_par[0].average_to_par == 1.0
+
+
+class TestNueves:
+    def test_separa_la_ida_de_la_vuelta(self):
+        holes = [hoyo(n, 4, 4) for n in range(1, 10)] + [hoyo(n, 4, 5) for n in range(10, 19)]
+        vuelta = RoundOutcome(golf_course_id="c1", golf_course_name="Campo", holes=holes)
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        assert resultado.front_nine.average_to_par == 0.0
+        assert resultado.back_nine.average_to_par == 1.0
+        assert resultado.front_nine.holes == 9
+
+    def test_el_hoyo_9_es_ida_y_el_10_es_vuelta(self):
+        vuelta = RoundOutcome(
+            golf_course_id=None,
+            golf_course_name=None,
+            holes=[hoyo(9, 4, 5), hoyo(10, 4, 4)],
+        )
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        assert resultado.front_nine.holes == 1
+        assert resultado.front_nine.average_to_par == 1.0
+        assert resultado.back_nine.average_to_par == 0.0
+
+    def test_quien_solo_juega_la_ida_no_tiene_media_de_vuelta(self):
+        """None, no cero: no haber jugado no es haber jugado en par."""
+        vuelta = RoundOutcome(
+            golf_course_id=None, golf_course_name=None, holes=[hoyo(1, 4, 4)]
+        )
+
+        assert ScoringBreakdownCalculator().compute([vuelta]).back_nine is None
+
+
+class TestPorCampo:
+    def test_ordena_los_campos_de_mejor_a_peor(self):
+        facil = vuelta_de_par([4] * 18, [4] * 18, golf_course_id="c1", golf_course_name="Fácil")
+        dificil = vuelta_de_par(
+            [4] * 18, [6] * 18, golf_course_id="c2", golf_course_name="Difícil"
+        )
+
+        por_campo = ScoringBreakdownCalculator().compute([dificil, facil]).by_course
+
+        assert [c.golf_course_name for c in por_campo] == ["Fácil", "Difícil"]
+        assert por_campo[0].average_to_par == 0.0
+        assert por_campo[1].average_to_par == 36.0
+
+    def test_agrupa_varias_vueltas_del_mismo_campo(self):
+        buena = vuelta_de_par([4] * 18, [4] * 18, golf_course_id="c1", golf_course_name="Campo")
+        mala = vuelta_de_par([4] * 18, [5] * 18, golf_course_id="c1", golf_course_name="Campo")
+
+        por_campo = ScoringBreakdownCalculator().compute([buena, mala]).by_course
+
+        assert len(por_campo) == 1
+        assert por_campo[0].rounds == 2
+        assert por_campo[0].average_to_par == 9.0
+
+    # Media vuelta se escala a 18, igual que hace `scoring_avg`: sin eso, jugar
+    # nueve hoyos parecería jugar la mitad de mal
+    def test_lleva_la_media_vuelta_a_la_escala_de_18(self):
+        nueve = vuelta_de_par([4] * 9, [5] * 9, golf_course_id="c1", golf_course_name="Campo")
+
+        assert ScoringBreakdownCalculator().compute([nueve]).by_course[0].average_to_par == 18.0
+
+    def test_deja_fuera_las_vueltas_sin_campo_conocido(self):
+        """Sin campo no hay nada con lo que comparar; agruparlas mentiría."""
+        sin_campo = vuelta_de_par([4] * 18, [5] * 18)
+
+        assert ScoringBreakdownCalculator().compute([sin_campo]).by_course == []
+
+    def test_esas_vueltas_si_cuentan_para_el_resto_del_desglose(self):
+        sin_campo = vuelta_de_par([4, 3], [5, 3])
+
+        resultado = ScoringBreakdownCalculator().compute([sin_campo])
+
+        assert resultado.holes_counted == 2
+        assert resultado.by_par != []

--- a/tests/unit/modules/user/domain/services/test_scoring_breakdown_calculator.py
+++ b/tests/unit/modules/user/domain/services/test_scoring_breakdown_calculator.py
@@ -13,11 +13,19 @@ from src.modules.user.domain.services.scoring_breakdown_calculator import (
 from src.shared.domain.value_objects.hole_outcome import HoleOutcome
 
 
-def hoyo(number: int, par: int, adjusted_gross: int, strokes_received: int = 0) -> HoleOutcome:
+def hoyo(
+    number: int,
+    par: int,
+    gross: int,
+    strokes_received: int = 0,
+    adjusted_gross: int | None = None,
+) -> HoleOutcome:
+    """Sin tope explícito, lo computable son los golpes que se dieron."""
     return HoleOutcome(
         number=number,
         par=par,
-        adjusted_gross=adjusted_gross,
+        gross=gross,
+        adjusted_gross=gross if adjusted_gross is None else adjusted_gross,
         strokes_received=strokes_received,
     )
 
@@ -214,3 +222,54 @@ class TestPorCampo:
 
         assert resultado.holes_counted == 2
         assert resultado.by_par != []
+
+
+class TestBrutoTopadoYBrutoReal:
+    """
+    La distribución en bruto mira los golpes que se dieron, no los computables.
+
+    Derivar el bruto del topado parecía inofensivo: para un jugador que recibe
+    golpes el tope está en `par + 2 + recibidos`, así que ninguna cesta cambia.
+    Para un jugador **plus** los recibidos son negativos y el tope cae POR
+    DEBAJO de `par + 2`: un doble bogey de verdad se contaba como bogey.
+    """
+
+    def test_un_jugador_plus_no_ve_su_doble_bogey_como_bogey(self):
+        # Par 4 jugado en 6 —doble bogey— por un plus que DEVUELVE un golpe:
+        # lo computable se topa en 5, pero el bruto sigue siendo 6
+        vuelta = RoundOutcome(
+            golf_course_id=None,
+            golf_course_name=None,
+            holes=[hoyo(1, 4, 6, strokes_received=-1, adjusted_gross=5)],
+        )
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        assert resultado.gross_distribution.double_or_worse == 1
+        assert resultado.gross_distribution.bogey == 0
+
+    def test_el_neto_sigue_usando_lo_computable(self):
+        """El tope es lo que impide que un hoyo mueva la media de la temporada."""
+        vuelta = RoundOutcome(
+            golf_course_id=None,
+            golf_course_name=None,
+            holes=[hoyo(1, 4, 9, strokes_received=0, adjusted_gross=6)],
+        )
+
+        resultado = ScoringBreakdownCalculator().compute([vuelta])
+
+        # Bruto: un 9 en un par 4. Neto: topado en doble bogey
+        assert resultado.gross_distribution.double_or_worse == 1
+        assert resultado.by_par[0].average_to_par == 2.0
+
+
+class TestVueltasVacias:
+    def test_una_vuelta_vacia_no_infla_el_recuento_de_vueltas(self):
+        """Antes contaba, aunque no aportara ni un hoyo a ninguna otra vista."""
+        vacia = RoundOutcome(golf_course_id="c1", golf_course_name="Campo", holes=[])
+        real = vuelta_de_par([4] * 18, [4] * 18, golf_course_id="c1", golf_course_name="Campo")
+
+        resultado = ScoringBreakdownCalculator().compute([vacia, real])
+
+        assert resultado.rounds_counted == 1
+        assert resultado.holes_counted == 18


### PR DESCRIPTION
Backend v2.16.0. **Este repo va PRIMERO**: el frontend v2.30.0 (RyderCupWeb#594) consume el endpoint que sale aquí.

## Qué entra

| PR | Issue | |
|---|---|---|
| #269 | #168 | Desglose de golpes: por par, por mitad de vuelta y por campo |

`GET /users/me/stats/breakdown`. **Sin datos nuevos y sin migración**: lee las tarjetas que ya se guardan.

Incluye el arreglo que salió en revisión: un doble bogey de un jugador **plus** se contaba como bogey, porque el bruto se derivaba del golpe ya topado en el doble bogey neto.

## La ventana entre despliegues es inocua

El cambio es **aditivo**: un endpoint nuevo, sin tocar ninguno existente. El frontend actual no lo llama, así que este despliegue no le afecta. Y el frontend nuevo, si sale antes de tiempo, tampoco rompe nada: su sección cae sola y avisa, sin llevarse por delante la pantalla de estadísticas — se comprobó en el navegador con el endpoint devolviendo 404.

## Verificación

- 3.091 tests unitarios, 16 de integración de estadísticas, `ruff` y `mypy` limpios
- Probado contra el clúster local con datos reales: el endpoint pasó de 404 a 401 a 200, y sus números cuadran con `/me/stats` (mismas vueltas, misma media)
