### PR TITLE
chore(release): Prepare v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-09-07
+
+Release de rendimiento: no añade endpoints ni cambia ningún contrato, así que el frontend
+actual funciona igual antes y después. Los dos cambios atacan lo mismo desde sitios
+distintos —lo que la API deja de hacer mientras atiende a una persona— y los dos se
+midieron contra producción antes de escribirse.
+
+### Changed
+
+- **Un login ya no congela la API entera.** bcrypt con 12 rondas cuesta unos 200 ms de CPU
+  y se ejecutaba dentro de la propia corrutina. Producción corre **un solo worker de
+  uvicorn**, así que mientras se cifraba una contraseña el proceso no atendía **ninguna
+  otra petición**; la comprobación del historial de contraseñas, que encadena hasta cinco
+  verificaciones, lo dejaba parado más de un segundo (#272).
+
+  Los **siete** puntos que cifran pasan ahora por `run_bcrypt()`: login, cambio de
+  contraseña (comprobación de la actual, bucle del historial y hash nuevo), restablecer
+  contraseña, registro y el arranque del usuario de sistema. Eran siete, no uno: arreglar
+  solo el login habría dejado el resto congelando igual.
+
+  `run_bcrypt()` tiene dos mitades y la segunda importa tanto como la primera. Entrega el
+  trabajo a un hilo —bcrypt suelta el GIL mientras trabaja, así que el bucle sigue
+  repartiendo— y lo hace en **su propio pool pequeño** (`BCRYPT_MAX_CONCURRENCY`, 2 por
+  defecto). Sin ese tope, desbloquear el bucle habría cambiado un problema de latencia por
+  uno de agotamiento de recursos (OWASP A04): N logins simultáneos disparando N hashes
+  sobre medio núcleo. Lo que excede el tope espera en el bucle, que es barato.
+
+  El contexto viaja al hilo igual que en `asyncio.to_thread`, de modo que el
+  correlation-id sigue apareciendo en los registros escritos desde dentro del hash.
+
+- **`golf_course_tees` deja de leerse entera en cada consulta.** Medido en producción el 7
+  sep: **31.071 barridos secuenciales y 36 millones de tuplas leídas** de una tabla de
+  4.321 filas — más que todo lo demás junto (#284).
+
+  No se ve en los modelos: la tabla **ya tenía** dos índices que empiezan por
+  `golf_course_id`, pero los dos son **parciales** (`WHERE color <> 'OTHER'` y
+  `WHERE color = 'OTHER'`). PostgreSQL solo usa un índice parcial cuando la consulta
+  implica su predicado, y un `WHERE golf_course_id = ?` a secas no implica ninguno de los
+  dos, así que el planificador no tenía nada que usar. Probado, no supuesto: con
+  `enable_seqscan=off` prefería un barrido de coste 10.000.000.000 antes que cualquiera de
+  los dos índices existentes. Los parciales se quedan como están —hacen su trabajo de
+  unicidad—; lo que faltaba era el normal.
+
+### Fixed
+
+- **La migración limpia un índice inválido antes de crear el suyo.** Un
+  `CREATE INDEX CONCURRENTLY` que muere a medias deja el índice con `indisvalid = false`,
+  que el planificador ignora. Como `entrypoint.sh` reintenta `alembic upgrade head` en cada
+  arranque del contenedor, un `IF NOT EXISTS` a secas habría visto el nombre ocupado, se
+  habría saltado la creación y Alembic habría sellado la revisión: **el arreglo constaría
+  como desplegado mientras los barridos siguen**. Por el mismo motivo `env.py` pasa a
+  `transaction_per_migration`, que es lo que permite crear el índice sin bloquear la tabla.
+
+- El test que vigila que bcrypt no bloquea el bucle comparaba tiempos absolutos y fallaba
+  en una máquina cargada. Ahora mide el avance de un contador antes y después del hash, que
+  es lo que la prueba quería decir desde el principio.
+
+### Notes
+
+- **Nada que tocar en el despliegue.** `BCRYPT_MAX_CONCURRENCY`, `DB_POOL_SIZE` y
+  `DB_MAX_OVERFLOW` traen valores por defecto que **no cambian el comportamiento actual con
+  un solo proceso**; solo hacen explícito lo que ya era implícito. `env_int()` las lee con
+  respaldo seguro y un aviso, de modo que una variable mal escrita o vacía no puede tumbar
+  el contenedor al importar.
+- **Es release solo de backend.** Al no cambiar ningún contrato, no hay ventana peligrosa
+  entre despliegues y el frontend no tiene que ir detrás.
+
 ## [2.16.0] - 2026-09-06
 
 ### Added

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -111,7 +111,19 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            # Una transacción POR migración, no una para todas las pendientes. Lo pide
+            # `autocommit_block()`, que usa la migración del índice de golf_course_tees
+            # (43bc18ca6df1): CREATE INDEX CONCURRENTLY no puede ir dentro de una
+            # transacción, así que el bloque cierra la que esté abierta. Sin esto, esa
+            # migración confirmaría de paso todas las anteriores del mismo arranque, y un
+            # fallo posterior dejaría la base a medias en vez de deshacerse entera.
+            # A cambio, cada revisión queda sellada al terminar: un reintento sigue por
+            # donde se quedó en lugar de repetirlas todas.
+            transaction_per_migration=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
+++ b/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
@@ -1,0 +1,75 @@
+"""add index on golf_course_tees.golf_course_id
+
+`golf_course_tees` se lleva la mayor parte del I/O de la base de datos: medido en
+producción el 7 sep 2026, **36 millones de tuplas leídas secuencialmente** en 31.071
+escaneos completos, sobre una tabla de 4.321 filas. Para comparar, `golf_course_tee_holes`
+es 18 veces más grande y se lee casi siempre por índice.
+
+La causa no se ve leyendo los modelos: la tabla YA tiene dos índices que empiezan por
+`golf_course_id`, pero los dos son **parciales**
+
+    uq_golf_course_tees_color_gender       ... WHERE (color <> 'OTHER')
+    uq_golf_course_tees_identifier_gender  ... WHERE (color = 'OTHER')
+
+y Postgres solo usa un índice parcial cuando puede demostrar que la consulta implica su
+predicado. Un `WHERE golf_course_id = ?` no implica ninguno de los dos, así que el
+planificador se queda sin índice utilizable y recorre la tabla entera. Los dos parciales
+se quedan como están: cumplen su función de unicidad, y lo que falta es el simple.
+
+CONCURRENTLY para no bloquear escrituras mientras se construye, lo que obliga a salir de
+la transacción de Alembic (`autocommit_block`).
+
+**Por qué se borra antes de crear.** Un CREATE INDEX CONCURRENTLY que muere a medias
+—el contenedor que se lleva por delante el despliegue, un timeout, la conexión que se
+cae— deja el índice creado pero con `indisvalid = false`, y el planificador ignora un
+índice inválido. Como `entrypoint.sh` reintenta `alembic upgrade head` en cada arranque,
+un simple `IF NOT EXISTS` vería el nombre ocupado, no haría nada, y Alembic marcaría la
+revisión como aplicada: `alembic current` diría que está arreglado mientras la tabla se
+sigue escaneando entera. Por eso se comprueba `indisvalid` y se borra el inválido antes
+de reintentar.
+
+Revision ID: 43bc18ca6df1
+Revises: d1c4b7e93a52
+Create Date: 2026-09-07
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "43bc18ca6df1"
+down_revision = "d1c4b7e93a52"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_golf_course_tees_golf_course_id"
+
+_IS_INVALID = sa.text(
+    """
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_index i ON i.indexrelid = c.oid
+    WHERE c.relname = :name AND NOT i.indisvalid
+    """
+)
+
+
+def upgrade() -> None:
+    # La comprobación va FUERA del autocommit_block, en la transacción de Alembic: solo
+    # lee, y así el bloque de abajo se queda con el DDL que no puede ir en transacción.
+    leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+
+    with op.get_context().autocommit_block():
+        if leftover_is_invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
+            "ON golf_course_tees (golf_course_id)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
+++ b/alembic/versions/43bc18ca6df1_add_index_on_golf_course_tees_golf_.py
@@ -57,11 +57,19 @@ _IS_INVALID = sa.text(
 
 
 def upgrade() -> None:
-    # La comprobación va FUERA del autocommit_block, en la transacción de Alembic: solo
-    # lee, y así el bloque de abajo se queda con el DDL que no puede ir en transacción.
-    leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+    context = op.get_context()
 
-    with op.get_context().autocommit_block():
+    if context.as_sql:
+        # Modo offline (`alembic upgrade --sql`, que el CI usa para validar): no hay
+        # conexión que consultar —`op.get_bind()` devuelve None—, así que se emite el
+        # DROP siempre. Es idempotente y el guion resultante queda correcto igual.
+        leftover_is_invalid = True
+    else:
+        # La comprobación va FUERA del autocommit_block, en la transacción de Alembic:
+        # solo lee, y así el bloque se queda con el DDL que no puede ir en transacción.
+        leftover_is_invalid = op.get_bind().execute(_IS_INVALID, {"name": INDEX_NAME}).scalar()
+
+    with context.autocommit_block():
         if leftover_is_invalid:
             op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
         op.execute(

--- a/src/config/database.py
+++ b/src/config/database.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from src.shared.infrastructure.env import env_int
+
 # Cargar las variables de entorno del fichero .env
 load_dotenv()
 
@@ -36,6 +38,13 @@ async_engine = create_async_engine(
     echo=False,
     pool_pre_ping=True,  # Detecta conexiones muertas antes de reutilizarlas
     pool_recycle=1800,  # Recicla conexiones cada 30 min (evita stale connections)
+    # El pool es POR PROCESO, y uvicorn lee WEB_CONCURRENCY del entorno por su cuenta
+    # (uvicorn/config.py), sin que este repo la declare en ninguna parte: subirla
+    # multiplica las conexiones contra Postgres por N x (pool_size + max_overflow), que
+    # los planes pequeños no dan. Los valores por defecto son los de SQLAlchemy, así que
+    # mientras haya un solo proceso nada cambia.
+    pool_size=env_int("DB_POOL_SIZE", default=5),
+    max_overflow=env_int("DB_MAX_OVERFLOW", default=10),
 )
 
 

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -10,7 +10,7 @@ una release ha llegado realmente a produccion.
 
 import os
 
-APP_VERSION = "2.16.0"
+APP_VERSION = "2.17.0"
 
 
 def get_deployed_commit() -> str:

--- a/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
+++ b/src/modules/golf_course/infrastructure/persistence/mappers/golf_course_mapper.py
@@ -307,6 +307,14 @@ golf_course_tees_table = Table(
     ),
     # Unique index funcional sobre (golf_course_id, color o identifier, género)
     # creado en la migración de tarjetas por barra
+    # Los dos funcionales de arriba empiezan por golf_course_id pero son PARCIALES, y
+    # Postgres solo usa un índice parcial si la consulta implica su predicado: un
+    # `WHERE golf_course_id = ?` no implica ninguno, así que la tabla se recorría entera
+    # (#284). Este va también en el modelo —y no solo en la migración, como el de
+    # tee_holes— porque es un índice normal de una columna y se expresa sin perder nada:
+    # así el esquema que los tests levantan desde los metadatos es el mismo que el de
+    # producción.
+    Index("ix_golf_course_tees_golf_course_id", "golf_course_id"),
     comment="Tees (salidas) de campos de golf con ratings WHS",
 )
 

--- a/src/modules/user/application/use_cases/ensure_system_user_use_case.py
+++ b/src/modules/user/application/use_cases/ensure_system_user_use_case.py
@@ -12,6 +12,7 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
 )
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_id import UserId
+from src.shared.infrastructure.security.bcrypt_executor import run_bcrypt
 
 # Longitud holgada: nadie va a teclear esta contraseña nunca, y cuanto más
 # larga, menos margen deja si algún día la cuenta se reactivara por error.
@@ -84,7 +85,8 @@ class EnsureSystemUserUseCase:
                 self._require_system_account(existing, email_str)
                 return self._require_id(existing)
 
-            system_user = User.create(
+            system_user = await run_bcrypt(
+                User.create,
                 first_name=first_name,
                 last_name=last_name,
                 email_str=email_str,

--- a/src/modules/user/application/use_cases/login_user_use_case.py
+++ b/src/modules/user/application/use_cases/login_user_use_case.py
@@ -35,6 +35,7 @@ from src.modules.user.domain.services.handicap_service import HandicapService
 from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.user_device_id import UserDeviceId
 from src.shared.infrastructure.logging.security_logger import get_security_logger
+from src.shared.infrastructure.security.bcrypt_executor import run_bcrypt
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ class LoginUserUseCase:
             )
 
         # Verificar contraseña
-        if not user.verify_password(request.password):
+        if not await run_bcrypt(user.verify_password, request.password):
             # Account Lockout (v1.13.0): Registrar intento fallido
             user.record_failed_login()
 

--- a/src/modules/user/application/use_cases/register_user_use_case.py
+++ b/src/modules/user/application/use_cases/register_user_use_case.py
@@ -21,6 +21,7 @@ from src.shared.domain.repositories.country_repository_interface import (
 )
 from src.shared.domain.value_objects.country_code import CountryCode
 from src.shared.domain.value_objects.gender import Gender
+from src.shared.infrastructure.security.bcrypt_executor import run_bcrypt
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,8 @@ class RegisterUserUseCase:
 
             # 2. Crear la entidad de dominio User
             gender = Gender(request.gender) if request.gender else None
-            new_user = User.create(
+            new_user = await run_bcrypt(
+                User.create,
                 email_str=request.email,
                 plain_password=request.password,
                 first_name=request.first_name,

--- a/src/modules/user/application/use_cases/reset_password_use_case.py
+++ b/src/modules/user/application/use_cases/reset_password_use_case.py
@@ -28,6 +28,7 @@ from src.modules.user.domain.repositories.user_unit_of_work_interface import (
     UserUnitOfWorkInterface,
 )
 from src.shared.infrastructure.logging.security_logger import get_security_logger
+from src.shared.infrastructure.security.bcrypt_executor import run_bcrypt
 
 
 class ResetPasswordUseCase:
@@ -120,7 +121,8 @@ class ResetPasswordUseCase:
         try:
             # reset_password() internamente llama a can_reset_password()
             # Si el token es inválido/expirado, lanza ValueError
-            user.reset_password(
+            await run_bcrypt(
+                user.reset_password,
                 token=request.token,
                 new_password=request.new_password,
                 ip_address=ip_address,

--- a/src/modules/user/application/use_cases/update_security_use_case.py
+++ b/src/modules/user/application/use_cases/update_security_use_case.py
@@ -29,6 +29,7 @@ from src.modules.user.domain.value_objects.email import Email
 from src.modules.user.domain.value_objects.password import Password
 from src.modules.user.domain.value_objects.user_id import UserId
 from src.shared.infrastructure.logging.security_logger import get_security_logger
+from src.shared.infrastructure.security.bcrypt_executor import run_bcrypt
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class UpdateSecurityUseCase:
         if not user:
             raise UserNotFoundError(f"User with id {user_id} not found")
 
-        if not user.verify_password(current_password):
+        if not await run_bcrypt(user.verify_password, current_password):
             raise InvalidCredentialsError("Current password is incorrect")
 
         return user_id_vo, user
@@ -91,13 +92,13 @@ class UpdateSecurityUseCase:
         # Verificar si la nueva contraseña coincide con alguna del historial
         for history_record in recent_history:
             temp_password = Password(history_record.password_hash)
-            if temp_password.verify(new_password):
+            if await run_bcrypt(temp_password.verify, new_password):
                 raise ValueError(
                     "Cannot reuse any of your last 5 passwords. Please choose a different password."
                 )
 
         # Cambiar la contraseña
-        user.change_password(new_password)
+        await run_bcrypt(user.change_password, new_password)
 
         # Guardar el nuevo hash en el historial
         total_history_count = await self._uow.password_history.count_by_user(user_id_vo) + 1

--- a/src/shared/infrastructure/env.py
+++ b/src/shared/infrastructure/env.py
@@ -1,0 +1,47 @@
+"""
+Lectura de enteros de configuración desde el entorno, tolerante a valores mal puestos.
+
+Estas variables se leen al importar el módulo que las usa: antes de que haya logging
+configurado y antes de que la app pueda contestar nada. Un `int()` directo sobre un valor
+vacío o con una errata tumba el contenedor con una traza pelada y sin pista de cuál de
+ellas fue —y en Render, vaciar una variable es justo la forma natural de desactivarla—.
+Es preferible arrancar con el valor por defecto y dejar el aviso escrito.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def env_int(name: str, default: int, minimum: int = 1) -> int:
+    """
+    Lee una variable de entorno como entero, cayendo al valor por defecto si no vale.
+
+    Args:
+        name: Nombre de la variable de entorno
+        default: Valor a usar si no está definida, está vacía o no es utilizable
+        minimum: Valor mínimo aceptable (por debajo se descarta y se usa `default`)
+
+    Returns:
+        El entero configurado, o `default` si la variable falta o no sirve.
+
+    Examples:
+        >>> env_int("DB_POOL_SIZE", 5)
+        5
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s='%s' no es un entero; se usa %d", name, raw, default)
+        return default
+
+    if value < minimum:
+        logger.warning("%s=%d es menor que el mínimo %d; se usa %d", name, value, minimum, default)
+        return default
+
+    return value

--- a/src/shared/infrastructure/security/bcrypt_executor.py
+++ b/src/shared/infrastructure/security/bcrypt_executor.py
@@ -1,0 +1,68 @@
+"""
+Ejecutor de bcrypt fuera del event loop, con la concurrencia acotada.
+
+bcrypt con 12 rounds (`Password._hash_password`) cuesta ~200 ms de CPU, y llamarlo
+directamente desde una corrutina bloquea el event loop: mientras dura, el proceso no
+atiende NINGUNA otra petición. Producción corre un único worker de uvicorn
+(`entrypoint.sh`), así que un login congelaba la API entera para todo el mundo, y la
+comprobación del historial de contraseñas —hasta 5 verificaciones seguidas— la congelaba
+más de un segundo.
+
+La corrección tiene dos mitades, y la segunda importa tanto como la primera:
+
+1. Saltar a un hilo libera el event loop. bcrypt suelta el GIL mientras trabaja (la parte
+   cara es C), así que el loop sigue despachando el resto de peticiones.
+2. Un pool PROPIO y pequeño limita cuántos hashes corren a la vez. Sin ese límite la
+   corrección abriría un agujero distinto: N logins simultáneos lanzarían N hashes contra
+   el medio núcleo del contenedor y lo dejarían de rodillas (OWASP A04, agotamiento de
+   recursos). Por encima del límite las peticiones esperan en el loop, que es barato.
+   `BCRYPT_MAX_CONCURRENCY` lo ajusta si algún día crece la CPU del plan.
+
+NO usar con `token_hash` (SHA-256): son microsegundos y el salto de hilo costaría más que
+la propia operación.
+"""
+
+import asyncio
+import contextvars
+import functools
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import ParamSpec, TypeVar
+
+from src.shared.infrastructure.env import env_int
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+# Con el medio núcleo del plan actual, más de dos hashes a la vez no acaban antes: solo
+# se estorban entre ellos y se llevan por delante la CPU del resto de peticiones.
+MAX_CONCURRENCY = env_int("BCRYPT_MAX_CONCURRENCY", default=2)
+
+# Pool propio, no el del runtime: así el límite es real y los hashes no compiten por los
+# hilos que FastAPI usa para los endpoints síncronos.
+_executor = ThreadPoolExecutor(max_workers=MAX_CONCURRENCY, thread_name_prefix="bcrypt")
+
+
+async def run_bcrypt(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """
+    Ejecuta en un hilo aparte una operación que hashea o verifica un password.
+
+    Args:
+        func: Operación síncrona que usa bcrypt (por ejemplo `user.verify_password`)
+        *args: Argumentos posicionales que se pasan tal cual a `func`
+        **kwargs: Argumentos con nombre que se pasan tal cual a `func`
+
+    Returns:
+        Lo que devuelva `func`. Las excepciones se propagan sin envolver, sin añadir los
+        argumentos al mensaje: por ahí pasan contraseñas en claro.
+
+    Examples:
+        >>> if not await run_bcrypt(user.verify_password, plain_password):
+        ...     raise InvalidCredentialsError()
+    """
+    loop = asyncio.get_running_loop()
+    # Se copia el contexto igual que hace `asyncio.to_thread`, para que el correlation-id
+    # y demás contextvars sigan estando en los logs que salgan desde el hilo.
+    context = contextvars.copy_context()
+    call = functools.partial(context.run, functools.partial(func, *args, **kwargs))
+    return await loop.run_in_executor(_executor, call)

--- a/src/shared/infrastructure/security/bcrypt_executor.py
+++ b/src/shared/infrastructure/security/bcrypt_executor.py
@@ -12,11 +12,14 @@ La corrección tiene dos mitades, y la segunda importa tanto como la primera:
 
 1. Saltar a un hilo libera el event loop. bcrypt suelta el GIL mientras trabaja (la parte
    cara es C), así que el loop sigue despachando el resto de peticiones.
-2. Un pool PROPIO y pequeño limita cuántos hashes corren a la vez. Sin ese límite la
-   corrección abriría un agujero distinto: N logins simultáneos lanzarían N hashes contra
-   el medio núcleo del contenedor y lo dejarían de rodillas (OWASP A04, agotamiento de
-   recursos). Por encima del límite las peticiones esperan en el loop, que es barato.
-   `BCRYPT_MAX_CONCURRENCY` lo ajusta si algún día crece la CPU del plan.
+2. Un pool PROPIO y pequeño limita cuántos hashes corren a la vez, y un semáforo del
+   mismo tamaño limita cuántos ESPERAN. Sin el primero, N logins simultáneos lanzarían N
+   hashes contra el medio núcleo del contenedor y lo dejarían de rodillas (OWASP A04,
+   agotamiento de recursos). Sin el segundo, la cola del `ThreadPoolExecutor` —que no
+   tiene tope— acumularía una tarea por petición, cada una reteniendo sus argumentos
+   (contraseñas en claro incluidas) hasta que le tocara el turno. Con el semáforo la
+   espera ocurre en el event loop, que es barato y no guarda nada.
+   `BCRYPT_MAX_CONCURRENCY` ajusta los dos si algún día crece la CPU del plan.
 
 NO usar con `token_hash` (SHA-256): son microsegundos y el salto de hilo costaría más que
 la propia operación.
@@ -25,6 +28,7 @@ la propia operación.
 import asyncio
 import contextvars
 import functools
+import weakref
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import ParamSpec, TypeVar
@@ -41,6 +45,22 @@ MAX_CONCURRENCY = env_int("BCRYPT_MAX_CONCURRENCY", default=2)
 # Pool propio, no el del runtime: así el límite es real y los hashes no compiten por los
 # hilos que FastAPI usa para los endpoints síncronos.
 _executor = ThreadPoolExecutor(max_workers=MAX_CONCURRENCY, thread_name_prefix="bcrypt")
+
+# Un semáforo por event loop. `asyncio.Semaphore` se ata al loop en el que se usa por
+# primera vez, así que uno global rompería en cuanto hubiera más de uno (los tests crean
+# uno por test). El diccionario es débil para que un loop cerrado no se quede retenido.
+_admission_gates: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Semaphore
+] = weakref.WeakKeyDictionary()
+
+
+def _admission_gate(loop: asyncio.AbstractEventLoop) -> asyncio.Semaphore:
+    """Devuelve el semáforo de admisión de este loop, creándolo la primera vez."""
+    gate = _admission_gates.get(loop)
+    if gate is None:
+        gate = asyncio.Semaphore(MAX_CONCURRENCY)
+        _admission_gates[loop] = gate
+    return gate
 
 
 async def run_bcrypt(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
@@ -65,4 +85,7 @@ async def run_bcrypt(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) ->
     # y demás contextvars sigan estando en los logs que salgan desde el hilo.
     context = contextvars.copy_context()
     call = functools.partial(context.run, functools.partial(func, *args, **kwargs))
-    return await loop.run_in_executor(_executor, call)
+    # Hay tantos permisos como hilos, así que nada llega al executor sin un hilo libre
+    # esperándolo: la cola de dentro no crece, y quien espera lo hace aquí.
+    async with _admission_gate(loop):
+        return await loop.run_in_executor(_executor, call)

--- a/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
+++ b/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
@@ -1,0 +1,104 @@
+"""
+Tests de `run_bcrypt`, el ejecutor que saca bcrypt del event loop.
+
+El test que de verdad protege la corrección es
+`test_does_not_block_the_event_loop_while_hashing`: si alguien sustituyera el salto
+al hilo por una llamada directa, ese test falla. Los demás cubren que el
+ejecutor es transparente para quien lo llama.
+"""
+
+import asyncio
+import contextvars
+import threading
+import time
+
+import pytest
+
+from src.shared.infrastructure.security.bcrypt_executor import MAX_CONCURRENCY, run_bcrypt
+
+_probe_context: contextvars.ContextVar[str] = contextvars.ContextVar("probe_context")
+
+
+@pytest.mark.asyncio
+async def test_returns_the_result_of_the_wrapped_function():
+    result = await run_bcrypt(lambda: "computed-hash")
+
+    assert result == "computed-hash"
+
+
+@pytest.mark.asyncio
+async def test_passes_positional_and_keyword_arguments():
+    def hash_it(password, *, rounds):
+        return f"{password}:{rounds}"
+
+    result = await run_bcrypt(hash_it, "secret", rounds=12)
+
+    assert result == "secret:12"
+
+
+@pytest.mark.asyncio
+async def test_propagates_the_exception_unwrapped():
+    def fails():
+        raise ValueError("password too short")
+
+    with pytest.raises(ValueError, match="password too short"):
+        await run_bcrypt(fails)
+
+
+@pytest.mark.asyncio
+async def test_does_not_block_the_event_loop_while_hashing():
+    """
+    Mientras `run_bcrypt` trabaja, el loop tiene que seguir atendiendo otras tareas.
+
+    Sin el salto de hilo el contador se quedaría en 0: la función síncrona monopolizaría
+    el loop hasta terminar, que es exactamente el defecto que esto corrige.
+    """
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    task = asyncio.create_task(ticker())
+    await asyncio.sleep(0)  # cede el control para que el ticker arranque
+
+    try:
+        await run_bcrypt(time.sleep, 0.2)  # simula el coste de bcrypt con 12 rounds
+    finally:
+        task.cancel()
+
+    assert ticks >= 3, f"el event loop quedó bloqueado (solo {ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_limits_how_many_hashes_run_at_once():
+    """
+    Sin tope, una avalancha de logins lanzaría un hash por petición contra la CPU del
+    contenedor. El pool propio tiene que dejar esperando a los que sobran.
+    """
+    running = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def work():
+        nonlocal running, peak
+        with lock:
+            running += 1
+            peak = max(peak, running)
+        time.sleep(0.05)
+        with lock:
+            running -= 1
+
+    await asyncio.gather(*(run_bcrypt(work) for _ in range(MAX_CONCURRENCY * 3)))
+
+    assert peak <= MAX_CONCURRENCY, f"{peak} hashes a la vez, el tope es {MAX_CONCURRENCY}"
+
+
+@pytest.mark.asyncio
+async def test_propagates_the_context_to_the_thread():
+    """El correlation-id de los logs vive en un contextvar: tiene que cruzar al hilo."""
+    _probe_context.set("correlation-123")
+
+    assert await run_bcrypt(_probe_context.get) == "correlation-123"

--- a/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
+++ b/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
@@ -54,8 +54,10 @@ async def test_does_not_block_the_event_loop_while_hashing():
     """
     Mientras `run_bcrypt` trabaja, el loop tiene que seguir atendiendo otras tareas.
 
-    Sin el salto de hilo el contador se quedaría en 0: la función síncrona monopolizaría
-    el loop hasta terminar, que es exactamente el defecto que esto corrige.
+    Se compara el contador ANTES y DESPUÉS en vez de exigir un número de vueltas: con el
+    loop bloqueado el ticker no avanza ni una sola vez, así que basta con que avance para
+    distinguir los dos casos. Exigir «al menos N vueltas en 200 ms» medía de rebote lo
+    ocupada que estuviera la máquina, y fallaba en una cargada sin que nada estuviera roto.
     """
     ticks = 0
 
@@ -67,13 +69,17 @@ async def test_does_not_block_the_event_loop_while_hashing():
 
     task = asyncio.create_task(ticker())
     await asyncio.sleep(0)  # cede el control para que el ticker arranque
+    ticks_before = ticks
 
     try:
         await run_bcrypt(time.sleep, 0.2)  # simula el coste de bcrypt con 12 rounds
     finally:
         task.cancel()
 
-    assert ticks >= 3, f"el event loop quedó bloqueado (solo {ticks} ticks)"
+    assert ticks > ticks_before, (
+        f"el event loop quedó bloqueado: el ticker no avanzó ni una vez "
+        f"durante el hash (seguía en {ticks})"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
+++ b/tests/unit/shared/infrastructure/security/test_bcrypt_executor.py
@@ -14,7 +14,11 @@ import time
 
 import pytest
 
-from src.shared.infrastructure.security.bcrypt_executor import MAX_CONCURRENCY, run_bcrypt
+from src.shared.infrastructure.security.bcrypt_executor import (
+    MAX_CONCURRENCY,
+    _executor,
+    run_bcrypt,
+)
 
 _probe_context: contextvars.ContextVar[str] = contextvars.ContextVar("probe_context")
 
@@ -102,3 +106,31 @@ async def test_propagates_the_context_to_the_thread():
     _probe_context.set("correlation-123")
 
     assert await run_bcrypt(_probe_context.get) == "correlation-123"
+
+
+@pytest.mark.asyncio
+async def test_does_not_let_work_pile_up_in_the_executor_queue():
+    """
+    El pool limita cuántos hashes CORREN; el semáforo limita cuántos ESPERAN.
+
+    Sin él, `ThreadPoolExecutor` encola una tarea por llamada en una cola sin tope, y
+    cada una retiene sus argumentos —contraseñas en claro entre ellos— hasta que le toca
+    el turno. Se mira la cola interna del executor a propósito: es la única forma de
+    afirmar la invariante desde fuera.
+    """
+    release = threading.Event()
+
+    def blocked():
+        release.wait(timeout=5)
+
+    tasks = [
+        asyncio.create_task(run_bcrypt(blocked)) for _ in range(MAX_CONCURRENCY * 10)
+    ]
+    try:
+        await asyncio.sleep(0.2)  # deja que todas intenten entrar
+        queued = _executor._work_queue.qsize()
+    finally:
+        release.set()
+        await asyncio.gather(*tasks)
+
+    assert queued <= MAX_CONCURRENCY, f"{queued} tareas esperando dentro del executor"

--- a/tests/unit/shared/infrastructure/test_env.py
+++ b/tests/unit/shared/infrastructure/test_env.py
@@ -1,0 +1,51 @@
+"""
+Tests de `env_int`.
+
+Lo que protegen: estas variables se leen al importar, así que un valor mal puesto no
+puede tumbar el arranque del contenedor. Cada caso de aquí es una forma real de
+equivocarse al escribirlas en el panel de Render.
+"""
+
+import pytest
+
+from src.shared.infrastructure.env import env_int
+
+
+def test_returns_the_default_when_the_variable_is_not_set(monkeypatch):
+    monkeypatch.delenv("SOME_LIMIT", raising=False)
+
+    assert env_int("SOME_LIMIT", default=5) == 5
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_returns_the_default_when_the_variable_is_blank(monkeypatch, raw):
+    """Vaciar la variable es la forma natural de 'desactivarla' en Render."""
+    monkeypatch.setenv("SOME_LIMIT", raw)
+
+    assert env_int("SOME_LIMIT", default=5) == 5
+
+
+def test_returns_the_default_when_the_value_is_not_a_number(monkeypatch):
+    monkeypatch.setenv("SOME_LIMIT", "dos")
+
+    assert env_int("SOME_LIMIT", default=5) == 5
+
+
+@pytest.mark.parametrize("raw", ["0", "-3"])
+def test_returns_the_default_when_the_value_is_below_the_minimum(monkeypatch, raw):
+    """`BCRYPT_MAX_CONCURRENCY=0` reventaría el ThreadPoolExecutor al importar."""
+    monkeypatch.setenv("SOME_LIMIT", raw)
+
+    assert env_int("SOME_LIMIT", default=5) == 5
+
+
+def test_returns_the_configured_value(monkeypatch):
+    monkeypatch.setenv("SOME_LIMIT", "12")
+
+    assert env_int("SOME_LIMIT", default=5) == 12
+
+
+def test_accepts_a_custom_minimum(monkeypatch):
+    monkeypatch.setenv("SOME_LIMIT", "1")
+
+    assert env_int("SOME_LIMIT", default=10, minimum=4) == 10


### PR DESCRIPTION
Performance release. **No new endpoints and no contract changes**, so the current frontend behaves identically before and after — backend-only deploy, no dangerous window between the two.

Both changes were measured against production before they were written.

## What ships

**A single login no longer freezes the whole API** (#272, PR #272)

bcrypt at 12 rounds costs ~200 ms of CPU and ran inside the coroutine itself. Production runs **one uvicorn worker**, so while a password was hashed the process served no other request; the password-history check chains up to five verifications and stalled it for over a second. All **seven** hashing call sites now go through `run_bcrypt()`, which hands the work to a thread and caps it with its own small pool (`BCRYPT_MAX_CONCURRENCY`, default 2) so unblocking the loop does not trade latency for resource exhaustion (OWASP A04).

**`golf_course_tees` stops being read in full on every query** (#284, PR #285)

Measured in production on 7 Sep: 31,071 sequential scans and 36M tuples read from a 4,321-row table — more than everything else combined. The table already had two indexes leading with `golf_course_id`, but both are partial, and a bare `WHERE golf_course_id = ?` implies neither predicate. Proved with `enable_seqscan=off`: the planner preferred a cost-10,000,000,000 scan over both.

The migration also clears a leftover invalid index before creating. `entrypoint.sh` retries `alembic upgrade head` on every container start, so a plain `IF NOT EXISTS` would skip creation and let Alembic stamp the revision — reporting the fix as deployed while the scans continue.

## Deploy notes

- **Nothing to change in Render.** `BCRYPT_MAX_CONCURRENCY`, `DB_POOL_SIZE` and `DB_MAX_OVERFLOW` ship with defaults that do not alter current behaviour with a single process; they only make explicit what SQLAlchemy left implicit. `env_int()` reads them with a safe fallback and a warning, so a blank or mistyped value cannot take the container down at import time.
- **The migration creates an index concurrently**, which is why `env.py` moves to `transaction_per_migration`. It does not lock the table.
- Backend deploys itself on merge to `main`; verify with `curl -s https://api.rydercupfriends.com/health` and confirm both `version` and `commit`.

## Contents

```
cc35d52 Merge pull request #285 (golf_course_tees index)
ef7afa0 Merge pull request #272 (bcrypt off the event loop)
```

Both were reviewed by CodeRabbit in their own PRs with no actionable findings. Per the release process, CodeRabbit does not review PRs targeting `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)