### PR TITLE
chore(deps): Keep the test runner out of the production image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,8 @@ RENDER_DEPLOYMENT.md
 
 # Tests
 tests/
+pytest.ini
+dev_tests.py
 .pytest_cache
 htmlcov/
 .coverage

--- a/README.md
+++ b/README.md
@@ -572,8 +572,8 @@ cd RyderCupAM
 python3.12 -m venv .venv
 source .venv/bin/activate
 
-# Install dependencies
-pip install -r requirements.txt
+# Install dependencies (dev includes production: it starts with -r requirements.txt)
+pip install -r requirements-dev.txt
 
 # Copy environment template
 cp .env.example .env

--- a/docs/architecture/decisions/ADR-003-testing-strategy.md
+++ b/docs/architecture/decisions/ADR-003-testing-strategy.md
@@ -122,4 +122,4 @@ tests/
 - [pytest-xdist Plugin](https://pytest-xdist.readthedocs.io/)
 - [Testing Best Practices](https://testing.googleblog.com/)
 - [Clean Architecture Testing](https://blog.cleancoder.com/uncle-bob/2014/05/14/TheLittleMocker.html)  
-- `requirements.txt`: Documented testing dependencies
+- `requirements-dev.txt`: Documented testing dependencies (moved out of `requirements.txt` in #291, so the production image does not ship the test runner)

--- a/docs/architecture/decisions/ADR-003-testing-strategy.md
+++ b/docs/architecture/decisions/ADR-003-testing-strategy.md
@@ -30,7 +30,7 @@ We need to establish a testing strategy that is:
 **We implement Optimized Testing** with:
 
 ### 1. Framework and Tools:
-- **pytest 8.3.0**: Main framework
+- **pytest 9.0.3**: Main framework
 - **pytest-xdist 3.8.0**: Automatic parallelization
 - **httpx 0.27.0**: HTTP client for API tests
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -102,6 +102,43 @@ msgpack==1.2.1
 zipp==3.19.1
 
 # ================================
+# TESTING
+# ================================
+# La suite no se ejecuta nunca dentro del contenedor: `.dockerignore` excluye `tests/`,
+# y el CI corre pytest directamente en el runner de GitHub. Vivían en requirements.txt,
+# de modo que la imagen de producción instalaba un ejecutor de pruebas y ninguna prueba
+# que ejecutar — 10 paquetes contando su árbol (#291).
+
+# pytest - Framework de testing moderno y potente
+# Más simple que unittest, mejor output de errores, fixtures potentes
+# Actualizado a 9.0.3 para resolver CVE-2025-71176 (arbitrary code execution via deserialization)
+pytest==9.0.3
+
+# pytest-json-report - Plugin para pytest que genera reportes en formato JSON
+# Esencial para el análisis programático de los resultados de los tests
+pytest-json-report==1.5.0
+
+# pytest-xdist - Plugin para pytest que permite ejecutar tests en paralelo
+# Acelera significativamente la suite de tests distribuyendo el trabajo
+pytest-xdist==3.8.0
+
+# pytest-asyncio - Plugin para pytest que proporciona soporte para tests asíncronos
+# Permite usar async/await en tests y fixtures con asyncio_mode = auto
+# Actualizado a 1.4.0: soporta pytest>=8.4,<10 (compatible con pytest 9.x)
+pytest-asyncio==1.4.0
+
+# pytest-cov - Plugin de cobertura para pytest
+# Sin versión fijada, como estaba en requirements.txt: se mueve tal cual para no
+# mezclar el traslado con un cambio de resolución
+pytest-cov
+
+# pygments - Syntax highlighter (dependencia transitiva de pytest)
+# Estaba pinneado en requirements.txt solo porque pytest lo arrastraba hasta producción.
+# Al mover el bloque de test, su único consumidor viene aquí, y el pin con él.
+# Fijada explícitamente para resolver CVE-2026-4539
+pygments==2.20.0
+
+# ================================
 # ANÁLISIS DE CÓDIGO
 # ================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -125,14 +125,6 @@ mako==1.3.12
 # Fijada explícitamente para resolver SNYK-PYTHON-CLICK-16347201 (Command Injection)
 click==8.3.3
 
-# pygments - Syntax highlighter (dependencia transitiva de pytest)
-# Se queda aquí, y no con los pins de las herramientas de auditoría, porque pytest está
-# declarado en ESTE fichero: sin el pin, la resolución de producción lo instala igual pero
-# sin garantía de versión. Comprobado con `pip install --dry-run -r requirements.txt`.
-# Si algún día el bloque de pytest se mueve a requirements-dev.txt, este pin se va con él.
-# Fijada explícitamente para resolver CVE-2026-4539
-pygments==2.20.0
-
 
 # ================================
 # IMÁGENES (Avatar de usuario)
@@ -170,22 +162,3 @@ httpx==0.27.0
 # Actualizado a 2.33.0 para resolver:
 # - MEDIUM (CVSS 4.1): Insecure Temporary File (CWE-377)
 requests==2.33.0
-
-# pytest - Framework de testing moderno y potente
-# Más simple que unittest, mejor output de errores, fixtures potentes
-# Actualizado a 9.0.3 para resolver CVE-2025-71176 (arbitrary code execution via deserialization)
-pytest==9.0.3
-
-# pytest-json-report - Plugin para pytest que genera reportes en formato JSON
-# Esencial para el análisis programático de los resultados de los tests
-pytest-json-report==1.5.0
-
-# pytest-xdist - Plugin para pytest que permite ejecutar tests en paralelo
-# Acelera significativamente la suite de tests distribuyendo el trabajo
-pytest-xdist==3.8.0
-
-# pytest-asyncio - Plugin para pytest que proporciona soporte para tests asíncronos
-# Permite usar async/await en tests y fixtures con asyncio_mode = auto
-# Actualizado a 1.4.0: soporta pytest>=8.4,<10 (compatible con pytest 9.x)
-pytest-asyncio==1.4.0
-pytest-cov


### PR DESCRIPTION
Closes #291 · Follow-up to #289, same class of problem and a bigger instance of it.

## What

`docker/Dockerfile:27-28` installs only `requirements.txt`, and that file declared `pytest` and four of its plugins. The image could not even use them: `.dockerignore:32` excludes `tests/`, so it shipped a test runner and nothing to run.

`pygments` moves with them. It was pinned in `requirements.txt` **only** because pytest dragged it into the production resolution — the comment added in #289 said exactly that, and this is the case it anticipated.

## Verification

`pip install --dry-run --ignore-installed` on both files:

| | Before | After |
|---|---|---|
| Production packages | 62 | **51** |
| Dev packages | 135 | 135 |

- Eleven leave production: `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, `pytest-json-report`, `pytest-metadata`, `pluggy`, `iniconfig`, `execnet`, `coverage`, `pygments`.
- **No new package**, and dev loses nothing and changes no version.
- None of the eleven is imported under `src/`, `main.py`, `alembic/` or `scripts/`.
- The pins stay audited: `pip-audit` and `safety` scan the dev-installed environment, so `pytest==9.0.3` (CVE-2025-71176) and `pygments==2.20.0` (CVE-2026-4539) are still covered.

Taken with #289, the production image goes from **100 packages to 51**.

## Two things the move broke, fixed here

Both came out of the local review, and both are regressions this change would have introduced:

- **`README.md:576`** installed `requirements.txt` in the development setup and then, a few lines below, told the reader to run `pytest tests/unit/ -v`. A fresh clone following it verbatim would have hit `pytest: command not found`. It now installs `requirements-dev.txt`, which begins with `-r requirements.txt` anyway.
- **`ADR-003:125`** still recorded `requirements.txt` as the home of testing dependencies — the kind of stale line that invites someone to put pytest back where it was.

## Also

`pytest.ini` and `dev_tests.py` were still reaching the image through `COPY . .`, which left the stated goal half done. Added to `.dockerignore`.

`pytest-cov` moves **unpinned**, exactly as it was in `requirements.txt` — the only unversioned line in the file. Pinning it is worth doing, but not mixed into a move: it would change a resolution while claiming not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development setup instructions to install the complete development dependency set.
  - Updated testing strategy documentation to reference the dedicated development requirements file.

- **Chores**
  - Separated testing tools from production dependencies, keeping test tooling out of production installations.
  - Added pinned testing dependencies, including coverage, parallel execution, and reporting tools.
  - Excluded selected test configuration files from Docker build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->