### PR TITLE
perf(db): Index golf_course_tees by golf_course_id

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -111,7 +111,19 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            # Una transacción POR migración, no una para todas las pendientes. Lo pide
+            # `autocommit_block()`, que usa la migración del índice de golf_course_tees
+            # (43bc18ca6df1): CREATE INDEX CONCURRENTLY no puede ir dentro de una
+            # transacción, así que el bloque cierra la que esté abierta. Sin esto, esa
+            # migración confirmaría de paso todas las anteriores del mismo arranque, y un
+            # fallo posterior dejaría la base a medias en vez de deshacerse entera.
+            # A cambio, cada revisión queda sellada al terminar: un reintento sigue por
+            # donde se quedó en lugar de repetirlas todas.
+            transaction_per_migration=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
+++ b/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
@@ -1,0 +1,75 @@
+"""add index on golf_course_tees.golf_course_id
+
+`golf_course_tees` se lleva la mayor parte del I/O de la base de datos: medido en
+producción el 7 sep 2026, **36 millones de tuplas leídas secuencialmente** en 31.071
+escaneos completos, sobre una tabla de 4.321 filas. Para comparar, `golf_course_tee_holes`
+es 18 veces más grande y se lee casi siempre por índice.
+
+La causa no se ve leyendo los modelos: la tabla YA tiene dos índices que empiezan por
+`golf_course_id`, pero los dos son **parciales**
+
+    uq_golf_course_tees_color_gender       ... WHERE (color <> 'OTHER')
+    uq_golf_course_tees_identifier_gender  ... WHERE (color = 'OTHER')
+
+y Postgres solo usa un índice parcial cuando puede demostrar que la consulta implica su
+predicado. Un `WHERE golf_course_id = ?` no implica ninguno de los dos, así que el
+planificador se queda sin índice utilizable y recorre la tabla entera. Los dos parciales
+se quedan como están: cumplen su función de unicidad, y lo que falta es el simple.
+
+CONCURRENTLY para no bloquear escrituras mientras se construye, lo que obliga a salir de
+la transacción de Alembic (`autocommit_block`).
+
+**Por qué se borra antes de crear.** Un CREATE INDEX CONCURRENTLY que muere a medias
+—el contenedor que se lleva por delante el despliegue, un timeout, la conexión que se
+cae— deja el índice creado pero con `indisvalid = false`, y el planificador ignora un
+índice inválido. Como `entrypoint.sh` reintenta `alembic upgrade head` en cada arranque,
+un simple `IF NOT EXISTS` vería el nombre ocupado, no haría nada, y Alembic marcaría la
+revisión como aplicada: `alembic current` diría que está arreglado mientras la tabla se
+sigue escaneando entera. Por eso se comprueba `indisvalid` y se borra el inválido antes
+de reintentar.
+
+Revision ID: 43bc18ca6df1
+Revises: d1c4b7e93a52
+Create Date: 2026-09-07
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "43bc18ca6df1"
+down_revision = "d1c4b7e93a52"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_golf_course_tees_golf_course_id"
+
+_IS_INVALID = sa.text(
+    """
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_index i ON i.indexrelid = c.oid
+    WHERE c.relname = :name AND NOT i.indisvalid
+    """
+)
+
+
+def upgrade() -> None:
+    # La comprobación va FUERA del autocommit_block, en la transacción de Alembic: solo
+    # lee, y así el bloque de abajo se queda con el DDL que no puede ir en transacción.
+    leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+
+    with op.get_context().autocommit_block():
+        if leftover_is_invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
+            "ON golf_course_tees (golf_course_id)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
+++ b/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
@@ -57,11 +57,19 @@ _IS_INVALID = sa.text(
 
 
 def upgrade() -> None:
-    # La comprobación va FUERA del autocommit_block, en la transacción de Alembic: solo
-    # lee, y así el bloque de abajo se queda con el DDL que no puede ir en transacción.
-    leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+    context = op.get_context()
 
-    with op.get_context().autocommit_block():
+    if context.as_sql:
+        # Modo offline (`alembic upgrade --sql`, que el CI usa para validar): no hay
+        # conexión que consultar —`op.get_bind()` devuelve None—, así que se emite el
+        # DROP siempre. Es idempotente y el guion resultante queda correcto igual.
+        leftover_is_invalid = True
+    else:
+        # La comprobación va FUERA del autocommit_block, en la transacción de Alembic:
+        # solo lee, y así el bloque se queda con el DDL que no puede ir en transacción.
+        leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+
+    with context.autocommit_block():
         if leftover_is_invalid:
             op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
         op.execute(

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -307,6 +307,14 @@ golf_course_tees_table = Table(
     ),
     # Unique index funcional sobre (golf_course_id, color o identifier, género)
     # creado en la migración de tarjetas por barra
+    # Los dos funcionales de arriba empiezan por golf_course_id pero son PARCIALES, y
+    # Postgres solo usa un índice parcial si la consulta implica su predicado: un
+    # `WHERE golf_course_id = ?` no implica ninguno, así que la tabla se recorría entera
+    # (#284). Este va también en el modelo —y no solo en la migración, como el de
+    # tee_holes— porque es un índice normal de una columna y se expresa sin perder nada:
+    # así el esquema que los tests levantan desde los metadatos es el mismo que el de
+    # producción.
+    Index("ix_golf_course_tees_golf_course_id", "golf_course_id"),
     comment="Tees (salidas) de campos de golf con ratings WHS",
 )
 

--- a/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
+++ b/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
@@ -54,8 +54,10 @@ async def test_does_not_block_the_event_loop_while_hashing():
     """
     Mientras `run_bcrypt` trabaja, el loop tiene que seguir atendiendo otras tareas.
 
-    Sin el salto de hilo el contador se quedaría en 0: la función síncrona monopolizaría
-    el loop hasta terminar, que es exactamente el defecto que esto corrige.
+    Se compara el contador ANTES y DESPUÉS en vez de exigir un número de vueltas: con el
+    loop bloqueado el ticker no avanza ni una sola vez, así que basta con que avance para
+    distinguir los dos casos. Exigir «al menos N vueltas en 200 ms» medía de rebote lo
+    ocupada que estuviera la máquina, y fallaba en una cargada sin que nada estuviera roto.
     """
     ticks = 0
 
@@ -67,13 +69,17 @@ async def test_does_not_block_the_event_loop_while_hashing():
 
     task = asyncio.create_task(ticker())
     await asyncio.sleep(0)  # cede el control para que el ticker arranque
+    ticks_before = ticks
 
     try:
         await run_bcrypt(time.sleep, 0.2)  # simula el coste de bcrypt con 12 rounds
     finally:
         task.cancel()
 
-    assert ticks >= 3, f"el event loop quedó bloqueado (solo {ticks} ticks)"
+    assert ticks > ticks_before, (
+        f"el event loop quedó bloqueado: el ticker no avanzó ni una vez "
+        f"durante el hash (seguía en {ticks})"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #284

## What

`golf_course_tees` accounts for most of this database's I/O. Measured in production on 7 Sep 2026:

| Table | seq_scan | seq_tup_read | idx_scan | rows |
|---|---|---|---|---|
| **golf_course_tees** | **31,071** | **35,997,275** | 85,750 | 4,321 |
| users | 94,245 | 1,398,294 | 1,033 | 21 |
| golf_course_tee_holes | 15 | 700,812 | 92,987 | 77,922 |

36 million tuples read sequentially from a 4,321-row table — more than everything else combined. `golf_course_tee_holes` is 18x larger and reads through its index, which is what healthy looks like here.

## Why it happens

Not visible in the models: the table already has two indexes leading with `golf_course_id`, but both are **partial** (`WHERE color <> 'OTHER'` and `WHERE color = 'OTHER'`). PostgreSQL only uses a partial index when the query implies its predicate, and a bare `WHERE golf_course_id = ?` implies neither. The planner has nothing usable.

Proved rather than assumed — with `enable_seqscan=off`, so a sequential scan costs 10 billion:

```
BEFORE:  Seq Scan on golf_course_tees  (cost=10000000000.00..10000000015.55)
AFTER:   Bitmap Index Scan on ix_golf_course_tees_golf_course_id  (cost=0.00..4.16)
```

It preferred a 10-billion-cost scan over both existing indexes. The two partial ones stay as they are — they do their uniqueness job; what was missing is the plain one.

## From the review

- **The migration drops a leftover invalid index before creating.** A `CREATE INDEX CONCURRENTLY` that dies half-way leaves `indisvalid = false`, which the planner ignores. `entrypoint.sh` retries `alembic upgrade head` on every container start, so a plain `IF NOT EXISTS` would see the name taken, skip, and let Alembic stamp the revision — **reporting the fix as deployed while the scans continue**. Verified both ways: with `IF NOT EXISTS` alone the index stays invalid (`already exists, skipping`); with the drop it recovers to `indisvalid=true`.
- **`env.py` now sets `transaction_per_migration=True`**, which `autocommit_block` requires. Without it one run wraps every pending migration in a single transaction, and this one would commit all of them on its way past — a later failure would leave the database half-migrated.
- **The index is declared in the mapper too**, unlike `ix_tee_holes_tee_id`. It is a plain single-column index that loses nothing in translation, so the schema tests build from metadata matches production.

## Testing

Against a disposable Postgres — deliberately not the local Kind, where applying a branch migration puts the API in CrashLoopBackOff:

- 45 migrations from scratch, with `transaction_per_migration` active
- Index created, `indisvalid=true`
- Invalid-index recovery, and the contra-proof that the previous version left it broken
- Downgrade clean, 0 indexes left
- 3105 unit tests, mypy and ruff clean

## Also here

`test_does_not_block_the_event_loop_while_hashing` (added yesterday in #272) was flaky by design: it required 3 ticker rounds of 10ms inside a 200ms window, which measures machine load as much as it measures the fix. It failed at load average 39 with nothing broken, and passed 5/5 alone. It now compares the counter before and after — with the loop blocked the ticker does not advance at all, so one advance separates the cases. Mutation-checked: removing the thread hop still fails it.

Unrelated to the index, but it would have made this PR's CI unreliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Added an index to improve the speed and responsiveness of golf course tee searches and related data retrieval.

- **Reliability**
  - Database updates now complete in separate steps, allowing interrupted updates to resume more safely and reducing disruption during deployment.

- **Bug Fixes**
  - Improved handling of database index creation so updates can recover cleanly from incomplete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->