### PR TITLE
chore(deps): Keep audit tooling out of the production image

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,9 +37,69 @@ sqlalchemy[mypy]>=2.0.31
 # Detecta: SQL injection, uso de eval(), contraseñas hardcodeadas, etc.
 bandit[toml]>=1.7.9
 
-# Safety - Verifica vulnerabilidades conocidas en dependencias
-# Usa la base de datos de PyUp.io para detectar CVEs
-safety>=3.2.0
+# safety - Auditoría de vulnerabilidades en dependencias
+# Escanea el proyecto contra Safety DB (40K+ vulnerabilidades conocidas)
+# Detecta CVEs en dependencias directas y transitivas
+# Cumple con OWASP Top 10: A06 (Vulnerable and Outdated Components)
+safety==3.7.0
+
+# pip-audit - Auditoría oficial de PyPA para dependencias
+# Escanea contra PyPI Advisory Database y OSV (Open Source Vulnerabilities)
+# Alternativa oficial mantenida por Python Packaging Authority
+# Cumple con OWASP Top 10: A06 (Vulnerable and Outdated Components)
+pip-audit==2.10.0
+
+# ================================
+# PINS TRANSITIVOS DE LAS HERRAMIENTAS DE AUDITORÍA
+# ================================
+# Ninguno de estos lo usa la aplicación: los arrastran safety y pip-audit, que
+# solo se ejecutan aquí y en el job "Security Checks" del CI. Viven en este
+# fichero para que la imagen de producción no los instale (#289).
+# Comprobado con `pip show <paquete>`: su "Required-by" es exclusivamente de dev.
+# Los que sí necesita producción se quedan en requirements.txt — click (uvicorn),
+# urllib3 (requests, sentry-sdk) y mako (alembic).
+
+# filelock - Sincronización de archivos mediante locks (dependencia transitiva de virtualenv/safety)
+# Fijada explícitamente para resolver CVE-2025-68146 (TOCTOU race condition) y CVE-2026-22701
+filelock==3.20.3
+
+# authlib - OAuth and OpenID Connect library (dependencia transitiva de safety)
+# NO la usa el login con Google del proyecto: nada en src/ la importa.
+# Fijada explícitamente para resolver:
+# - CVE-2025-61920 (DoS via large base64 tokens)
+# - CVE-2025-62706 (DoS via zip bomb decompression)
+# - CVE-2025-68158 (Login CSRF vulnerability - fixed in 1.6.6)
+# - CRITICAL (CVSS 9.3): Improper Verification of Cryptographic Signature (x2, fixed in 1.6.7 + 1.6.9)
+# - HIGH (CVSS 8.7): Not Failing Securely - Failing Open (fixed in 1.6.9)
+# - HIGH (CVSS 8.3): Timing Attack (fixed in 1.6.9)
+# - PYSEC-2026-25 (Improper Verification of Cryptographic Signature - fixed in 1.6.11)
+# - PYSEC-2026-188 (fixed in 1.6.12)
+authlib==1.6.12
+
+# marshmallow - Object serialization/deserialization library (dependencia transitiva de safety)
+# Fijada explícitamente para resolver CVE-2025-68480 (DoS via Asymmetric Resource Consumption)
+marshmallow==3.26.2
+
+# nltk - Natural Language Toolkit (dependencia transitiva de safety)
+# Sin versión parcheada para CVE-2026-81726 (GHSA-8mgp-746c-j5xp): 3.10.3 es la última
+# y sigue afectada. No la importa ningún módulo, así que la vía es no llevarla a producción.
+# OJO: esto NO la saca del CI. Los pasos de auditoría corren `pip-audit` y `safety scan`
+# contra el entorno instalado, que aquí sigue incluyendo nltk, así que la próxima CVE suya
+# CON versión de arreglo volverá a poner el pipeline en rojo igual que hoy.
+# Fijada explícitamente para resolver:
+# - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
+# - CVE-2026-54293, CVE-2026-12243, CVE-2026-12252 (path traversal / firma criptográfica, GHSA Dependabot #29/#31)
+# - CVE-2026-72818 (arreglada en 3.10.1) y CVE-2026-78680, -12876, -81723, -71513 (en 3.10.3)
+nltk==3.10.3
+
+# msgpack - Serialización binaria (dependencia transitiva de pip-audit > cachecontrol)
+# Fijada explícitamente para resolver SNYK-PYTHON-MSGPACK-17391445 (Use After Free)
+msgpack==1.2.1
+
+# zipp - Pathlib-compatible Zipfile object wrapper (dependencia transitiva de importlib-metadata,
+# que a su vez entra con las herramientas de auditoría: ya no existe en producción)
+# Fijada explícitamente para resolver CVE-2024-5569 (Infinite loop DoS via Path module)
+zipp==3.19.1
 
 # ================================
 # ANÁLISIS DE CÓDIGO

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,38 +85,10 @@ secure==0.3.0
 # Cumple con OWASP Top 10: A09 (Logging & Monitoring)
 sentry-sdk[fastapi]==2.19.2
 
-# safety - Auditoría de vulnerabilidades en dependencias
-# Escanea el proyecto contra Safety DB (40K+ vulnerabilidades conocidas)
-# Detecta CVEs en dependencias directas y transitivas
-# Cumple con OWASP Top 10: A06 (Vulnerable and Outdated Components)
-safety==3.7.0
-
-# pip-audit - Auditoría oficial de PyPA para dependencias
-# Escanea contra PyPI Advisory Database y OSV (Open Source Vulnerabilities)
-# Alternativa oficial mantenida por Python Packaging Authority
-# Cumple con OWASP Top 10: A06 (Vulnerable and Outdated Components)
-pip-audit==2.10.0
-
 # urllib3 - Cliente HTTP de bajo nivel (dependencia transitiva de requests/httpx)
 # Actualizado a 2.7.0 para resolver:
 # - PYSEC-2026-141, PYSEC-2026-142 (decompression bomb y unlimited decompression chain)
 urllib3==2.7.0
-
-# filelock - Sincronización de archivos mediante locks (dependencia transitiva de virtualenv/safety)
-# Fijada explícitamente para resolver CVE-2025-68146 (TOCTOU race condition) y CVE-2026-22701
-filelock==3.20.3
-
-# authlib - OAuth and OpenID Connect library (dependencia transitiva de safety)
-# Fijada explícitamente para resolver:
-# - CVE-2025-61920 (DoS via large base64 tokens)
-# - CVE-2025-62706 (DoS via zip bomb decompression)
-# - CVE-2025-68158 (Login CSRF vulnerability - fixed in 1.6.6)
-# - CRITICAL (CVSS 9.3): Improper Verification of Cryptographic Signature (x2, fixed in 1.6.7 + 1.6.9)
-# - HIGH (CVSS 8.7): Not Failing Securely - Failing Open (fixed in 1.6.9)
-# - HIGH (CVSS 8.3): Timing Attack (fixed in 1.6.9)
-# - PYSEC-2026-25 (Improper Verification of Cryptographic Signature - fixed in 1.6.11)
-# - PYSEC-2026-188 (fixed in 1.6.12)
-authlib==1.6.12
 
 # cryptography - Primitivas criptográficas de bajo nivel (dependencia transitiva)
 # Actualizado a 48.0.1 para resolver:
@@ -129,21 +101,17 @@ authlib==1.6.12
 # - CVE-2026-69249 (fixed in 49.0.0)
 cryptography==50.0.0
 
-# setuptools - Build system y package installer (dependencia transitiva de safety)
+# setuptools - Build system y package installer
+# Nadie lo declara como dependencia en producción: los paquetes que lo piden lo hacen desde
+# extras de test o dev. Se queda aquí a propósito, porque la imagen base de Python lo trae de
+# serie y hay librerías que usan pkg_resources en tiempo de ejecución sin declararlo; el pin
+# garantiza entonces que la versión presente sea una sin CVEs conocidas.
 # Fijada explícitamente para resolver:
 # - CVE-2024-6345 (Code Injection via package_index - CVSS 7.5 HIGH)
 # - CVE-2022-40897 (Regular Expression DoS - CVSS 5.9 MEDIUM)
 # - CVE-2025-47273 (Directory Traversal en _download_url - CVSS 6.8 MEDIUM)
 # - CVE-2026-59890 (Improper Handling of Unicode Encoding - MEDIUM)
 setuptools==83.0.0
-
-# zipp - Pathlib-compatible Zipfile object wrapper (dependencia transitiva de importlib-metadata)
-# Fijada explícitamente para resolver CVE-2024-5569 (Infinite loop DoS via Path module)
-zipp==3.19.1
-
-# marshmallow - Object serialization/deserialization library (dependencia transitiva de safety)
-# Fijada explícitamente para resolver CVE-2025-68480 (DoS via Asymmetric Resource Consumption)
-marshmallow==3.26.2
 
 # idna - Internationalized Domain Names in Applications (dependencia transitiva de requests/httpx)
 # Fijada explícitamente para resolver CVE-2026-45409
@@ -153,22 +121,15 @@ idna==3.15
 # Fijada explícitamente para resolver CVE-2026-44307
 mako==1.3.12
 
-# nltk - Natural Language Toolkit (dependencia transitiva de safety)
-# Fijada explícitamente para resolver:
-# - PYSEC-2026-96, -97, -98, -99, CVE-2026-33230, CVE-2026-33231, GHSA-rf74-v2fm-23pw
-# - CVE-2026-54293, CVE-2026-12243, CVE-2026-12252 (path traversal / firma criptográfica, GHSA Dependabot #29/#31)
-# - CVE-2026-72818 (arreglada en 3.10.1) y CVE-2026-78680, -12876, -81723, -71513 (en 3.10.3)
-nltk==3.10.3
-
-# click - Command line interface creation kit (dependencia transitiva de nltk/safety/typer/uvicorn)
+# click - Command line interface creation kit (dependencia transitiva de uvicorn)
 # Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)
 click==8.3.3
 
-# msgpack - Serialización binaria (dependencia transitiva de pip-audit > cachecontrol)
-# Fijada explícitamente para resolver SNYK-PYTHON-MSGPACK-17391445 (Use After Free)
-msgpack==1.2.1
-
-# pygments - Syntax highlighter (dependencia transitiva de varios dev tools)
+# pygments - Syntax highlighter (dependencia transitiva de pytest)
+# Se queda aquí, y no con los pins de las herramientas de auditoría, porque pytest está
+# declarado en ESTE fichero: sin el pin, la resolución de producción lo instala igual pero
+# sin garantía de versión. Comprobado con `pip install --dry-run -r requirements.txt`.
+# Si algún día el bloque de pytest se mueve a requirements-dev.txt, este pin se va con él.
 # Fijada explícitamente para resolver CVE-2026-4539
 pygments==2.20.0
 


### PR DESCRIPTION
Closes #289

## What

`safety` and `pip-audit` were declared in `requirements.txt` — the file `docker/Dockerfile:28` installs into the production image. Nothing in the running API imports them, and the CI job that uses them installs `requirements-dev.txt` (which starts with `-r requirements.txt`, so it keeps resolving the same set).

They do not travel alone. `nltk`, `authlib`, `marshmallow`, `filelock` and `msgpack` are pinned **only** because those two tools pull them in — the comments in the file said so already. That is how a natural-language toolkit ended up shipping to production, and why Dependabot has two open high alerts for `CVE-2026-81726`, an nltk advisory **with no patched version**: it cannot be closed by upgrading, only by not shipping the package.

`zipp` goes too. Its stated consumer, `importlib-metadata`, only ever reached the tree through the audit tooling, so this change is what turns that pin into an orphan.

## What stays, and why

| Package | Real consumer in production |
|---|---|
| `click` | `uvicorn` |
| `urllib3` | `requests`, `sentry-sdk` |
| `mako` | `alembic` |
| `pygments` | `pytest`, which is still declared in `requirements.txt` |
| `setuptools` | nobody declares it — kept on purpose (see below) |

`pygments` is the one the verification caught: I had moved it, and the dry-run showed it still resolving into production, now unpinned at 2.21.0. `setuptools` stays because the base Python image ships it anyway and libraries reach for `pkg_resources` at runtime without declaring it, so the pin is what guarantees the version present has no known CVEs. Both reasons are now written next to the pins.

## Verification

`pip install --dry-run --ignore-installed` against both files, before and after:

| | Before | After |
|---|---|---|
| Production packages | 100 | **62** |

- **No new package** and **no version change** among those that stay.
- `requirements-dev.txt` still resolves all 135, same versions.
- None of the 38 removed modules is imported under `src/`, `main.py`, `alembic/` or `scripts/`. The single grep hit was `import yaml` in `logging/factory.py`, which is PyYAML — still in production — not `ruamel.yaml`.
- Nothing under `docker/`, `entrypoint.sh`, `k8s/` or `scripts/` invokes `safety`, `pip-audit` or `nltk`.

## What this does NOT do

**It does not take nltk off the CI gate.** The audit steps run `pip-audit` and `safety scan` against the *installed environment*, not against a requirements file, and this branch installs `requirements-dev.txt` there — nltk included. The next nltk CVE that ships *with* a fix version will fail the pipeline exactly as before. Changing that means pointing the scanners at `requirements.txt` explicitly, which narrows what gets audited, so it is a separate decision. Noted in the file so the next reader does not assume otherwise.

**It leaves a bigger instance of the same problem.** `pytest`, `pytest-xdist`, `pytest-cov`, `pytest-asyncio` and `pytest-json-report` are still in `requirements.txt`, so the production image also ships the whole test suite. That is a strictly larger dev-only surface than the five packages moved here, but it deserves its own issue — in particular, checking first whether any k8s job runs tests inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pinned security-auditing tools for development and maintenance workflows.
  * Updated development setup to use consistent versions for security checks.
  * Removed security-auditing tools and their related version pins from the application’s runtime requirements.
  * Retained existing runtime version constraints and clarified their accompanying documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->